### PR TITLE
ログインフォームと認証ロジックのusername_id対応

### DIFF
--- a/app/Http/Requests/Auth/LoginRequest.php
+++ b/app/Http/Requests/Auth/LoginRequest.php
@@ -27,7 +27,7 @@ class LoginRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'email' => ['required', 'string', 'email'],
+            'username_id' => ['required', 'string', 'exists:users,username_id'], // username_idのバリデーションルール
             'password' => ['required', 'string'],
         ];
     }
@@ -41,11 +41,12 @@ class LoginRequest extends FormRequest
     {
         $this->ensureIsNotRateLimited();
 
-        if (! Auth::attempt($this->only('email', 'password'), $this->boolean('remember'))) {
+        // username_idでの認証
+        if (! Auth::attempt($this->only('username_id', 'password'), $this->boolean('remember'))) {
             RateLimiter::hit($this->throttleKey());
 
             throw ValidationException::withMessages([
-                'email' => trans('auth.failed'),
+                'username_id' => trans('auth.failed'), // username_idのエラーメッセージ
             ]);
         }
 
@@ -68,7 +69,7 @@ class LoginRequest extends FormRequest
         $seconds = RateLimiter::availableIn($this->throttleKey());
 
         throw ValidationException::withMessages([
-            'email' => trans('auth.throttle', [
+            'username_id' => trans('auth.throttle', [ // username_idのエラーメッセージ
                 'seconds' => $seconds,
                 'minutes' => ceil($seconds / 60),
             ]),
@@ -80,6 +81,6 @@ class LoginRequest extends FormRequest
      */
     public function throttleKey(): string
     {
-        return Str::transliterate(Str::lower($this->string('email')).'|'.$this->ip());
+        return Str::transliterate(Str::lower($this->input('username_id')).'|'.$this->ip()); // username_idを使用
     }
 }

--- a/resources/js/Pages/Auth/Login.vue
+++ b/resources/js/Pages/Auth/Login.vue
@@ -1,11 +1,11 @@
 <script setup>
-import Checkbox from '@/Components/Checkbox.vue';
-import GuestLayout from '@/Layouts/GuestLayout.vue';
-import InputError from '@/Components/InputError.vue';
-import InputLabel from '@/Components/InputLabel.vue';
-import PrimaryButton from '@/Components/PrimaryButton.vue';
-import TextInput from '@/Components/TextInput.vue';
-import { Head, Link, useForm } from '@inertiajs/vue3';
+import Checkbox from "@/Components/Checkbox.vue";
+import GuestLayout from "@/Layouts/GuestLayout.vue";
+import InputError from "@/Components/InputError.vue";
+import InputLabel from "@/Components/InputLabel.vue";
+import PrimaryButton from "@/Components/PrimaryButton.vue";
+import TextInput from "@/Components/TextInput.vue";
+import { Head, Link, useForm } from "@inertiajs/vue3";
 
 defineProps({
     canResetPassword: {
@@ -16,15 +16,17 @@ defineProps({
     },
 });
 
+// フォームデータにusername_idを使用
 const form = useForm({
-    email: '',
-    password: '',
+    username_id: "", // 修正: emailをusername_idに変更
+    password: "",
     remember: false,
+    _token: document.querySelector('meta[name="csrf-token"]').getAttribute('content'), // CSRFトークンを追加
 });
 
 const submit = () => {
-    form.post(route('login'), {
-        onFinish: () => form.reset('password'),
+    form.post(route("login"), {
+        onFinish: () => form.reset("password"),
     });
 };
 </script>
@@ -39,19 +41,15 @@ const submit = () => {
 
         <form @submit.prevent="submit">
             <div>
-                <InputLabel for="email" value="Email" />
-
+                <InputLabel for="username_id" value="Username_ID" />
                 <TextInput
-                    id="email"
-                    type="email"
+                    id="username_id"
+                    type="text"
                     class="mt-1 block w-full"
-                    v-model="form.email"
+                    v-model="form.username_id"
                     required
-                    autofocus
-                    autocomplete="username"
                 />
-
-                <InputError class="mt-2" :message="form.errors.email" />
+                <InputError class="mt-2" :message="form.errors.username_id" />
             </div>
 
             <div class="mt-4">
@@ -85,7 +83,11 @@ const submit = () => {
                     Forgot your password?
                 </Link>
 
-                <PrimaryButton class="ms-4" :class="{ 'opacity-25': form.processing }" :disabled="form.processing">
+                <PrimaryButton
+                    class="ms-4"
+                    :class="{ 'opacity-25': form.processing }"
+                    :disabled="form.processing"
+                >
                     Log in
                 </PrimaryButton>
             </div>


### PR DESCRIPTION
## 目的

ログイン機能の認証キーを`email`から`username_id`に変更し、ユーザー認証の一貫性を確保します。これにより、ユーザーがログインフォームを通じてより直感的にシステムにアクセスできるようにします。

## 達成条件

- ログインフォームが`username_id`を使用して認証情報を送信できること。
- ログインプロセス全体で`username_id`を用いた認証が正しく行われること。
- CSRFトークンの適切な送信により、419エラーが回避されること。

## 実装の概要

1. **ログインフォームの変更**:

   - フォームフィールドを`email`から`username_id`に変更しました。
   - フォームにCSRFトークンを追加し、セキュリティを強化しました。

2. **認証ロジックの更新**:

   - `LoginRequest`クラスにおいて、`username_id`を使ったバリデーションルールを設定しました。
   - スロットリングキーを`username_id`に変更し、認証試行の制限を適切に行います。

3. **エラーハンドリングの改善**:

   - 認証失敗時に`username_id`に基づいたエラーメッセージを表示するようにしました。
   - 認証成功時にはセッションを再生成し、セキュリティを確保しています。

## レビューしてほしいところ

- `LoginRequest`クラスでのバリデーションとエラーメッセージの適切性。
- フロントエンドでのフォーム送信時のCSRFトークンの動作確認。

## 不安に思っていること

- 既存のユーザーが新しい認証キー`username_id`を使用して問題なくログインできるか。
- フロントエンドの変更が他のコンポーネントに影響を与えていないか。

## 保留していること

- ユーザーテストによるフィードバックの収集とそれに基づくさらなる改善。

## 関連

- 変更作業ブランチ: `feature/customize-login-form`