### PR TITLE
419エラー対策のためのセッション再生成を一時的にコメントアウト

### DIFF
--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -28,23 +28,25 @@ class AuthenticatedSessionController extends Controller
      * Handle an incoming authentication request.
      */
     public function store(LoginRequest $request): RedirectResponse
-    {
-        $credentials = $request->only('username_id', 'password');
+{
+    $credentials = $request->only('username_id', 'password');
 
-        if (Auth::attempt($credentials)) {
-            $request->session()->regenerate();
+    if (Auth::attempt($credentials)) {
+        // セッションの再生成を一時的にコメントアウトしてみる
+        // $request->session()->regenerate();
 
-            // 現在のリクエストからホスト名を取得し、セッションに保存
-            $domain = $request->getHost();
-            session(['tenant_domain' => $domain]);
+        // 現在のリクエストからホスト名を取得し、セッションに保存
+        $domain = $request->getHost();
+        session(['tenant_domain' => $domain]);
 
-            return redirect()->intended(route('dashboard', absolute: false));
-        }
-
-        return back()->withErrors([
-            'username_id' => 'The provided credentials do not match our records.',
-        ]);
+        return redirect()->intended(route('dashboard', absolute: false));
     }
+
+    return back()->withErrors([
+        'username_id' => 'The provided credentials do not match our records.',
+    ]);
+}
+
 
     /**
      * Destroy an authenticated session.


### PR DESCRIPTION
## 目的

ログイン処理後のリダイレクト時に発生していた419エラーを解消するため、セッション再生成の処理を一時的にコメントアウトする対応を行いました。

## 達成条件

- ログイン後のリダイレクトで419エラーが発生しなくなること。
- セッション再生成の影響を一時的に取り除き、問題の原因を特定するためのデバッグが可能になること。

## 実装の概要

`LoginRequest` の `store` メソッドにおいて、セッション再生成 (`$request->session()->regenerate()`) が原因で419エラーが発生していることが確認されました。このため、該当箇所をコメントアウトし、一時的に無効化しました。セッション再生成はセキュリティ上重要な処理であるため、今後のデバッグと原因特定が完了次第、再度有効化する予定です。

## レビューしてほしいところ

- 419エラーが発生しなくなったかどうかの確認。
- セッション再生成をコメントアウトしたことによるセキュリティ上の懸念点について。

## 不安に思っていること

セッション再生成を無効化したことにより、セキュリティ面でのリスクが一時的に増す可能性があるため、適切なタイミングでの再有効化が必要です。

## 保留していること

- 問題の原因を特定した後、セッション再生成の再有効化を行う予定です。
- セキュリティリスクに関するモニタリングを継続します。