### PR TITLE
ページネーション機能の追加および表示対応

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -16,7 +16,7 @@ class PostController extends Controller
             $query->whereNull('parent_id') // 親コメントのみ取得
                   ->with(['children.user', 'user']); // 子コメントと再帰的に子コメントを取得
         }
-    ])->latest()->get();
+    ])->latest()->paginate(5);
 
     return Inertia::render('Forum', [
         'posts' => $posts

--- a/resources/js/Components/Pagination.vue
+++ b/resources/js/Components/Pagination.vue
@@ -1,6 +1,14 @@
+<script setup>
+import { Link } from "@inertiajs/vue3";
+
+defineProps({
+    links: Array,
+});
+</script>
+
 <template>
     <div v-if="links.length > 3">
-        <div class="flex flex-wrap -mb-1">
+        <div class="flex flex-wrap -mb-1 justify-center">
             <template v-for="(link, key) in links" :key="key">
                 <div
                     v-if="link.url === null"
@@ -18,11 +26,3 @@
         </div>
     </div>
 </template>
-
-<script setup>
-import { Link } from "@inertiajs/vue3";
-
-defineProps({
-    links: Array,
-});
-</script>

--- a/resources/js/Components/Pagination.vue
+++ b/resources/js/Components/Pagination.vue
@@ -1,0 +1,28 @@
+<template>
+    <div v-if="links.length > 3">
+        <div class="flex flex-wrap -mb-1">
+            <template v-for="(link, key) in links" :key="key">
+                <div
+                    v-if="link.url === null"
+                    class="mr-1 mb-1 px-4 py-3 text-sm leading-4 text-gray-400 border rounded"
+                    v-html="link.label"
+                />
+                <Link
+                    v-else
+                    class="mr-1 mb-1 px-4 py-3 text-sm leading-4 border rounded hover:bg-white focus:border-indigo-500 focus:text-indigo-500"
+                    :class="{ 'bg-white': link.active }"
+                    :href="link.url"
+                    v-html="link.label"
+                />
+            </template>
+        </div>
+    </div>
+</template>
+
+<script setup>
+import { Link } from "@inertiajs/vue3";
+
+defineProps({
+    links: Array,
+});
+</script>

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -6,6 +6,7 @@ import dayjs from "dayjs";
 import PostForm from "@/Components/PostForm.vue";
 import CommentForm from "@/Components/CommentForm.vue";
 import CommentList from "@/Components/CommentList.vue";
+import Pagination from "@/Components/Pagination.vue";
 import { getCsrfToken } from "@/Utils/csrf";
 
 // propsからページのデータを取得
@@ -166,7 +167,7 @@ const isCommentAuthor = (comment) => {
 
             <!-- 投稿一覧 -->
             <div
-                v-for="post in posts"
+                v-for="post in posts.data"
                 :key="post.id"
                 class="bg-white rounded-md mt-1 mb-5 p-3"
             >
@@ -236,6 +237,9 @@ const isCommentAuthor = (comment) => {
                 />
             </div>
         </div>
+
+        <!-- ページネーションコンポーネント -->
+        <Pagination :links="posts.links" />
     </AuthenticatedLayout>
 </template>
 

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -163,6 +163,9 @@ const isCommentAuthor = (comment) => {
         <div class="w-11/12 max-w-screen-md m-auto">
             <h1 class="text-xl font-bold mt-5">{{ appName }}</h1>
 
+            <!-- 上部ページネーション -->
+            <Pagination :links="posts.links" />
+
             <PostForm />
 
             <!-- 投稿一覧 -->
@@ -238,7 +241,7 @@ const isCommentAuthor = (comment) => {
             </div>
         </div>
 
-        <!-- ページネーションコンポーネント -->
+        <!-- 下部ページネーション -->
         <Pagination :links="posts.links" />
     </AuthenticatedLayout>
 </template>


### PR DESCRIPTION
## 目的

掲示板の投稿リストが長くなった際に、ユーザーが容易にページ移動できるよう、ページネーション機能を追加しました。また、ユーザー体験を向上させるために、ページネーションボタンを中央揃えに変更し、さらに掲示板の上部にもページネーションを追加しました。

## 達成条件

- 投稿リストに5件ごとのページネーション機能を実装する。
- ページネーションのボタンを中央揃えにし、表示を整える。
- ページネーションを掲示板の上下両方に表示させ、ユーザーがリストの上でも下でもページ移動できるようにする。

## 実装の概要

1. **ページネーション機能の追加**  
   投稿リストを5件ずつ表示するようにし、ページネーション機能を実装しました。これにより、長い投稿リストでもユーザーがスムーズに閲覧できるようになります。また、`Pagination.vue` コンポーネントを新規作成し、ページリンクの生成および表示を管理しました。

2. **ページネーションのボタン配置の改善**  
   ページネーションボタンを画面中央に配置するため、スタイルを `flex` を使用して調整しました。これにより、ページ移動のボタンが視覚的に見やすくなり、ユーザーの利便性が向上しました。

3. **掲示板の上下両方にページネーションを追加**  
   ユーザーがページ下部にスクロールしなくてもページ移動できるよう、掲示板の上部にもページネーションを追加しました。

## レビューしてほしいところ

- ページネーションの表示および配置の改善が意図した通りに機能しているかどうか。
- 上下両方のページネーションが、ユーザーの体験にどのような影響を与えるか。

## 不安に思っていること

- ページネーションの上下表示がユーザーにとって便利かどうか、もしくはUIが過剰になっていないか。

## 保留していること

- なし