### PR TITLE
ログイン機能のバリデーション追加とエラーメッセージの簡略化

### DIFF
--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -42,7 +42,7 @@ class AuthenticatedSessionController extends Controller
         }
 
         return back()->withErrors([
-            'username_id' => 'The provided credentials do not match our records.',
+            'username_id' => '入力された情報が一致しません。',
         ]);
     }
 

--- a/app/Http/Requests/Auth/LoginRequest.php
+++ b/app/Http/Requests/Auth/LoginRequest.php
@@ -28,7 +28,7 @@ class LoginRequest extends FormRequest
     {
         return [
             'username_id' => ['required', 'string', 'exists:users,username_id'], // username_idのバリデーションルール
-            'password' => ['required', 'string'],
+            'password' => ['required', 'string', 'min:8'],
         ];
     }
 


### PR DESCRIPTION
## 目的

ユーザーがより安全にログインできるように、パスワードのバリデーションを追加し、認証エラーメッセージを簡潔にすることで、ユーザーエクスペリエンスを向上させることを目的としています。

## 達成条件

- ログイン時にパスワードが8文字以上であることをバリデートし、条件を満たさない場合は適切なエラーメッセージが表示される。
- 認証情報が一致しない場合、簡潔なエラーメッセージ「入力された情報が一致しません。」が表示される。

## 実装の概要

- `LoginRequest.php`におけるパスワードバリデーションに、`min:8`を追加しました。
- 認証エラーメッセージを「入力された情報が一致しません。」に修正しました。

## レビューしてほしいところ

- パスワードのバリデーションが適切に機能しているか。
- 認証エラーメッセージの内容がユーザーにとって理解しやすいか。

## 不安に思っていること

- エラーメッセージの変更がユーザーの混乱を招かないか。
- パスワードバリデーションの追加によってログイン体験が阻害されていないか。

## 保留していること

- 今後のユーザーからのフィードバックに基づく微調整。
- 他の部分のバリデーションおよびエラーメッセージの一貫性の見直し。