### PR TITLE
社員一覧ページの作成と詳細ポップアップ表示機能の追加

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -15,7 +15,10 @@ class UserController extends Controller
      */
     public function index()
     {
-        //
+        $users = User::all();
+        return Inertia::render('Admin/EmployeeList', [
+            'users' => $users,
+        ]);
     }
 
     /**

--- a/resources/js/Pages/Admin/Dashboard.vue
+++ b/resources/js/Pages/Admin/Dashboard.vue
@@ -40,7 +40,7 @@ import { Link, Head } from "@inertiajs/vue3";
                     </p>
                     <div class="mt-4">
                         <Link
-                            href="/admin/employees/list"
+                            :href="route('users.index')"
                             class="text-indigo-600 hover:text-indigo-900"
                             >{{ $t("List page") }}</Link
                         >

--- a/resources/js/Pages/Admin/EmployeeList.vue
+++ b/resources/js/Pages/Admin/EmployeeList.vue
@@ -1,8 +1,22 @@
 <script setup>
-import { Head, usePage, Link } from "@inertiajs/vue3";
+import { Head, usePage} from "@inertiajs/vue3";
+import { ref } from "vue";
+import Show from "@/Pages/Users/Show.vue";
 
 const { props } = usePage();
 const users = props.users;
+
+const isUserProfileVisible = ref(false);
+const selectedUser = ref(null);
+
+const openUserProfile = (user) => {
+    selectedUser.value = user;
+    isUserProfileVisible.value = true; // ユーザーの詳細ページを表示
+};
+
+const closeUserProfile = () => {
+    isUserProfileVisible.value = false;
+};
 </script>
 
 <template>
@@ -24,15 +38,30 @@ const users = props.users;
                             : 'https://via.placeholder.com/150'
                     "
                     alt="Profile Icon"
-                    class="w-16 h-16 rounded-full"
+                    class="w-16 h-16 rounded-full cursor-pointer hover:opacity-70"
+                    @click="openUserProfile(user)"
                 />
 
-                <Link :href="route('users.show', user.id)" class="flex-grow">
-                    <p class="text-lg font-bold text-gray-900">
+                <p class="text-lg font-bold text-gray-900">
+                    <span
+                        @click="openUserProfile(user)"
+                        class="hover:bg-blue-300 p-1 rounded cursor-pointer"
+                    >
                         {{ user.name }}
-                    </p>
-                </Link>
+                    </span>
+                </p>
             </div>
+        </div>
+    </div>
+
+    <!-- 選択された投稿のユーザーの詳細ページを表示 -->
+    <div
+        v-if="isUserProfileVisible"
+        class="fixed inset-0 bg-black/50 flex justify-center items-center z-50"
+        @click="closeUserProfile"
+    >
+        <div @click.stop>
+            <Show v-if="selectedUser" :user="selectedUser" />
         </div>
     </div>
 </template>

--- a/resources/js/Pages/Admin/EmployeeList.vue
+++ b/resources/js/Pages/Admin/EmployeeList.vue
@@ -1,7 +1,8 @@
 <script setup>
-import { Head, usePage} from "@inertiajs/vue3";
+import { Head, usePage } from "@inertiajs/vue3";
 import { ref } from "vue";
 import Show from "@/Pages/Users/Show.vue";
+import AuthenticatedLayout from "@/Layouts/AuthenticatedLayout.vue";
 
 const { props } = usePage();
 const users = props.users;
@@ -22,46 +23,48 @@ const closeUserProfile = () => {
 <template>
     <Head :title="$t('Employee List')" />
 
-    <div class="max-w-7xl mx-auto py-10 sm:px-6 lg:px-8">
-        <h1 class="text-2xl font-bold mb-6">{{ $t("Employee List") }}</h1>
+    <AuthenticatedLayout>
+        <div class="max-w-7xl mx-auto py-10 sm:px-6 lg:px-8">
+            <h1 class="text-2xl font-bold mb-6">{{ $t("Employee List") }}</h1>
 
-        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-            <div
-                v-for="user in users"
-                :key="user.id"
-                class="bg-white overflow-hidden shadow rounded-lg p-4 flex items-center space-x-4"
-            >
-                <img
-                    :src="
-                        user.icon
-                            ? `/storage/${user.icon}`
-                            : 'https://via.placeholder.com/150'
-                    "
-                    alt="Profile Icon"
-                    class="w-16 h-16 rounded-full cursor-pointer hover:opacity-70"
-                    @click="openUserProfile(user)"
-                />
-
-                <p class="text-lg font-bold text-gray-900">
-                    <span
+            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                <div
+                    v-for="user in users"
+                    :key="user.id"
+                    class="bg-white overflow-hidden shadow rounded-lg p-4 flex items-center space-x-4"
+                >
+                    <img
+                        :src="
+                            user.icon
+                                ? `/storage/${user.icon}`
+                                : 'https://via.placeholder.com/150'
+                        "
+                        alt="Profile Icon"
+                        class="w-16 h-16 rounded-full cursor-pointer hover:opacity-70"
                         @click="openUserProfile(user)"
-                        class="hover:bg-blue-300 p-1 rounded cursor-pointer"
-                    >
-                        {{ user.name }}
-                    </span>
-                </p>
+                    />
+
+                    <p class="text-lg font-bold text-gray-900">
+                        <span
+                            @click="openUserProfile(user)"
+                            class="hover:bg-blue-300 p-1 rounded cursor-pointer"
+                        >
+                            {{ user.name }}
+                        </span>
+                    </p>
+                </div>
             </div>
         </div>
-    </div>
 
-    <!-- 選択された投稿のユーザーの詳細ページを表示 -->
-    <div
-        v-if="isUserProfileVisible"
-        class="fixed inset-0 bg-black/50 flex justify-center items-center z-50"
-        @click="closeUserProfile"
-    >
-        <div @click.stop>
-            <Show v-if="selectedUser" :user="selectedUser" />
+        <!-- 選択された投稿のユーザーの詳細ページを表示 -->
+        <div
+            v-if="isUserProfileVisible"
+            class="fixed inset-0 bg-black/50 flex justify-center items-center z-50"
+            @click="closeUserProfile"
+        >
+            <div @click.stop>
+                <Show v-if="selectedUser" :user="selectedUser" />
+            </div>
         </div>
-    </div>
+    </AuthenticatedLayout>
 </template>

--- a/resources/js/Pages/Admin/EmployeeList.vue
+++ b/resources/js/Pages/Admin/EmployeeList.vue
@@ -1,0 +1,38 @@
+<script setup>
+import { Head, usePage } from "@inertiajs/vue3";
+
+const { props } = usePage();
+const users = props.users;
+</script>
+
+<template>
+    <Head :title="$t('Employee List')" />
+
+    <div class="max-w-7xl mx-auto py-10 sm:px-6 lg:px-8">
+        <h1 class="text-2xl font-bold mb-6">{{ $t('Employee List') }}</h1>
+
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+            <div
+                v-for="user in users"
+                :key="user.id"
+                class="bg-white overflow-hidden shadow rounded-lg p-4 flex items-center"
+            >
+                <img
+                    :src="
+                        user.icon
+                            ? `/storage/${user.icon}`
+                            : 'https://via.placeholder.com/150'
+                    "
+                    alt="Profile Icon"
+                    class="w-16 h-16 rounded-full mr-4"
+                />
+
+                <div>
+                    <p class="text-lg font-bold text-gray-900">
+                        {{ user.name }}
+                    </p>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>

--- a/resources/js/Pages/Admin/EmployeeList.vue
+++ b/resources/js/Pages/Admin/EmployeeList.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { Head, usePage } from "@inertiajs/vue3";
+import { Head, usePage, Link } from "@inertiajs/vue3";
 
 const { props } = usePage();
 const users = props.users;
@@ -9,13 +9,13 @@ const users = props.users;
     <Head :title="$t('Employee List')" />
 
     <div class="max-w-7xl mx-auto py-10 sm:px-6 lg:px-8">
-        <h1 class="text-2xl font-bold mb-6">{{ $t('Employee List') }}</h1>
+        <h1 class="text-2xl font-bold mb-6">{{ $t("Employee List") }}</h1>
 
         <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
             <div
                 v-for="user in users"
                 :key="user.id"
-                class="bg-white overflow-hidden shadow rounded-lg p-4 flex items-center"
+                class="bg-white overflow-hidden shadow rounded-lg p-4 flex items-center space-x-4"
             >
                 <img
                     :src="
@@ -24,14 +24,14 @@ const users = props.users;
                             : 'https://via.placeholder.com/150'
                     "
                     alt="Profile Icon"
-                    class="w-16 h-16 rounded-full mr-4"
+                    class="w-16 h-16 rounded-full"
                 />
 
-                <div>
+                <Link :href="route('users.show', user.id)" class="flex-grow">
                     <p class="text-lg font-bold text-gray-900">
                         {{ user.name }}
                     </p>
-                </div>
+                </Link>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## 目的

社員一覧ページを作成し、全ユーザー情報を表示することで、管理者が簡単に社員情報を把握できるようにします。また、各社員の詳細情報をポップアップで確認できる機能を追加し、ユーザーエクスペリエンスを向上させることを目的とします。

## 達成条件

1. 社員一覧ページに全ユーザーをカード形式で表示する。

2. ユーザーのプロフィール画像や名前をクリックした際に、詳細情報がポップアップで表示される。

## 実装の概要

- **社員一覧の表示**:

  - 全ユーザー情報を取得し、社員一覧ページでカード形式で表示。

  - プロフィール画像と名前を各カード内に配置し、ユーザー情報を視覚的にわかりやすく表現しました。

- **詳細ポップアップの追加**:

  - ユーザーのプロフィール画像や名前をクリックすると、`Show.vue` を利用してユーザーの詳細情報がポップアップ表示される機能を追加しました。

  - このポップアップ機能は、以前のプルリクエスト [#32 - プロフィールポップアップ機能とユーザーアイコン表示の追加](https://github.com/shotasato0/CommuniCareV2/pull/32) で作成した機能を流用しており、今回の社員一覧ページにも同様の仕組みを取り入れています。

  - ポップアップは画面中央に表示され、背景を黒い半透明にすることでフォーカスがポップアップに集中するデザインとしています。

- **社員一覧ページのレイアウトを認証レイアウトに統合**:

  - 社員一覧ページを`AuthenticatedLayout`に組み込むことで、全体の統一感を持たせ、管理者が利用しやすいレイアウトに改善しました。

## レビューしてほしいところ

- **コードの可読性**: コンポーネントの分割や変数の命名が分かりやすいかどうか。

- **ポップアップ表示の使い勝手**: ユーザーインターフェースとしてポップアップが自然かどうか、改善点があれば教えてください。

- **ルート設定の整合性**: 社員一覧ページやユーザー詳細ポップアップへのルート設定が適切かどうか。

## 不安に思っていること

- 詳細ポップアップとリンクの重複がユーザーエクスペリエンスに与える影響がないか少し懸念しています。このあたりについてフィードバックいただけると助かります。

## 保留していること

- 将来的に、事業所（ユニット）別に社員を分けて表示する機能を追加する予定です。現時点では全ての社員を一覧で表示していますが、より組織構造に応じた表示ができるよう改善していく予定です。

## 関連

- **UserController**: 全ユーザーを取得するためのメソッドを追加。

- **EmployeeList.vue**: 社員一覧ページのビュー作成とデザイン改善。

- **Show\.vue**: 社員詳細情報のポップアップ表示用コンポーネント。

- **AuthenticatedLayout.vue**: 社員一覧ページを認証レイアウトに統合して、管理者向けに利便性を向上。