### PR TITLE
プロフィールポップアップ機能とユーザーアイコン表示の追加

### DIFF
--- a/resources/js/Components/ChildComment.vue
+++ b/resources/js/Components/ChildComment.vue
@@ -9,6 +9,7 @@ const props = defineProps({
     deleteItem: Function, // コメント削除用関数
     toggleCommentForm: Function, // コメントフォームの表示切替関数
     commentFormVisibility: Object, // コメントフォームの表示状態
+    openUserProfile: Function, // ユーザープロフィールを開く関数
 });
 </script>
 
@@ -18,12 +19,14 @@ const props = defineProps({
             <div class="ml-4 mb-2 pl-2">
                 <p class="text-xs">
                     {{ formatDate(comment.created_at) }}
-                    <a
-                        :href="route('users.show', comment.user.id)"
-                        class="hover:bg-blue-300 p-1 rounded"
+                    <span
+                        v-if="comment.user"
+                        @click="openUserProfile(comment)"
+                        class="hover:bg-blue-300 p-1 rounded cursor-pointer"
                     >
-                        @{{ comment.user?.name || "Unknown" }}
-                    </a>
+                        @{{ comment.user.name }}
+                    </span>
+                    <span v-else>＠Unknown</span>
                 </p>
                 <p>{{ comment.message }}</p>
 
@@ -74,6 +77,7 @@ const props = defineProps({
                     :deleteItem="deleteItem"
                     :toggleCommentForm="toggleCommentForm"
                     :commentFormVisibility="commentFormVisibility"
+                    :openUserProfile="openUserProfile"
                 />
             </div>
         </div>

--- a/resources/js/Components/ChildComment.vue
+++ b/resources/js/Components/ChildComment.vue
@@ -17,8 +17,30 @@ const props = defineProps({
     <div v-if="childComments.length">
         <div v-for="comment in childComments" :key="comment.id" class="mb-4">
             <div class="ml-4 mb-2 pl-2">
-                <p class="text-xs">
+                <p class="text-xs flex items-center space-x-2">
                     {{ formatDate(comment.created_at) }}
+
+                    <!-- ユーザーアイコンの表示 -->
+                    <img
+                        v-if="comment.user && comment.user.icon"
+                        :src="
+                            comment.user.icon.startsWith('/storage/')
+                                ? comment.user.icon
+                                : `/storage/${comment.user.icon}`
+                        "
+                        alt="User Icon"
+                        class="w-6 h-6 rounded-full cursor-pointer"
+                        @click="openUserProfile(comment)"
+                    />
+                    <img
+                        v-else
+                        src="https://via.placeholder.com/40"
+                        alt="Default Icon"
+                        class="w-6 h-6 rounded-full cursor-pointer"
+                        @click="openUserProfile(comment)"
+                    />
+
+                    <!-- 投稿者名の表示 -->
                     <span
                         v-if="comment.user"
                         @click="openUserProfile(comment)"

--- a/resources/js/Components/ChildComment.vue
+++ b/resources/js/Components/ChildComment.vue
@@ -17,9 +17,13 @@ const props = defineProps({
         <div v-for="comment in childComments" :key="comment.id" class="mb-4">
             <div class="ml-4 mb-2 pl-2">
                 <p class="text-xs">
-                    {{ formatDate(comment.created_at) }} ＠{{
-                        comment.user?.name || "Unknown"
-                    }}
+                    {{ formatDate(comment.created_at) }}
+                    <a
+                        :href="route('users.show', comment.user.id)"
+                        class="hover:bg-blue-300 p-1 rounded"
+                    >
+                        @{{ comment.user?.name || "Unknown" }}
+                    </a>
                 </p>
                 <p>{{ comment.message }}</p>
 

--- a/resources/js/Components/ParentComment.vue
+++ b/resources/js/Components/ParentComment.vue
@@ -11,6 +11,7 @@ const props = defineProps({
     deleteItem: Function, // コメント削除用関数
     toggleCommentForm: Function, // コメントフォームの表示切替関数
     commentFormVisibility: Object, // コメントフォームの表示状態
+    openUserProfile: Function, // ユーザープロフィールを開く関数
 });
 
 // 子コメントの折りたたみ状態を管理
@@ -41,12 +42,16 @@ const getCommentCountRecursive = (comments) => {
             <div class="ml-4 mb-2 border-l-2 border-gray-300 pl-2">
                 <p class="text-xs">
                     {{ formatDate(comment.created_at) }}
-                    <a
-                        :href="route('users.show', comment.user.id)"
-                        class="hover:bg-blue-300 p-1 rounded"
+                    <span
+                        v-if="comment.user"
+                        @click="openUserProfile(comment)"
+                        class="hover:bg-blue-300 p-1 rounded cursor-pointer"
                     >
-                        @{{ comment.user?.name || "Unknown" }}
-                    </a>
+                        <span v-if="comment.user">
+                            ＠{{ comment.user.name }}
+                        </span>
+                        <span v-else>＠Unknown</span>
+                    </span>
                 </p>
                 <p>{{ comment.message }}</p>
 
@@ -129,6 +134,7 @@ const getCommentCountRecursive = (comments) => {
                         :deleteItem="deleteItem"
                         :toggleCommentForm="toggleCommentForm"
                         :commentFormVisibility="commentFormVisibility"
+                        :openUserProfile="openUserProfile"
                     />
                 </div>
             </div>

--- a/resources/js/Components/ParentComment.vue
+++ b/resources/js/Components/ParentComment.vue
@@ -40,18 +40,37 @@ const getCommentCountRecursive = (comments) => {
     <div v-if="comments.length">
         <div v-for="comment in comments" :key="comment.id" class="mb-4">
             <div class="ml-4 mb-2 border-l-2 border-gray-300 pl-2">
-                <p class="text-xs">
+                <p class="text-xs flex items-center space-x-2">
                     {{ formatDate(comment.created_at) }}
+                    <!-- ユーザーアイコンを追加 -->
+                    <img
+                        v-if="comment.user && comment.user.icon"
+                        :src="
+                            comment.user.icon.startsWith('/storage/')
+                                ? comment.user.icon
+                                : `/storage/${comment.user.icon}`
+                        "
+                        alt="User Icon"
+                        class="w-6 h-6 rounded-full cursor-pointer"
+                        @click="openUserProfile(comment)"
+                    />
+                    <img
+                        v-else
+                        src="https://via.placeholder.com/40"
+                        alt="Default Icon"
+                        class="w-6 h-6 rounded-full cursor-pointer"
+                        @click="openUserProfile(comment)"
+                    />
+
+                    <!-- 投稿者名の表示 -->
                     <span
                         v-if="comment.user"
                         @click="openUserProfile(comment)"
                         class="hover:bg-blue-300 p-1 rounded cursor-pointer"
                     >
-                        <span v-if="comment.user">
-                            ＠{{ comment.user.name }}
-                        </span>
-                        <span v-else>＠Unknown</span>
+                        ＠{{ comment.user.name }}
                     </span>
+                    <span v-else>＠Unknown</span>
                 </p>
                 <p>{{ comment.message }}</p>
 

--- a/resources/js/Components/ParentComment.vue
+++ b/resources/js/Components/ParentComment.vue
@@ -40,9 +40,13 @@ const getCommentCountRecursive = (comments) => {
         <div v-for="comment in comments" :key="comment.id" class="mb-4">
             <div class="ml-4 mb-2 border-l-2 border-gray-300 pl-2">
                 <p class="text-xs">
-                    {{ formatDate(comment.created_at) }} ＠{{
-                        comment.user?.name || "Unknown"
-                    }}
+                    {{ formatDate(comment.created_at) }}
+                    <a
+                        :href="route('users.show', comment.user.id)"
+                        class="hover:bg-blue-300 p-1 rounded"
+                    >
+                        @{{ comment.user?.name || "Unknown" }}
+                    </a>
                 </p>
                 <p>{{ comment.message }}</p>
 

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -180,8 +180,10 @@ const isCommentAuthor = (comment) => {
                 <div>
                     <p class="mb-2 text-xs">
                         {{ formatDate(post.created_at) }}
-                        <span v-if="post.user">＠{{ post.user.name }}</span>
-                        <span v-else>＠Unknown</span>
+                        <a :href="route('users.show', post.user.id)">
+                            <span v-if="post.user">＠{{ post.user.name }}</span>
+                            <span v-else>＠Unknown</span>
+                        </a>
                     </p>
                     <p class="mb-2 text-xl font-bold">{{ post.title }}</p>
                     <p class="mb-2">{{ post.message }}</p>

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -180,7 +180,10 @@ const isCommentAuthor = (comment) => {
                 <div>
                     <p class="mb-2 text-xs">
                         {{ formatDate(post.created_at) }}
-                        <a :href="route('users.show', post.user.id)">
+                        <a
+                            :href="route('users.show', post.user.id)"
+                            class="hover:bg-blue-300 p-1 rounded"
+                        >
                             <span v-if="post.user">＠{{ post.user.name }}</span>
                             <span v-else>＠Unknown</span>
                         </a>

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -8,11 +8,29 @@ import CommentForm from "@/Components/CommentForm.vue";
 import ParentComment from "@/Components/ParentComment.vue"; // 新しいコンポーネント
 import Pagination from "@/Components/Pagination.vue";
 import { getCsrfToken } from "@/Utils/csrf";
+import Show from "./Users/Show.vue";
 
 // propsからページのデータを取得
 const pageProps = usePage().props;
 const posts = ref(pageProps.posts || []); // 投稿のデータ
 const auth = pageProps.auth; // ログインユーザー情報
+
+const selectedPost = ref(null); // 選択された投稿
+const isUserProfileVisible = ref(false); // ユーザーの詳細ページの表示状態
+
+const openUserProfile = (post) => {
+    selectedPost.value = post;
+    isUserProfileVisible.value = true; // ユーザーの詳細ページを表示
+};
+
+const closeUserProfile = () => {
+    isUserProfileVisible.value = false;
+};
+
+// 投稿を選択する関数
+const selectPost = (post) => {
+    selectedPost.value = post;
+};
 
 // コメントフォーム表示状態を管理するためのオブジェクト
 const commentFormVisibility = ref({});
@@ -180,13 +198,15 @@ const isCommentAuthor = (comment) => {
                 <div>
                     <p class="mb-2 text-xs">
                         {{ formatDate(post.created_at) }}
-                        <a
-                            :href="route('users.show', post.user.id)"
-                            class="hover:bg-blue-300 p-1 rounded"
+                        <span
+                            v-if="post.user"
+                            @click="openUserProfile(post)"
+                            class="hover:bg-blue-300 p-1 rounded cursor-pointer"
                         >
-                            <span v-if="post.user">＠{{ post.user.name }}</span>
+                            <span v-if="post.user">
+                                ＠{{ post.user.name }}</span>
                             <span v-else>＠Unknown</span>
-                        </a>
+                        </span>
                     </p>
                     <p class="mb-2 text-xl font-bold">{{ post.title }}</p>
                     <p class="mb-2">{{ post.message }}</p>
@@ -246,6 +266,15 @@ const isCommentAuthor = (comment) => {
                     :commentFormVisibility="commentFormVisibility"
                 />
             </div>
+        </div>
+
+        <!-- 選択された投稿のユーザーの詳細ページを表示 -->
+        <div
+            v-if="isUserProfileVisible"
+            class="fixed inset-0 bg-black/50 flex justify-center items-center z-50"
+            @click="closeUserProfile"
+        >
+            <Show v-if="selectedPost" :user="selectedPost.user" />
         </div>
 
         <!-- 下部ページネーション -->

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -265,6 +265,7 @@ const isCommentAuthor = (comment) => {
                     :deleteItem="deleteItem"
                     :toggleCommentForm="toggleCommentForm"
                     :commentFormVisibility="commentFormVisibility"
+                    :openUserProfile="openUserProfile"
                 />
             </div>
         </div>

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -211,13 +211,15 @@ const isCommentAuthor = (comment) => {
                                         : `/storage/${post.user.icon}`
                                 "
                                 alt="User Icon"
-                                class="w-6 h-6 rounded-full"
+                                class="w-6 h-6 rounded-full cursor-pointer"
+                                @click="openUserProfile(post)"
                             />
                             <img
                                 v-else
                                 src="https://via.placeholder.com/40"
                                 alt="Default Icon"
-                                class="w-6 h-6 rounded-full"
+                                class="w-6 h-6 rounded-full cursor-pointer"
+                                @click="openUserProfile(post)"
                             />
 
                             <!-- 投稿者名の表示 -->

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -200,14 +200,35 @@ const isCommentAuthor = (comment) => {
                         {{ formatDate(post.created_at) }}
                         <span
                             v-if="post.user"
-                            @click="openUserProfile(post)"
-                            class="hover:bg-blue-300 p-1 rounded cursor-pointer"
+                            class="flex items-center space-x-2"
                         >
-                            <span v-if="post.user">
-                                ＠{{ post.user.name }}</span
+                            <!-- ユーザーアイコンの表示 -->
+                            <img
+                                v-if="post.user.icon"
+                                :src="
+                                    post.user.icon.startsWith('/storage/')
+                                        ? post.user.icon
+                                        : `/storage/${post.user.icon}`
+                                "
+                                alt="User Icon"
+                                class="w-6 h-6 rounded-full"
+                            />
+                            <img
+                                v-else
+                                src="https://via.placeholder.com/40"
+                                alt="Default Icon"
+                                class="w-6 h-6 rounded-full"
+                            />
+
+                            <!-- 投稿者名の表示 -->
+                            <span
+                                @click="openUserProfile(post)"
+                                class="hover:bg-blue-300 p-1 rounded cursor-pointer"
                             >
-                            <span v-else>＠Unknown</span>
+                                ＠{{ post.user.name }}
+                            </span>
                         </span>
+                        <span v-else>＠Unknown</span>
                     </p>
                     <p class="mb-2 text-xl font-bold">{{ post.title }}</p>
                     <p class="mb-2">{{ post.message }}</p>

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -204,7 +204,8 @@ const isCommentAuthor = (comment) => {
                             class="hover:bg-blue-300 p-1 rounded cursor-pointer"
                         >
                             <span v-if="post.user">
-                                ＠{{ post.user.name }}</span>
+                                ＠{{ post.user.name }}</span
+                            >
                             <span v-else>＠Unknown</span>
                         </span>
                     </p>
@@ -274,7 +275,10 @@ const isCommentAuthor = (comment) => {
             class="fixed inset-0 bg-black/50 flex justify-center items-center z-50"
             @click="closeUserProfile"
         >
-            <Show v-if="selectedPost" :user="selectedPost.user" />
+            <!-- show.vue のコンポーネントにクリックイベントをストップさせる -->
+            <div @click.stop>
+                <Show v-if="selectedPost" :user="selectedPost.user" />
+            </div>
         </div>
 
         <!-- 下部ページネーション -->

--- a/resources/js/Pages/Profile/Partials/IconEditForm.vue
+++ b/resources/js/Pages/Profile/Partials/IconEditForm.vue
@@ -13,12 +13,15 @@ const form = useForm({
     icon: null, // アイコンを追加
 });
 
-// 選択された画像のプレビューURLを保存するref
+// アイコンのプレビューURLを定義
 const previewUrl = ref(
-    props.user.icon.startsWith("/storage/")
-        ? `${props.user.icon}` // すでに/storageがついている場合はそのまま
-        : `/storage/${props.user.icon}` // ついていない場合は/storageをつける
+    props.user.icon && typeof props.user.icon === 'string' && props.user.icon.startsWith("/storage/")
+        ? props.user.icon
+        : props.user.icon
+        ? `/storage/${props.user.icon}`
+        : "https://via.placeholder.com/100"
 );
+
 
 // ローカルプレビュー用の一時的なBlob URLかどうかを識別するフラグ
 const isLocalPreview = ref(false);

--- a/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
+++ b/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
@@ -81,13 +81,18 @@ const handleOpenIconEdit = () => {
                     <!-- プロフィール画像 -->
                     <img
                         :src="
+                            user.icon &&
+                            typeof user.icon === 'string' &&
                             user.icon.startsWith('/storage/')
                                 ? user.icon
-                                : `/storage/${user.icon}`
+                                : user.icon
+                                ? `/storage/${user.icon}`
+                                : 'https://via.placeholder.com/100'
                         "
                         alt="ユーザーのプロフィール写真"
                         class="w-24 h-24 rounded-full object-cover transition-opacity duration-300 group-hover:opacity-70"
                     />
+
                     <!-- ペンのマーク -->
                     <div
                         class="absolute bottom-0 right-0 bg-gray-800 text-white p-1 rounded-full"

--- a/resources/js/Pages/Users/Show.vue
+++ b/resources/js/Pages/Users/Show.vue
@@ -23,7 +23,7 @@ export default {
 
 <template>
     <div
-        class="flex items-center justify-center inset-0 bg-black bg-opacity-50 z-50"
+        class="flex items-center justify-center inset-0 bg-black rounded-lg bg-opacity-50 z-50"
     >
         <div
             class="bg-white p-6 rounded-lg shadow-lg max-h-screen overflow-auto w-80"

--- a/resources/js/Pages/Users/Show.vue
+++ b/resources/js/Pages/Users/Show.vue
@@ -65,7 +65,7 @@ export default {
 
             <button
                 @click="profileEdit"
-                class="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600"
+                class="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600 mx-auto block"
             >
                 プロフィールを編集
             </button>

--- a/resources/js/Pages/Users/Show.vue
+++ b/resources/js/Pages/Users/Show.vue
@@ -14,7 +14,7 @@ export default {
     },
     methods: {
         profileEdit() {
-            // 編集ボタンを押したときの処理をここに書く
+            // 編集ボタンを押したときの処理
             router.visit(route("profile.edit"));
         },
     },
@@ -22,8 +22,12 @@ export default {
 </script>
 
 <template>
-    <div class="flex justify-center items-center min-h-screen bg-gray-100">
-        <div class="w-80 bg-white p-6 rounded-lg shadow-lg text-center">
+    <div
+        class="flex items-center justify-center inset-0 bg-black bg-opacity-50 z-50"
+    >
+        <div
+            class="bg-white p-6 rounded-lg shadow-lg max-h-screen overflow-auto w-80"
+        >
             <img
                 :src="
                     user.icon
@@ -61,7 +65,7 @@ export default {
 
             <button
                 @click="profileEdit"
-                class="bg-blue-500 text-white px-4 py-2 rounded mb-6 hover:bg-blue-600"
+                class="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600"
             >
                 プロフィールを編集
             </button>

--- a/resources/js/Pages/Users/Show.vue
+++ b/resources/js/Pages/Users/Show.vue
@@ -10,7 +10,8 @@ export default {
     },
     setup() {
         const page = usePage();
-        return { page };
+        const authUser = page.props.auth.user; // ログインユーザー情報を取得
+        return { page, authUser };
     },
     methods: {
         profileEdit() {
@@ -63,7 +64,9 @@ export default {
                 </div>
             </div>
 
+            <!-- ログインユーザーと一致する場合にのみ表示 -->
             <button
+                v-if="authUser && authUser.id === user.id"
                 @click="profileEdit"
                 class="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600 mx-auto block"
             >


### PR DESCRIPTION
# 目的

掲示板やコメント欄で、ユーザー名やアイコンをクリックすることで、簡単にユーザーの詳細情報を確認できるようにするため。また、ユーザーアイコンの表示を追加することで、UI/UXの向上を図る。

# 達成条件

1. 掲示板の投稿者名やコメントのユーザー名をクリックした際に、プロフィール詳細をポップアップ表示できること。
2. 投稿やコメントに対して、ユーザーアイコンを表示し、アイコンのクリックでもプロフィールポップアップを表示できること。
3. ユーザーアイコンがない場合は、デフォルトのプレースホルダー画像が表示されること。

# 実装の概要

- 掲示板の投稿者名の隣に、ユーザーアイコンを表示する機能を追加。
- ユーザー名やアイコンをクリックすると、プロフィールポップアップが表示される機能を実装。
- コメント欄にも同様に、親コメント・子コメントにおいて、ユーザーアイコンを表示し、アイコンやユーザー名をクリックするとポップアップが表示されるように修正。
- ポップアップ表示のレイアウトやスタイルを調整し、中央に表示されるように改善。
- ログインユーザーと表示されているユーザーが一致する場合のみ、プロフィール編集ボタンを表示する機能を追加。

# レビューしてほしいところ

1. ユーザーアイコンとポップアップ表示機能が、掲示板とコメント欄の両方で意図したとおりに動作するか確認してほしい。
2. ポップアップ表示のレイアウトやスタイルが、レスポンシブ対応を含めて適切かどうか見てほしい。
3. nullチェックやアイコンのデフォルト表示の部分で、不足がないか確認してほしい。

# 不安に思っていること

- ポップアップ表示のレイアウトが、デバイスによって崩れてしまう可能性がないか。
- 大量のコメントがある場合のパフォーマンスへの影響について。

# 保留していること

- レイアウトの調整は別途行う予定。