### PR TITLE
CSRFトークン設定の修正に伴う419エラーの解消

### DIFF
--- a/resources/js/bootstrap.js
+++ b/resources/js/bootstrap.js
@@ -2,3 +2,14 @@ import axios from "axios";
 window.axios = axios;
 
 window.axios.defaults.headers.common["X-Requested-With"] = "XMLHttpRequest";
+
+// CSRFトークンを設定
+const token = document.head.querySelector('meta[name="csrf-token"]');
+
+if (token) {
+    window.axios.defaults.headers.common["X-CSRF-TOKEN"] = token.content;
+} else {
+    console.error(
+        "CSRF token not found: https://laravel.com/docs/csrf#csrf-x-csrf-token"
+    );
+}


### PR DESCRIPTION
## 目的

このプルリクエストの目的は、AxiosによるCSRFトークン設定の不足が原因で発生していた419エラーを解消し、Inertia.jsとAxiosを通じて正しくCSRFトークンを送信することです。

## 達成条件

- 419エラーが発生しないように、リクエストに正しいCSRFトークンを付与する。
- Inertia.js経由のPOSTリクエストが成功し、CSRFトークンが正しく認識されることを確認する。

## 実装の概要

1. `resources/js/bootstrap.js` にCSRFトークンをAxiosのデフォルトヘッダーとして追加しました。これにより、すべてのリクエストでCSRFトークンが自動的に送信されるように設定しました。
2. Inertia.jsのセットアップ時に明示的にCSRFトークンを渡す必要はなく、Axiosが自動的に`X-XSRF-TOKEN`ヘッダーを利用します。
3. Inertia.jsとAxiosの連携について確認し、公式ドキュメント【リンク先：Inertia.jsとAxiosの公式ガイド】に基づき、適切な方法で実装しました。

## レビューしてほしいところ

- AxiosによるCSRFトークンの設定が正しく機能しているかどうか。
- 他のフォーム送信処理に影響が出ていないか。
- Inertia.jsの構成とAxiosの連携が適切に動作しているか。

## 不安に思っていること

- Axiosの設定が全てのリクエストに適用されているかどうか。
- 今回の変更が他のAPI通信部分に影響を与えていないか。

## 関連

- [Inertia.jsドキュメント - CSRFトークン]()
- [Axiosドキュメント - CSRFトークンの設定]()