### PR TITLE
419エラー解決のための作業途中マージおよび他ブランチの変更反映

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -58,6 +58,7 @@ class ProfileController extends Controller
         $request->session()->invalidate();
         $request->session()->regenerateToken();
 
-        return Redirect::to('/');
+        \Log::info('リダイレクト時にリフレッシュフラグを設定しています。');
+        return Redirect::to('http://' . $domain . '/home')->with(['refresh' => true]);
     }
 }

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,23 +1,46 @@
-import './bootstrap';
-import '../css/app.css';
+import "./bootstrap";
+import "../css/app.css";
 
-import { createApp, h } from 'vue';
-import { createInertiaApp } from '@inertiajs/vue3';
-import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
-import { ZiggyVue } from '../../vendor/tightenco/ziggy';
+import { createApp, h } from "vue";
+import { createInertiaApp } from "@inertiajs/vue3";
+import { resolvePageComponent } from "laravel-vite-plugin/inertia-helpers";
+import { ZiggyVue } from "../../vendor/tightenco/ziggy";
 
-const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
+const appName = import.meta.env.VITE_APP_NAME || "Laravel";
 
 createInertiaApp({
     title: (title) => `${title} - ${appName}`,
-    resolve: (name) => resolvePageComponent(`./Pages/${name}.vue`, import.meta.glob('./Pages/**/*.vue')),
+    resolve: (name) =>
+        resolvePageComponent(
+            `./Pages/${name}.vue`,
+            import.meta.glob("./Pages/**/*.vue")
+        ),
     setup({ el, App, props, plugin }) {
-        return createApp({ render: () => h(App, props) })
+        const app = createApp({ render: () => h(App, props) })
             .use(plugin)
-            .use(ZiggyVue)
-            .mount(el);
+            .use(ZiggyVue);
+
+        app.mount(el);
+
+        // Inertia.jsのカスタムイベントでリロードをトリガーする
+        document.addEventListener("inertia:finish", (event) => {
+            console.log("Inertia:finish イベントが発火しました");
+
+            if (event.detail && event.detail.page && event.detail.page.props) {
+                console.log("プロパティが存在します:", event.detail.page.props);
+
+                if (event.detail.page.props.refresh) {
+                    console.log(
+                        "リフレッシュフラグによりページがリロードされます。"
+                    );
+                    window.location.reload();
+                }
+            } else {
+                console.log("event.detail.page にプロパティが存在しません。");
+            }
+        });
     },
     progress: {
-        color: '#4B5563',
+        color: "#4B5563",
     },
 });


### PR DESCRIPTION
## 目的

作業途中ですが、他のブランチで行った変更を反映させるため、一度`master`ブランチにマージする必要があります。今回の作業では、別のブランチ（`feature/customize-profile-page`）での変更が必要でしたが、そのブランチをマージする前に`fix/inertia-csrf-reload`ブランチで作業を開始してしまいました。今後の作業をスムーズに進めるため、このタイミングで今回の変更をマージします。

## 達成条件

- 作業途中であるが、現在の変更がシステム全体に悪影響を与えないこと。
- 他ブランチの変更を反映させ、今後の作業がスムーズに進められる状態にすること。

## 実装の概要

- **Inertia.jsイベントリスナーの追加**: 419エラーを解決するためのリロード処理を追加しましたが、まだ完全には機能していません。この処理は今後さらに調整を行う予定です。
- **リダイレクト時のフラグ設定とログ出力**: リダイレクト後のリロードを確実に行うため、フラグ設定を行い、その動作を確認するためのログ出力を追加しました。
- **他ブランチの変更の統合**: `feature/customize-profile-page`ブランチでの変更を反映するため、現在の状態でマージを行います。これにより、今後の開発が滞りなく進行できるようにします。

## レビューしてほしいところ

- 現在の変更が他の機能に悪影響を与えていないかどうか。
- 今後の作業がこの状態からスムーズに進められるかどうか。

## 不安に思っていること

- 作業途中でのマージが、今後の開発や他のブランチに影響を与えないか。
- イベントリスナーによるリロード処理が特定の環境で予期しない動作を引き起こさないか。

## 保留していること

- **CSRFトークンの不一致問題**: 以下の手順で発生する問題を解決する予定です。

  1. `register.vue`からユーザーを新規登録し、ダッシュボードに遷移。この時のクライアント側のCSRFトークンをトークンAとする。
  2. ダッシュボードからProfileController経由でアカウントを削除し、`localhost/home`に遷移。この時のクライアント側のCSRFトークンはトークンAのまま。
  3. 再度`register.vue`からユーザーを新規登録しようとすると419エラーが発生。この時のクライアント側のCSRFトークンはトークンAのまま。
  4. 上記の2または3の段階でページをリロードすると、クライアント側のCSRFトークンがトークンBに置き換わる。

  これらの事実から、サーバー側のCSRFトークンがトークンBに置き換わっているにもかかわらず、クライアント側はトークンAのままであることが問題であると考えています。今後、JavaScript（Vue.js）による自動リロード機能（refresh）を実装して、この問題を解決する予定です。