### PR TITLE
プロフィールフォームおよび関連処理の改善と419エラー解決のためのCSRFトークン追加

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -54,6 +54,9 @@ class ProfileController extends Controller
         $request->session()->invalidate();
         $request->session()->regenerateToken();
 
-        return Redirect::to('/');
+        // セッションからドメイン情報を取得し、セッションが存在しない場合はリクエストから取得
+        $domain = session('tenant_domain', $request->getHost());
+
+        return Redirect::to('http://' . $domain . '/home');
     }
 }

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -47,6 +47,9 @@ class ProfileController extends Controller
 
         $user = $request->user();
 
+        // セッションからドメイン情報を取得し、セッションが存在しない場合はリクエストから取得
+        $domain = session('tenant_domain', $request->getHost());
+
         Auth::logout();
 
         $user->delete();
@@ -54,9 +57,7 @@ class ProfileController extends Controller
         $request->session()->invalidate();
         $request->session()->regenerateToken();
 
-        // セッションからドメイン情報を取得し、セッションが存在しない場合はリクエストから取得
-        $domain = session('tenant_domain', $request->getHost());
-
-        return Redirect::to('http://' . $domain . '/home');
+        return Redirect::to('http://' . $domain . '/home'); // 必要に応じて 'http://' を 'https://' に変更
     }
+
 }

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -3,7 +3,6 @@
 namespace App\Http\Controllers;
 
 use App\Http\Requests\ProfileUpdateRequest;
-use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -19,7 +18,6 @@ class ProfileController extends Controller
     public function edit(Request $request): Response
     {
         return Inertia::render('Profile/Edit', [
-            'mustVerifyEmail' => $request->user() instanceof MustVerifyEmail,
             'status' => session('status'),
         ]);
     }
@@ -29,12 +27,10 @@ class ProfileController extends Controller
      */
     public function update(ProfileUpdateRequest $request): RedirectResponse
     {
-        $request->user()->fill($request->validated());
+        // リクエストから 'name' と 'username_id' のデータを抽出。only メソッドは、指定されたキーに対応するデータを配列で返す。
+        $request->user()->fill($request->only('name', 'username_id'));
 
-        if ($request->user()->isDirty('email')) {
-            $request->user()->email_verified_at = null;
-        }
-
+        // モデルの変更をデータベースに保存
         $request->user()->save();
 
         return Redirect::route('profile.edit');

--- a/app/Http/Requests/ProfileUpdateRequest.php
+++ b/app/Http/Requests/ProfileUpdateRequest.php
@@ -17,7 +17,7 @@ class ProfileUpdateRequest extends FormRequest
     {
         return [
             'name' => ['required', 'string', 'max:255'],
-            'email' => ['required', 'string', 'lowercase', 'email', 'max:255', Rule::unique(User::class)->ignore($this->user()->id)],
+            'username_id' => ['required', 'string', 'max:255', Rule::unique(User::class)->ignore($this->user()->id)],
         ];
     }
 }

--- a/resources/js/Pages/Profile/Partials/DeleteUserForm.vue
+++ b/resources/js/Pages/Profile/Partials/DeleteUserForm.vue
@@ -1,18 +1,21 @@
 <script setup>
-import DangerButton from '@/Components/DangerButton.vue';
-import InputError from '@/Components/InputError.vue';
-import InputLabel from '@/Components/InputLabel.vue';
-import Modal from '@/Components/Modal.vue';
-import SecondaryButton from '@/Components/SecondaryButton.vue';
-import TextInput from '@/Components/TextInput.vue';
-import { useForm } from '@inertiajs/vue3';
-import { nextTick, ref } from 'vue';
+import DangerButton from "@/Components/DangerButton.vue";
+import InputError from "@/Components/InputError.vue";
+import InputLabel from "@/Components/InputLabel.vue";
+import Modal from "@/Components/Modal.vue";
+import SecondaryButton from "@/Components/SecondaryButton.vue";
+import TextInput from "@/Components/TextInput.vue";
+import { useForm } from "@inertiajs/vue3";
+import { nextTick, ref } from "vue";
 
 const confirmingUserDeletion = ref(false);
 const passwordInput = ref(null);
 
 const form = useForm({
-    password: '',
+    password: "",
+    _token: document
+        .querySelector('meta[name="csrf-token"]')
+        .getAttribute("content"),
 });
 
 const confirmUserDeletion = () => {
@@ -22,7 +25,7 @@ const confirmUserDeletion = () => {
 };
 
 const deleteUser = () => {
-    form.delete(route('profile.destroy'), {
+    form.delete(route("profile.destroy"), {
         preserveScroll: true,
         onSuccess: () => closeModal(),
         onError: () => passwordInput.value.focus(),
@@ -43,8 +46,9 @@ const closeModal = () => {
             <h2 class="text-lg font-medium text-gray-900">Delete Account</h2>
 
             <p class="mt-1 text-sm text-gray-600">
-                Once your account is deleted, all of its resources and data will be permanently deleted. Before deleting
-                your account, please download any data or information that you wish to retain.
+                Once your account is deleted, all of its resources and data will
+                be permanently deleted. Before deleting your account, please
+                download any data or information that you wish to retain.
             </p>
         </header>
 
@@ -57,12 +61,17 @@ const closeModal = () => {
                 </h2>
 
                 <p class="mt-1 text-sm text-gray-600">
-                    Once your account is deleted, all of its resources and data will be permanently deleted. Please
-                    enter your password to confirm you would like to permanently delete your account.
+                    Once your account is deleted, all of its resources and data
+                    will be permanently deleted. Please enter your password to
+                    confirm you would like to permanently delete your account.
                 </p>
 
                 <div class="mt-6">
-                    <InputLabel for="password" value="Password" class="sr-only" />
+                    <InputLabel
+                        for="password"
+                        value="Password"
+                        class="sr-only"
+                    />
 
                     <TextInput
                         id="password"
@@ -78,7 +87,9 @@ const closeModal = () => {
                 </div>
 
                 <div class="mt-6 flex justify-end">
-                    <SecondaryButton @click="closeModal"> Cancel </SecondaryButton>
+                    <SecondaryButton @click="closeModal">
+                        Cancel
+                    </SecondaryButton>
 
                     <DangerButton
                         class="ms-3"

--- a/resources/js/Pages/Profile/Partials/UpdatePasswordForm.vue
+++ b/resources/js/Pages/Profile/Partials/UpdatePasswordForm.vue
@@ -1,31 +1,34 @@
 <script setup>
-import InputError from '@/Components/InputError.vue';
-import InputLabel from '@/Components/InputLabel.vue';
-import PrimaryButton from '@/Components/PrimaryButton.vue';
-import TextInput from '@/Components/TextInput.vue';
-import { useForm } from '@inertiajs/vue3';
-import { ref } from 'vue';
+import InputError from "@/Components/InputError.vue";
+import InputLabel from "@/Components/InputLabel.vue";
+import PrimaryButton from "@/Components/PrimaryButton.vue";
+import TextInput from "@/Components/TextInput.vue";
+import { useForm } from "@inertiajs/vue3";
+import { ref } from "vue";
 
 const passwordInput = ref(null);
 const currentPasswordInput = ref(null);
 
 const form = useForm({
-    current_password: '',
-    password: '',
-    password_confirmation: '',
+    current_password: "",
+    password: "",
+    password_confirmation: "",
+    _token: document
+        .querySelector('meta[name="csrf-token"]')
+        .getAttribute("content"),
 });
 
 const updatePassword = () => {
-    form.put(route('password.update'), {
+    form.put(route("password.update"), {
         preserveScroll: true,
         onSuccess: () => form.reset(),
         onError: () => {
             if (form.errors.password) {
-                form.reset('password', 'password_confirmation');
+                form.reset("password", "password_confirmation");
                 passwordInput.value.focus();
             }
             if (form.errors.current_password) {
-                form.reset('current_password');
+                form.reset("current_password");
                 currentPasswordInput.value.focus();
             }
         },
@@ -39,7 +42,8 @@ const updatePassword = () => {
             <h2 class="text-lg font-medium text-gray-900">Update Password</h2>
 
             <p class="mt-1 text-sm text-gray-600">
-                Ensure your account is using a long, random password to stay secure.
+                Ensure your account is using a long, random password to stay
+                secure.
             </p>
         </header>
 
@@ -56,7 +60,10 @@ const updatePassword = () => {
                     autocomplete="current-password"
                 />
 
-                <InputError :message="form.errors.current_password" class="mt-2" />
+                <InputError
+                    :message="form.errors.current_password"
+                    class="mt-2"
+                />
             </div>
 
             <div>
@@ -75,7 +82,10 @@ const updatePassword = () => {
             </div>
 
             <div>
-                <InputLabel for="password_confirmation" value="Confirm Password" />
+                <InputLabel
+                    for="password_confirmation"
+                    value="Confirm Password"
+                />
 
                 <TextInput
                     id="password_confirmation"
@@ -85,7 +95,10 @@ const updatePassword = () => {
                     autocomplete="new-password"
                 />
 
-                <InputError :message="form.errors.password_confirmation" class="mt-2" />
+                <InputError
+                    :message="form.errors.password_confirmation"
+                    class="mt-2"
+                />
             </div>
 
             <div class="flex items-center gap-4">
@@ -97,7 +110,12 @@ const updatePassword = () => {
                     leave-active-class="transition ease-in-out"
                     leave-to-class="opacity-0"
                 >
-                    <p v-if="form.recentlySuccessful" class="text-sm text-gray-600">Saved.</p>
+                    <p
+                        v-if="form.recentlySuccessful"
+                        class="text-sm text-gray-600"
+                    >
+                        Saved.
+                    </p>
                 </Transition>
             </div>
         </form>

--- a/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
+++ b/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
@@ -1,9 +1,9 @@
 <script setup>
-import InputError from '@/Components/InputError.vue';
-import InputLabel from '@/Components/InputLabel.vue';
-import PrimaryButton from '@/Components/PrimaryButton.vue';
-import TextInput from '@/Components/TextInput.vue';
-import { Link, useForm, usePage } from '@inertiajs/vue3';
+import InputError from "@/Components/InputError.vue";
+import InputLabel from "@/Components/InputLabel.vue";
+import PrimaryButton from "@/Components/PrimaryButton.vue";
+import TextInput from "@/Components/TextInput.vue";
+import { Link, useForm, usePage } from "@inertiajs/vue3";
 
 defineProps({
     mustVerifyEmail: {
@@ -19,20 +19,30 @@ const user = usePage().props.auth.user;
 const form = useForm({
     name: user.name,
     username_id: user.username_id,
+    _token: document
+        .querySelector('meta[name="csrf-token"]')
+        .getAttribute("content"),
 });
 </script>
 
 <template>
     <section>
         <header>
-            <h2 class="text-lg font-medium text-gray-900">Profile Information</h2>
+            <h2 class="text-lg font-medium text-gray-900">
+                Profile Information
+            </h2>
 
             <p class="mt-1 text-sm text-gray-600">
                 Update your account's profile information and email address.
             </p>
         </header>
 
-        <form @submit.prevent="form.patch(route('profile.update'))" class="mt-6 space-y-6">
+        <form
+            @submit.prevent="form.patch(route('profile.update'))"
+            class="mt-6 space-y-6"
+        >
+            <input type="hidden" name="_token" :value="form._token" />
+
             <div>
                 <InputLabel for="name" value="Name" />
 
@@ -58,7 +68,6 @@ const form = useForm({
                     class="mt-1 block w-full"
                     v-model="form.username_id"
                     required
-                    autocomplete="username"
                 />
 
                 <InputError class="mt-2" :message="form.errors.username_id" />
@@ -94,7 +103,12 @@ const form = useForm({
                     leave-active-class="transition ease-in-out"
                     leave-to-class="opacity-0"
                 >
-                    <p v-if="form.recentlySuccessful" class="text-sm text-gray-600">Saved.</p>
+                    <p
+                        v-if="form.recentlySuccessful"
+                        class="text-sm text-gray-600"
+                    >
+                        Saved.
+                    </p>
                 </Transition>
             </div>
         </form>

--- a/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
+++ b/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
@@ -18,7 +18,7 @@ const user = usePage().props.auth.user;
 
 const form = useForm({
     name: user.name,
-    email: user.email,
+    username_id: user.username_id,
 });
 </script>
 
@@ -50,18 +50,18 @@ const form = useForm({
             </div>
 
             <div>
-                <InputLabel for="email" value="Email" />
+                <InputLabel for="username_id" value="Username" />
 
                 <TextInput
-                    id="email"
-                    type="email"
+                    id="username_id"
+                    type="text"
                     class="mt-1 block w-full"
-                    v-model="form.email"
+                    v-model="form.username_id"
                     required
                     autocomplete="username"
                 />
 
-                <InputError class="mt-2" :message="form.errors.email" />
+                <InputError class="mt-2" :message="form.errors.username_id" />
             </div>
 
             <div v-if="mustVerifyEmail && user.email_verified_at === null">


### PR DESCRIPTION
## 目的

このプルリクエストの目的は、ユーザー認証プロセスにおけるemailフィールドの役割をusername\_idに置き換えることで、ユーザー体験とセキュリティを向上させることです。また、419エラーを解決するために、CSRFトークンの追加とコードの整形を行い、全体的なコード品質の向上を目指します。

## 達成条件

- プロフィール更新フォームのemailフィールドをusername\_idに置き換えること。
- 419エラーを防ぐため、プロフィール更新フォーム、パスワード更新フォーム、ユーザー削除フォームにCSRFトークンを追加すること。
- ログアウト後のリダイレクト先がテナント固有のドメインになるように修正すること。
- 全体的なコードの整形と可読性の向上。

## 実装の概要

- プロフィールフォームでのemailフィールドをusername\_idに変更し、ユーザー認証に対応させました。
- プロフィール更新フォーム、パスワード更新フォーム、ユーザー削除フォームにCSRFトークンを追加し、419エラーを解決しました。また、これらのフォームにおいてコードの整形を行い、可読性とメンテナンス性を向上させました。
- プロフィール更新処理において、不要なメール認証関連コードを削除し、更新処理を簡素化しました。
- ログアウト後のリダイレクト先を、テナント固有のホームページに変更するため、セッションからテナントドメイン情報を取得するロジックを追加しました。

## レビューしてほしいところ

- CSRFトークンの追加により、419エラーが確実に解決されているか。
- username\_idへの変更により、ユーザー認証が期待通りに動作しているか。
- ログアウト後のリダイレクト処理が、テナントごとのホームページに正しく遷移するか。

## 不安に思っていること

- ログアウト処理の際、セッション無効化前に正しいドメインにリダイレクトされるかどうか。
- 一部のフォームでCSRFトークンが適切に渡されていない場合の挙動。

## 保留していること

- ログアウト時のリダイレクト先のプロトコルを`http`から`https`に変更することについては、セキュリティ要件に応じて検討中です。

- 以下の問題についても引き続き検討中です：

  1. `register.vue`からユーザーを新規登録後、ダッシュボードに遷移。この時のクライアント側のCSRFトークンをトークンAとする。
  2. ダッシュボードからProfileController経由でアカウントを削除し、`localhost/home`に遷移。この時のクライアント側のCSRFトークンはトークンAのまま。
  3. 再度`register.vue`からユーザーを新規登録しようとすると419エラーが発生。この時のクライアント側のCSRFトークンはトークンAのまま。
  4. 上記の2または3の段階でページをリロードすると、クライアント側のCSRFトークンがトークンBに置き換わる。

  これらの事実から、サーバー側のCSRFトークンがトークンBに置き換わっているにも関わらず、クライアント側はトークンAのままである可能性があるため、この問題の解決方法を検討中です。