### PR TITLE
Inertia.jsのリダイレクトを変更

### DIFF
--- a/app/Http/Controllers/TenantController.php
+++ b/app/Http/Controllers/TenantController.php
@@ -7,6 +7,7 @@ use App\Models\Tenant;
 use Illuminate\Support\Facades\Log;
 use Stancl\Tenancy\Database\Models\Domain;
 use Stancl\Tenancy\Resolvers\DomainTenantResolver;
+use Inertia\Inertia;
 
 class TenantController extends Controller
 {
@@ -41,6 +42,6 @@ class TenantController extends Controller
         session(['tenant_id' => $tenant->id]);
 
         // テナント初期化後にリダイレクト
-        return redirect()->to('http://' . $domain . '/register'); // リダイレクト先を新しいドメインに設定
+        return Inertia::location('http://' . $domain . '/register'); // リダイレクト先を新しいドメインに設定
     }
 }


### PR DESCRIPTION
## 目的

本プルリクエストは、テナント登録後のリダイレクトをサーバーサイドリダイレクトからInertia.jsのクライアントサイドリダイレクトに変更することで、CORS問題を回避し、正しいURLへのリダイレクトを確実に行うことを目的としています。

## 達成条件

- Inertia.jsのリダイレクトが正しく動作し、正しいURLにリダイレクトされること
- CORS問題が発生せず、スムーズなリダイレクトが行われること

## 実装の概要

### Inertia.jsのリダイレクトに変更

サーバーサイドリダイレクトではなく、Inertia.jsの`Inertia::location()`メソッドを使用して、クライアントサイドでリダイレクトを行うように変更しました。これにより、CORS問題を回避し、正しいURLへのリダイレクトが確実に行われるようになりました。

## レビューしてほしいところ

- Inertia.jsのリダイレクトが正しく動作しているかの確認
- リダイレクト先のURLが正しく設定されているかの確認

## 不安に思っていること

- 特になし

## 保留していること

- 特になし
