### PR TITLE
CSRFトークン管理の改善とページリロード処理の一時的な対応、レイアウトコンポーネントの修正

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -67,7 +67,7 @@ class ProfileController extends Controller
     $csrfTokenB = $request->session()->token();
     \Log::info('トークンB: ' . $csrfTokenB);
 
-    return Redirect::to('http://' . $domain . '/home')->with(['refresh' => true]);
+    return Redirect::to('http://' . $domain . '/home'); // 必要に応じて 'http://' を 'https://' に変更
 }
 
 }

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -41,33 +41,25 @@ class ProfileController extends Controller
      * Delete the user's account.
      */
     public function destroy(Request $request): RedirectResponse
-{
-    $request->validate([
-        'password' => ['required', 'current_password'],
-    ]);
+    {
+        $request->validate([
+            'password' => ['required', 'current_password'],
+        ]);
 
-    $user = $request->user();
+        $user = $request->user();
 
-    // セッションからドメイン情報を取得
-    $domain = session('tenant_domain', $request->getHost());
+        // セッションからドメイン情報を取得し、セッションが存在しない場合はリクエストから取得
+        $domain = session('tenant_domain', $request->getHost());
 
-    // トークンA（無効化前のトークン）を取得
-    $csrfTokenA = $request->session()->token();
-    \Log::info('トークンA: ' . $csrfTokenA);
+        Auth::logout();
 
-    Auth::logout();
+        $user->delete();
 
-    // セッションを無効化し、トークンAが削除される
-    $request->session()->invalidate();
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
+        Log::info('セッションが再生成されました');
 
-    // トークンB（再生成されたトークン）を生成
-    $request->session()->regenerateToken();
-
-    // トークンBを取得
-    $csrfTokenB = $request->session()->token();
-    \Log::info('トークンB: ' . $csrfTokenB);
-
-    return Redirect::to('http://' . $domain . '/home'); // 必要に応じて 'http://' を 'https://' に変更
-}
+        return Redirect::to('http://' . $domain . '/home'); // 必要に応じて 'http://' を 'https://' に変更
+    }
 
 }

--- a/resources/js/Pages/Auth/ForgotPassword.vue
+++ b/resources/js/Pages/Auth/ForgotPassword.vue
@@ -1,5 +1,5 @@
 <script setup>
-import TenantGuestLayout from "@/Layouts/tGuestLayout.vue";
+import TenantGuestLayout from "@/Layouts/GuestLayout.vue";
 import InputError from "@/Components/InputError.vue";
 import InputLabel from "@/Components/InputLabel.vue";
 import PrimaryButton from "@/Components/PrimaryButton.vue";

--- a/resources/js/Pages/Auth/Register.vue
+++ b/resources/js/Pages/Auth/Register.vue
@@ -5,20 +5,13 @@ import InputLabel from "@/Components/InputLabel.vue";
 import PrimaryButton from "@/Components/PrimaryButton.vue";
 import TextInput from "@/Components/TextInput.vue";
 import { Head, Link, useForm } from "@inertiajs/vue3";
-import { ref } from "vue";
 
-// CSRFトークンを取得
-const csrfToken = ref(
-    document.querySelector('meta[name="csrf-token"]').getAttribute("content")
-);
-console.log("CSRF Token:", csrfToken.value);
-
+// フォームの初期データを定義
 const form = useForm({
     name: "",
     username_id: "",
     password: "",
     password_confirmation: "",
-    _token: csrfToken.value, // フォームデータにトークンを含める
 });
 
 const submit = () => {
@@ -31,9 +24,6 @@ const submit = () => {
         onError: (errors) => {
             console.error("Form submission errors:", errors);
         },
-        headers: {
-            "X-CSRF-TOKEN": csrfToken.value, // リクエストヘッダーにトークンを含める
-        },
     });
 };
 </script>
@@ -43,8 +33,6 @@ const submit = () => {
         <Head title="Register" />
 
         <form @submit.prevent="submit">
-            <input type="hidden" name="_token" :value="csrfToken.value" />
-
             <div>
                 <InputLabel for="name" value="Name" />
                 <TextInput

--- a/resources/js/Pages/Auth/Register.vue
+++ b/resources/js/Pages/Auth/Register.vue
@@ -5,6 +5,13 @@ import InputLabel from "@/Components/InputLabel.vue";
 import PrimaryButton from "@/Components/PrimaryButton.vue";
 import TextInput from "@/Components/TextInput.vue";
 import { Head, Link, useForm } from "@inertiajs/vue3";
+import { ref } from "vue";
+
+// CSRFトークンを取得
+const csrfToken = ref(
+    document.querySelector('meta[name="csrf-token"]').getAttribute("content")
+);
+console.log("CSRF Token:", csrfToken.value);
 
 // フォームの初期データを定義
 const form = useForm({
@@ -12,6 +19,7 @@ const form = useForm({
     username_id: "",
     password: "",
     password_confirmation: "",
+    _token: csrfToken.value, // フォームデータにCSRFトークンを含める
 });
 
 const submit = () => {
@@ -24,6 +32,9 @@ const submit = () => {
         onError: (errors) => {
             console.error("Form submission errors:", errors);
         },
+        headers: {
+            "X-CSRF-TOKEN": csrfToken.value, // リクエストヘッダーにCSRFトークンを含める
+        },
     });
 };
 </script>
@@ -33,6 +44,7 @@ const submit = () => {
         <Head title="Register" />
 
         <form @submit.prevent="submit">
+            <input type="hidden" name="_token" :value="csrfToken" />
             <div>
                 <InputLabel for="name" value="Name" />
                 <TextInput

--- a/resources/js/Pages/Profile/Partials/DeleteUserForm.vue
+++ b/resources/js/Pages/Profile/Partials/DeleteUserForm.vue
@@ -8,11 +8,17 @@ import TextInput from "@/Components/TextInput.vue";
 import { useForm } from "@inertiajs/vue3";
 import { nextTick, ref } from "vue";
 
+// CSRFトークンを取得
+const csrfToken = ref(
+    document.querySelector('meta[name="csrf-token"]').getAttribute("content")
+);
+
 const confirmingUserDeletion = ref(false);
 const passwordInput = ref(null);
 
 const form = useForm({
     password: "",
+    _token: csrfToken.value, // フォームデータにCSRFトークンを含める
 });
 
 const confirmUserDeletion = () => {
@@ -27,6 +33,9 @@ const deleteUser = () => {
         onSuccess: () => closeModal(),
         onError: () => passwordInput.value.focus(),
         onFinish: () => form.reset(),
+        headers: {
+            "X-CSRF-TOKEN": csrfToken.value, // リクエストヘッダーにCSRFトークンを含める
+        },
     });
 };
 

--- a/resources/js/Pages/Profile/Partials/DeleteUserForm.vue
+++ b/resources/js/Pages/Profile/Partials/DeleteUserForm.vue
@@ -13,9 +13,6 @@ const passwordInput = ref(null);
 
 const form = useForm({
     password: "",
-    _token: document
-        .querySelector('meta[name="csrf-token"]')
-        .getAttribute("content"),
 });
 
 const confirmUserDeletion = () => {

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -26,18 +26,23 @@ createInertiaApp({
         document.addEventListener("inertia:finish", (event) => {
             console.log("Inertia:finish イベントが発火しました");
 
-            if (event.detail && event.detail.page && event.detail.page.props) {
-                console.log("プロパティが存在します:", event.detail.page.props);
+            document.addEventListener("inertia:finish", (event) => {
+                if (event.detail && event.detail.visit) {
+                    // 現在のURLを取得
+                    const currentUrl = window.location.href;
 
-                if (event.detail.page.props.refresh) {
-                    console.log(
-                        "リフレッシュフラグによりページがリロードされます。"
-                    );
-                    window.location.reload();
+                    // URLに 'localhost/home' が含まれているかチェック
+                    if (currentUrl.includes("localhost/home")) {
+                        console.log(
+                            "URLが 'localhost/home' を含んでいます。ページをリロードします。"
+                        );
+                        // 2秒後にページをリロード
+                        setTimeout(() => {
+                            window.location.reload();
+                        }, 2000);
+                    }
                 }
-            } else {
-                console.log("event.detail.page にプロパティが存在しません。");
-            }
+            });
         });
     },
     progress: {

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -32,9 +32,12 @@ createInertiaApp({
                     const currentUrl = window.location.href;
 
                     // URLに 'localhost/home' が含まれているかチェック
-                    if (currentUrl.includes("localhost/home")) {
+                    if (
+                        currentUrl.includes("localhost/home") ||
+                        currentUrl.includes("localhost/dashboard")
+                    ) {
                         console.log(
-                            "URLが 'localhost/home' を含んでいます。ページをリロードします。"
+                            "URLが 'localhost/home'または'localhost/dashboard'を含んでいます。ページをリロードします。"
                         );
                         window.location.reload();
                     }

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -36,10 +36,7 @@ createInertiaApp({
                         console.log(
                             "URLが 'localhost/home' を含んでいます。ページをリロードします。"
                         );
-                        // 2秒後にページをリロード
-                        setTimeout(() => {
-                            window.location.reload();
-                        }, 2000);
+                        window.location.reload();
                     }
                 }
             });

--- a/resources/js/bootstrap.js
+++ b/resources/js/bootstrap.js
@@ -2,6 +2,3 @@ import axios from "axios";
 window.axios = axios;
 
 window.axios.defaults.headers.common["X-Requested-With"] = "XMLHttpRequest";
-axios.defaults.headers.common["X-CSRF-TOKEN"] = document
-    .querySelector('meta[name="csrf-token"]')
-    .getAttribute("content");

--- a/resources/js/bootstrap.js
+++ b/resources/js/bootstrap.js
@@ -1,4 +1,7 @@
-import axios from 'axios';
+import axios from "axios";
 window.axios = axios;
 
-window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
+window.axios.defaults.headers.common["X-Requested-With"] = "XMLHttpRequest";
+axios.defaults.headers.common["X-CSRF-TOKEN"] = document
+    .querySelector('meta[name="csrf-token"]')
+    .getAttribute("content");


### PR DESCRIPTION
## 目的

本プルリクエストでは、CSRFトークンの管理方法を見直し、419エラーを解決するための一時的なリロード処理を導入します。また、レイアウトコンポーネントのインポートパス修正も行い、全体の安定性を向上させます。

## 達成条件

- CSRFトークン管理の改善により、419エラーが発生しないこと
- 必要なタイミングで適切にページがリロードされること
- レイアウトコンポーネントが正しくインポートされること

## 実装の概要

1. **レイアウトコンポーネントのインポートパス修正**:

   - `GuestLayout.vue`へのインポートパスが誤っていたため、正しいパスに修正しました。これにより、リソースが正しく読み込まれるようになりました。

2. **CSRFトークンの手動管理への移行**:

   - 当初、Inertia.jsによるCSRFトークンの自動管理を試みましたが、419エラーが発生する問題が解消されなかったため、CSRFトークンを手動で設定する方式に戻しました。これにより、トークンが確実にリクエストに含まれることを保証し、システムの安定性を向上させました。

3. **Axios設定にCSRFトークンの自動付与を追加**:

   - AxiosのヘッダーにCSRFトークンを手動で付与する設定を追加しました。これにより、フォーム送信時に419エラーが発生するリスクを低減しました。

4. **アカウント削除フォームでのCSRFトークンの明示的な設定の再導入**:

   - 一度はCSRFトークンの手動管理を削除しましたが、419エラーを回避するために再度フォームデータとリクエストヘッダーに明示的に含める処理を追加しました。

5. **セッション再生成時のCSRFトークンをログに記録し、refreshによるリロード機能を削除**:

   - セッション再生成時にCSRFトークンの状態を確認するため、トークンのログ記録機能を追加しました。また、不要なリロード処理を削除し、リダイレクト処理を改善しました。

6. **特定のURLに基づいてページをリロードするロジックを追加**:

   - `localhost/home`や`localhost/dashboard`がURLに含まれる場合に、ページをリロードするロジックを追加しました。特に、419エラーが発生しやすい操作において、確実にリロードが行われるようにしました。

   - **注意**: このリロード処理は、SPAの特性を活かすためには本来避けるべきですが、419エラーの回避という緊急対応として一時的に導入されています。将来的には、Inertia.jsのロジックを活用し、リロードを不要とする解決策を検討する予定です。

## レビューしてほしいところ

- CSRFトークン管理の改善により、419エラーが発生しなくなったかの確認
- 不要なリロード処理の削除がユーザーエクスペリエンスに与える影響
- 特定のURL遷移時にページが正しくリロードされるかの確認

## 不安に思っていること

- CSRFトークン管理の変更に伴い、他の箇所で予期しないエラーが発生しないか
- リロード処理の削除がユーザーのナビゲーションに支障を与えていないか

## 保留していること

- Inertia.jsのロジックを活用して、リロードせずにCSRFトークンの不一致を解消する方法の再検討。現時点ではリロードによる解決を採用していますが、将来的によりスムーズな方法を模索する必要があります。
- 今回の変更が全体に与える影響を評価するための追加テスト
- リロード処理の改善に伴うユーザーエクスペリエンスの向上が期待通りかを検証するためのフィードバック収集
