### PR TITLE
部署管理機能の追加および関連レイアウトと国際化対応の改善

### DIFF
--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -7,6 +7,7 @@ use App\Models\Comment;  // Commentモデル
 use App\Models\Post;     // Postモデル
 use Illuminate\Support\Facades\Auth;
 use Inertia\Inertia;
+use App\Models\Unit;
 
 class CommentController extends Controller
 {
@@ -30,8 +31,12 @@ class CommentController extends Controller
           // コメントに関連するユーザー情報をロードする
         $comment->load('user');
 
+        $units = Unit::all();
+
          // Inertiaレスポンスを返す
-        return Inertia::render('Forum');
+        return Inertia::render('Forum', [
+            'units' => $units,
+        ]);
     }
 
     public function destroy($id)

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use Inertia\Inertia;
 use App\Models\Post;
 use Illuminate\Http\Request;
+use App\Models\Unit;
 
 class PostController extends Controller
 {
@@ -28,9 +29,12 @@ class PostController extends Controller
     ->latest()
     ->paginate(5);
 
+    $units = Unit::all();
+
     return Inertia::render('Forum', [
         'posts' => $posts,
         'search' => $search, // 検索ワードを渡す
+        'units' => $units,
     ]);
 }
 
@@ -52,10 +56,13 @@ class PostController extends Controller
     // 新しい投稿にユーザー情報をロードして返す
     $post->load('user'); // リレーションをロードする
 
+    $units = Unit::all();
+
        // 正しいInertiaレスポンスで新しい投稿とauth情報を返す
        return Inertia::render('Forum', [
         'newPost' => $post,
         'auth' => auth()->user(), // ログインユーザー情報も渡す
+        'units' => $units,
     ]);
 }
 

--- a/app/Http/Controllers/UnitController.php
+++ b/app/Http/Controllers/UnitController.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\Unit;
+use Inertia\Inertia;
+
+class UnitController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create()
+    {
+        return inertia("Unit/Register");
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(string $id)
+    {
+        //
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit(string $id)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, string $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(string $id)
+    {
+        //
+    }
+}

--- a/app/Http/Controllers/UnitController.php
+++ b/app/Http/Controllers/UnitController.php
@@ -77,6 +77,7 @@ class UnitController extends Controller
      */
     public function destroy(string $id)
     {
-        //
+        Unit::find($id)->delete();
+        return redirect()->route("dashboard")->with(["success" => "ユニット削除が完了しました。"]);
     }
 }

--- a/app/Http/Controllers/UnitController.php
+++ b/app/Http/Controllers/UnitController.php
@@ -29,7 +29,8 @@ class UnitController extends Controller
      */
     public function store(Request $request)
     {
-        //
+        Unit::create($request->all());
+        return redirect()->route("dashboard")->with(["success" => "ユニット登録が完了しました。"]);
     }
 
     /**

--- a/app/Http/Controllers/UnitController.php
+++ b/app/Http/Controllers/UnitController.php
@@ -29,6 +29,15 @@ class UnitController extends Controller
      */
     public function store(Request $request)
     {
+        $request->validate([
+            "name" => "required|string|max:255|unique:units,name",
+        ], [
+            "name.required" => "部署名は必須です。",
+            "name.string" => "部署名は文字列で入力してください。",
+            "name.max" => "部署名は255文字以内で入力してください。",
+            "name.unique" => "この部署名は既に登録されています。",
+        ]);
+
         Unit::create($request->all());
         return redirect()->route("dashboard")->with(["success" => "ユニット登録が完了しました。"]);
     }

--- a/app/Http/Controllers/UnitController.php
+++ b/app/Http/Controllers/UnitController.php
@@ -24,7 +24,10 @@ class UnitController extends Controller
      */
     public function create()
     {
-        return inertia("Unit/Register");
+        $units = Unit::select('id', 'name')->get();
+        return inertia("Unit/Register", [
+            'units' => $units,
+        ]);
     }
 
     /**

--- a/app/Http/Controllers/UnitController.php
+++ b/app/Http/Controllers/UnitController.php
@@ -13,7 +13,10 @@ class UnitController extends Controller
      */
     public function index()
     {
-        //
+        $units = Unit::all();
+        return Inertia::render('Unit/List', [
+            'units' => $units,
+        ]);
     }
 
     /**

--- a/database/migrations/tenant/2024_10_27_055448_add_unique_constraint_to_units_name_column.php
+++ b/database/migrations/tenant/2024_10_27_055448_add_unique_constraint_to_units_name_column.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('units', function (Blueprint $table) {
+            $table->string('name')->unique()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('units', function (Blueprint $table) {
+            $table->string('name')->change();
+        });
+    }
+};

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -160,5 +160,9 @@
     "Registration page": "登録ページへ",
     "Unit Registration": "部署登録",
     "Unit Name": "部署名",
-    "Register Unit": "部署登録"
+    "Register Unit": "部署登録",
+    "Unit List": "部署一覧",
+    "Delete Unit": "部署削除",
+    "No units available.": "部署がありません",
+    "Delete": "削除"
 }

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -164,5 +164,8 @@
     "Unit List": "部署一覧",
     "Delete Unit": "部署削除",
     "No units available.": "部署がありません",
-    "Delete": "削除"
+    "Delete": "削除",
+    "Unit Management": "部署管理",
+    "Manage unit names.": "部署名を管理します",
+    "Management page": "管理ページへ"
 }

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -157,5 +157,8 @@
     "List page": "一覧ページへ",
     "Unit Name Registration": "ユニット名登録",
     "Register a new unit name.": "新しいユニット名を登録します",
-    "Registration page": "登録ページへ"
+    "Registration page": "登録ページへ",
+    "Unit Registration": "部署登録",
+    "Unit Name": "部署名",
+    "Register Unit": "部署登録"
 }

--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -21,7 +21,9 @@ const auth = usePage().props.auth || {};
 <template>
     <div>
         <div class="min-h-screen bg-gray-100">
-            <nav class="bg-white border-b border-gray-100">
+            <nav
+                class="bg-white border-b border-gray-100 fixed top-0 left-0 w-full z-10"
+            >
                 <!-- Primary Navigation Menu -->
                 <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
                     <div class="flex justify-between h-16">

--- a/resources/js/Pages/Admin/Dashboard.vue
+++ b/resources/js/Pages/Admin/Dashboard.vue
@@ -59,7 +59,7 @@ import { Link, Head } from "@inertiajs/vue3";
                     </p>
                     <div class="mt-4">
                         <Link
-                            href="/admin/units/register"
+                            :href="route('units.create')"
                             class="text-indigo-600 hover:text-indigo-900"
                             >{{ $t("Registration page") }}</Link
                         >

--- a/resources/js/Pages/Admin/Dashboard.vue
+++ b/resources/js/Pages/Admin/Dashboard.vue
@@ -48,20 +48,20 @@ import { Link, Head } from "@inertiajs/vue3";
                 </div>
             </div>
 
-            <!-- ユニット名登録 -->
+            <!-- 部署管理 -->
             <div class="bg-white overflow-hidden shadow rounded-lg">
                 <div class="px-4 py-5 sm:p-6">
                     <h3 class="text-lg font-medium leading-6 text-gray-900">
-                        {{ $t("Unit Name Registration") }}
+                        {{ $t("Unit Management") }}
                     </h3>
                     <p class="mt-2 max-w-4xl text-sm text-gray-500">
-                        {{ $t("Register a new unit name.") }}
+                        {{ $t("Manage unit names.") }}
                     </p>
                     <div class="mt-4">
                         <Link
                             :href="route('units.create')"
                             class="text-indigo-600 hover:text-indigo-900"
-                            >{{ $t("Registration page") }}</Link
+                            >{{ $t("Management page") }}</Link
                         >
                     </div>
                 </div>

--- a/resources/js/Pages/Admin/EmployeeList.vue
+++ b/resources/js/Pages/Admin/EmployeeList.vue
@@ -26,7 +26,7 @@ const closeUserProfile = () => {
 
     <AuthenticatedLayout>
         <div class="max-w-7xl mx-auto py-10 sm:px-6 lg:px-8">
-            <h1 class="text-2xl font-bold mb-6">{{ $t("Employee List") }}</h1>
+            <h1 class="text-2xl font-bold mb-6 mt-16">{{ $t("Employee List") }}</h1>
 
             <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
                 <div

--- a/resources/js/Pages/Admin/EmployeeList.vue
+++ b/resources/js/Pages/Admin/EmployeeList.vue
@@ -6,6 +6,7 @@ import AuthenticatedLayout from "@/Layouts/AuthenticatedLayout.vue";
 
 const { props } = usePage();
 const users = props.users;
+const units = props.units;
 
 const isUserProfileVisible = ref(false);
 const selectedUser = ref(null);
@@ -63,7 +64,7 @@ const closeUserProfile = () => {
             @click="closeUserProfile"
         >
             <div @click.stop>
-                <Show v-if="selectedUser" :user="selectedUser" />
+                <Show v-if="selectedUser" :user="selectedUser" :units="units"/>
             </div>
         </div>
     </AuthenticatedLayout>

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -191,7 +191,7 @@ const search = ref(pageProps.search || "");
     <Head :title="$t('Forum')" />
 
     <AuthenticatedLayout>
-        <div class="flex">
+        <div class="flex mt-16">
             <!-- オーバーレイ (サイドバー表示時のみ) -->
             <div
                 v-if="sidebarVisible"

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -202,7 +202,7 @@ const search = ref(pageProps.search || "");
             <!-- サイドバー -->
             <List
                 :units="units"
-                class="sidebar-mobile p-4 mt-16 lg:block"
+                class="sidebar-mobile p-4 lg:mt-16 lg:block"
                 :class="{ visible: sidebarVisible }"
                 ref="sidebar"
             />

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -10,7 +10,7 @@ import Pagination from "@/Components/Pagination.vue";
 import { getCsrfToken } from "@/Utils/csrf";
 import Show from "./Users/Show.vue";
 import SearchForm from "@/Components/SearchForm.vue";
-
+import List from "./Unit/List.vue";
 // propsからページのデータを取得
 const pageProps = usePage().props;
 const posts = ref(pageProps.posts || []); // 投稿のデータ
@@ -184,149 +184,156 @@ const search = ref(pageProps.search || "");
     <Head :title="$t('Forum')" />
 
     <AuthenticatedLayout>
-        <div class="w-11/12 max-w-screen-md m-auto">
-            <div class="flex justify-between items-center">
-                <h1 class="text-xl font-bold">{{ appName }}</h1>
+        <div class="flex">
+            <!-- サイドバー -->
+            <List :units="units" class="w-1/4 p-4 mt-16" />
 
-                <!-- 検索結果があるかどうかを判断して表示を切り替える -->
-                <div v-if="search" class="text-xl font-bold">
+            <!-- メインコンテンツエリア -->
+            <div class="flex-1 max-w-4xl mx-auto p-4">
+                <div class="flex justify-between items-center mb-4">
+                    <h1 class="text-xl font-bold">{{ appName }}</h1>
+
+                    <!-- 検索フォーム -->
+                    <SearchForm class="ml-auto" />
+                </div>
+
+                <!-- 検索結果 -->
+                <div v-if="search" class="text-lg font-bold mb-4">
                     <p>検索結果: {{ posts.total }}件</p>
                 </div>
 
-                <!-- 検索フォーム -->
-                <div class="flex justify-end">
-                    <SearchForm />
-                </div>
-            </div>
+                <!-- 上部ページネーション -->
+                <Pagination :links="posts.links" class="mb-4" />
 
-            <!-- 上部ページネーション -->
-            <Pagination :links="posts.links" />
+                <!-- 投稿フォーム -->
+                <PostForm class="mb-6" />
 
-            <PostForm />
-
-            <!-- 投稿一覧 -->
-            <div
-                v-for="post in posts.data"
-                :key="post.id"
-                class="bg-white rounded-md mt-1 mb-5 p-3"
-            >
-                <!-- スレッド -->
-                <div>
-                    <p class="mb-2 text-xs">
-                        {{ formatDate(post.created_at) }}
-                        <span
-                            v-if="post.user"
-                            class="flex items-center space-x-2"
-                        >
-                            <!-- ユーザーアイコンの表示 -->
-                            <img
-                                v-if="post.user.icon"
-                                :src="
-                                    post.user.icon.startsWith('/storage/')
-                                        ? post.user.icon
-                                        : `/storage/${post.user.icon}`
-                                "
-                                alt="User Icon"
-                                class="w-6 h-6 rounded-full cursor-pointer"
-                                @click="openUserProfile(post)"
-                            />
-                            <img
-                                v-else
-                                src="https://via.placeholder.com/40"
-                                alt="Default Icon"
-                                class="w-6 h-6 rounded-full cursor-pointer"
-                                @click="openUserProfile(post)"
-                            />
-
-                            <!-- 投稿者名の表示 -->
+                <!-- 投稿一覧 -->
+                <div
+                    v-for="post in posts.data"
+                    :key="post.id"
+                    class="bg-white rounded-md shadow-md mb-6 p-4"
+                >
+                    <div>
+                        <p class="mb-2 text-xs text-gray-500">
+                            {{ formatDate(post.created_at) }}
                             <span
-                                @click="openUserProfile(post)"
-                                class="hover:bg-blue-300 p-1 rounded cursor-pointer"
+                                v-if="post.user"
+                                class="flex items-center space-x-2"
                             >
-                                ＠{{ post.user.name }}
-                            </span>
-                        </span>
-                        <span v-else>＠Unknown</span>
-                    </p>
-                    <p class="mb-2 text-xl font-bold">{{ post.title }}</p>
-                    <p class="mb-2">{{ post.message }}</p>
+                                <!-- ユーザーアイコンの表示 -->
+                                <img
+                                    v-if="post.user.icon"
+                                    :src="
+                                        post.user.icon.startsWith('/storage/')
+                                            ? post.user.icon
+                                            : `/storage/${post.user.icon}`
+                                    "
+                                    alt="User Icon"
+                                    class="w-6 h-6 rounded-full cursor-pointer"
+                                    @click="openUserProfile(post)"
+                                />
+                                <img
+                                    v-else
+                                    src="https://via.placeholder.com/40"
+                                    alt="Default Icon"
+                                    class="w-6 h-6 rounded-full cursor-pointer"
+                                    @click="openUserProfile(post)"
+                                />
 
-                    <!-- ボタンを投稿の下、右端に配置 -->
-                    <div class="flex justify-end space-x-2 mt-2">
-                        <!-- 投稿に対する返信ボタン -->
-                        <button
-                            @click="
-                                toggleCommentForm(
-                                    post.id,
-                                    'post',
-                                    post.user ? post.user.name : 'Unknown'
-                                )
+                                <!-- 投稿者名の表示 -->
+                                <span
+                                    @click="openUserProfile(post)"
+                                    class="hover:bg-blue-300 p-1 rounded cursor-pointer"
+                                >
+                                    ＠{{ post.user.name }}
+                                </span>
+                            </span>
+                            <span v-else>＠Unknown</span>
+                        </p>
+                        <p class="mb-2 text-xl font-bold">{{ post.title }}</p>
+                        <p class="mb-2">{{ post.message }}</p>
+
+                        <!-- ボタンを投稿の下、右端に配置 -->
+                        <div class="flex justify-end space-x-2 mt-2">
+                            <!-- 投稿に対する返信ボタン -->
+                            <button
+                                @click="
+                                    toggleCommentForm(
+                                        post.id,
+                                        'post',
+                                        post.user ? post.user.name : 'Unknown'
+                                    )
+                                "
+                                class="px-2 py-1 rounded bg-green-500 text-white font-bold link-hover cursor-pointer"
+                            >
+                                <i class="bi bi-reply"></i>
+                            </button>
+                            <!-- 投稿の削除ボタン -->
+                            <button
+                                v-if="
+                                    post.user && post.user.id === auth.user.id
+                                "
+                                @click.prevent="deleteItem('post', post.id)"
+                                class="px-2 py-1 ml-2 rounded bg-red-500 text-white font-bold link-hover cursor-pointer"
+                            >
+                                <i class="bi bi-trash"></i>
+                            </button>
+                        </div>
+
+                        <!-- 投稿へのコメントフォーム -->
+                        <CommentForm
+                            v-if="
+                                commentFormVisibility[post.id]?.['post']
+                                    ?.isVisible
                             "
-                            class="px-2 py-1 rounded bg-green-500 text-white font-bold link-hover cursor-pointer"
-                        >
-                            <i class="bi bi-reply"></i>
-                        </button>
-                        <!-- 投稿の削除ボタン -->
-                        <button
-                            v-if="post.user && post.user.id === auth.user.id"
-                            @click.prevent="deleteItem('post', post.id)"
-                            class="px-2 py-1 ml-2 rounded bg-red-500 text-white font-bold link-hover cursor-pointer"
-                        >
-                            <i class="bi bi-trash"></i>
-                        </button>
+                            :postId="post.id"
+                            :parentId="null"
+                            :replyToName="
+                                commentFormVisibility[post.id]?.['post']
+                                    ?.replyToName
+                            "
+                            class="mt-4"
+                        />
                     </div>
 
-                    <!-- 投稿へのコメントフォーム -->
-                    <CommentForm
-                        v-if="
-                            commentFormVisibility[post.id]?.['post']?.isVisible
-                        "
+                    <h3 class="font-bold mt-8 mb-2">
+                        {{ getCurrentCommentCount(post) }}件のコメント
+                    </h3>
+
+                    <!-- 親コメントビュー -->
+                    <ParentComment
+                        :comments="post.comments"
                         :postId="post.id"
-                        :parentId="null"
-                        :replyToName="
-                            commentFormVisibility[post.id]?.['post']
-                                ?.replyToName
-                        "
-                        class="mt-4"
+                        :formatDate="formatDate"
+                        :isCommentAuthor="isCommentAuthor"
+                        :deleteItem="deleteItem"
+                        :toggleCommentForm="toggleCommentForm"
+                        :commentFormVisibility="commentFormVisibility"
+                        :openUserProfile="openUserProfile"
                     />
                 </div>
 
-                <h3 class="font-bold mt-8 mb-2">
-                    {{ getCurrentCommentCount(post) }}件のコメント
-                </h3>
+                <!-- 下部ページネーション -->
+                <Pagination :links="posts.links" class="mt-4" />
+            </div>
 
-                <!-- 親コメントビュー -->
-                <ParentComment
-                    :comments="post.comments"
-                    :postId="post.id"
-                    :formatDate="formatDate"
-                    :isCommentAuthor="isCommentAuthor"
-                    :deleteItem="deleteItem"
-                    :toggleCommentForm="toggleCommentForm"
-                    :commentFormVisibility="commentFormVisibility"
-                    :openUserProfile="openUserProfile"
-                />
+            <!-- 選択された投稿のユーザーの詳細ページを表示 -->
+            <div
+                v-if="isUserProfileVisible"
+                class="fixed inset-0 bg-black/50 flex justify-center items-center z-50"
+                @click="closeUserProfile"
+            >
+                <!-- show.vue のコンポーネントにクリックイベントをストップさせる -->
+                <div @click.stop>
+                    <Show
+                        v-if="selectedPost"
+                        :user="selectedPost.user"
+                        :units="units"
+                    />
+                </div>
             </div>
         </div>
-
-        <!-- 選択された投稿のユーザーの詳細ページを表示 -->
-        <div
-            v-if="isUserProfileVisible"
-            class="fixed inset-0 bg-black/50 flex justify-center items-center z-50"
-            @click="closeUserProfile"
-        >
-            <!-- show.vue のコンポーネントにクリックイベントをストップさせる -->
-            <div @click.stop>
-                <Show
-                    v-if="selectedPost"
-                    :user="selectedPost.user"
-                    :units="units"
-                />
-            </div>
-        </div>
-
-        <!-- 下部ページネーション -->
-        <Pagination :links="posts.links" />
     </AuthenticatedLayout>
 </template>
 

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -11,6 +11,7 @@ import { getCsrfToken } from "@/Utils/csrf";
 import Show from "./Users/Show.vue";
 import SearchForm from "@/Components/SearchForm.vue";
 import List from "./Unit/List.vue";
+
 // propsからページのデータを取得
 const pageProps = usePage().props;
 const posts = ref(pageProps.posts || []); // 投稿のデータ
@@ -18,6 +19,7 @@ const auth = pageProps.auth; // ログインユーザー情報
 const units = pageProps.units; // 部署のデータ
 const selectedPost = ref(null); // 選択された投稿
 const isUserProfileVisible = ref(false); // ユーザーの詳細ページの表示状態
+const sidebarVisible = ref(false); // サイドバーの表示状態
 
 const openUserProfile = (post) => {
     selectedPost.value = post;
@@ -31,6 +33,11 @@ const closeUserProfile = () => {
 // 投稿を選択する関数
 const selectPost = (post) => {
     selectedPost.value = post;
+};
+
+const toggleSidebar = () => {
+    sidebarVisible.value = !sidebarVisible.value;
+    console.log("sidebarVisible.value:", sidebarVisible.value);
 };
 
 // コメントフォーム表示状態を管理するためのオブジェクト
@@ -186,12 +193,22 @@ const search = ref(pageProps.search || "");
     <AuthenticatedLayout>
         <div class="flex">
             <!-- サイドバー -->
-            <List :units="units" class="w-1/4 p-4 mt-16" />
+            <List
+                :units="units"
+                class="sidebar-mobile  p-4 mt-16 lg:block"
+                :class="{ visible: sidebarVisible }"
+                ref="sidebar"
+            />
 
             <!-- メインコンテンツエリア -->
             <div class="flex-1 max-w-4xl mx-auto p-4">
                 <div class="flex justify-between items-center mb-4">
-                    <h1 class="text-xl font-bold">{{ appName }}</h1>
+                    <h1
+                        class="text-xl font-bold cursor-pointer"
+                        @click="toggleSidebar"
+                    >
+                        {{ appName }}
+                    </h1>
 
                     <!-- 検索フォーム -->
                     <SearchForm class="ml-auto" />
@@ -340,5 +357,17 @@ const search = ref(pageProps.search || "");
 <style>
 .link-hover:hover {
     opacity: 70%;
+}
+
+/* モバイルサイズ用のスタイル（切り替え可能） */
+@media (max-width: 1024px) {
+    .sidebar-mobile {
+        width: 70%; /* モバイル時のサイドバー幅 */
+        transform: translateX(-100%); /* デフォルトで非表示 */
+        transition: transform 0.3s ease-in-out;
+    }
+    .sidebar-mobile.visible {
+        transform: translateX(0); /* 表示 */
+    }
 }
 </style>

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -10,11 +10,12 @@ import Pagination from "@/Components/Pagination.vue";
 import { getCsrfToken } from "@/Utils/csrf";
 import Show from "./Users/Show.vue";
 import SearchForm from "@/Components/SearchForm.vue";
+
 // propsからページのデータを取得
 const pageProps = usePage().props;
 const posts = ref(pageProps.posts || []); // 投稿のデータ
 const auth = pageProps.auth; // ログインユーザー情報
-
+const units = pageProps.units; // 部署のデータ
 const selectedPost = ref(null); // 選択された投稿
 const isUserProfileVisible = ref(false); // ユーザーの詳細ページの表示状態
 
@@ -316,7 +317,11 @@ const search = ref(pageProps.search || "");
         >
             <!-- show.vue のコンポーネントにクリックイベントをストップさせる -->
             <div @click.stop>
-                <Show v-if="selectedPost" :user="selectedPost.user" />
+                <Show
+                    v-if="selectedPost"
+                    :user="selectedPost.user"
+                    :units="units"
+                />
             </div>
         </div>
 

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -365,6 +365,7 @@ const search = ref(pageProps.search || "");
         width: 70%; /* モバイル時のサイドバー幅 */
         transform: translateX(-100%); /* デフォルトで非表示 */
         transition: transform 0.3s ease-in-out;
+        z-index: 50;
     }
     .sidebar-mobile.visible {
         transform: translateX(0); /* 表示 */

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -192,10 +192,17 @@ const search = ref(pageProps.search || "");
 
     <AuthenticatedLayout>
         <div class="flex">
+            <!-- オーバーレイ (サイドバー表示時のみ) -->
+            <div
+                v-if="sidebarVisible"
+                class="overlay"
+                @click="toggleSidebar"
+            ></div>
+
             <!-- サイドバー -->
             <List
                 :units="units"
-                class="sidebar-mobile  p-4 mt-16 lg:block"
+                class="sidebar-mobile p-4 mt-16 lg:block"
                 :class="{ visible: sidebarVisible }"
                 ref="sidebar"
             />
@@ -366,9 +373,22 @@ const search = ref(pageProps.search || "");
         transform: translateX(-100%); /* デフォルトで非表示 */
         transition: transform 0.3s ease-in-out;
         z-index: 50;
+        background-color: #ffffff; /* サイドバーの背景色 */
     }
     .sidebar-mobile.visible {
         transform: translateX(0); /* 表示 */
+    }
+
+    /* オーバーレイスタイル */
+    .overlay {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background-color: rgba(0, 0, 0, 0.5); /* 背景を半透明に */
+        z-index: 40;
+        transition: opacity 0.3s ease-in-out;
     }
 }
 </style>

--- a/resources/js/Pages/Unit/List.vue
+++ b/resources/js/Pages/Unit/List.vue
@@ -1,0 +1,34 @@
+<template>
+    <div class="sidebar bg-gray-100 w-60 h-screen p-4 shadow-lg">
+      <h2 class="text-xl font-bold mb-4">部署一覧</h2>
+      <ul>
+        <li 
+          v-for="unit in units" 
+          :key="unit.id" 
+          class="mb-2 p-2 rounded hover:bg-gray-200 cursor-pointer">
+          {{ unit.name }}
+        </li>
+      </ul>
+    </div>
+  </template>
+  
+  <script>
+  export default {
+    props: {
+      units: {
+        type: Array,
+        required: true,
+      },
+    },
+  };
+  </script>
+  
+  <style scoped>
+  .sidebar {
+    position: fixed;
+    left: 0;
+    top: 0;
+    background-color: #f7fafc;
+  }
+  </style>
+  

--- a/resources/js/Pages/Unit/Register.vue
+++ b/resources/js/Pages/Unit/Register.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { Head } from "@inertiajs/vue3";
 import { useForm, usePage } from "@inertiajs/vue3";
+import AuthenticatedLayout from "@/Layouts/AuthenticatedLayout.vue";
 
 defineProps({
     units: Array,
@@ -27,61 +28,71 @@ const deleteUnit = (id) => {
 </script>
 
 <template>
-    <Head :title="$t('Unit Registration')" />
-    <div class="max-w-2xl mx-auto py-10 space-y-8">
-        <h1 class="text-2xl font-bold mb-6">{{ $t("Unit Registration") }}</h1>
+    <AuthenticatedLayout>
+        <Head :title="$t('Unit Registration')" />
+        <div class="max-w-2xl mx-auto py-10 space-y-8 mt-16">
+            <h1 class="text-2xl font-bold mb-6">
+                {{ $t("Unit Registration") }}
+            </h1>
 
-        <!-- 部署登録フォーム -->
-        <form @submit.prevent="submit" class="bg-white p-6 rounded-lg shadow">
-            <div class="mb-4">
-                <label
-                    for="name"
-                    class="block text-sm font-medium text-gray-700"
-                    >{{ $t("Unit Name") }}</label
-                >
-                <input
-                    type="text"
-                    id="name"
-                    v-model="form.name"
-                    class="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-                />
-                <div v-if="form.errors.name" class="text-red-600 text-sm mt-1">
-                    {{ form.errors.name }}
-                </div>
-            </div>
-
-            <button
-                type="submit"
-                class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline"
+            <!-- 部署登録フォーム -->
+            <form
+                @submit.prevent="submit"
+                class="bg-white p-6 rounded-lg shadow"
             >
-                {{ $t("Register Unit") }}
-            </button>
-        </form>
-
-        <!-- 部署一覧 -->
-        <div class="bg-white p-6 rounded-lg shadow">
-            <h2 class="text-xl font-bold mb-4">{{ $t("Unit List") }}</h2>
-
-            <ul class="divide-y divide-gray-200">
-                <li
-                    v-for="unit in units"
-                    :key="unit.id"
-                    class="flex justify-between items-center py-4"
-                >
-                    <span class="text-gray-800">{{ unit.name }}</span>
-                    <button
-                        @click="deleteUnit(unit.id)"
-                        class="text-red-600 hover:text-red-800 font-bold"
+                <div class="mb-4">
+                    <label
+                        for="name"
+                        class="block text-sm font-medium text-gray-700"
+                        >{{ $t("Unit Name") }}</label
                     >
-                        {{ $t("Delete") }}
-                    </button>
-                </li>
-            </ul>
+                    <input
+                        type="text"
+                        id="name"
+                        v-model="form.name"
+                        class="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+                    />
+                    <div
+                        v-if="form.errors.name"
+                        class="text-red-600 text-sm mt-1"
+                    >
+                        {{ form.errors.name }}
+                    </div>
+                </div>
 
-            <!-- 部署がない場合のメッセージ -->
-            <p v-if="units.length === 0" class="text-gray-500 mt-4">
-                {{ $t("No units available.") }}
-            </p>
+                <button
+                    type="submit"
+                    class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline"
+                >
+                    {{ $t("Register Unit") }}
+                </button>
+            </form>
+
+            <!-- 部署一覧 -->
+            <div class="bg-white p-6 rounded-lg shadow">
+                <h2 class="text-xl font-bold mb-4">{{ $t("Unit List") }}</h2>
+
+                <ul class="divide-y divide-gray-200">
+                    <li
+                        v-for="unit in units"
+                        :key="unit.id"
+                        class="flex justify-between items-center py-4"
+                    >
+                        <span class="text-gray-800">{{ unit.name }}</span>
+                        <button
+                            @click="deleteUnit(unit.id)"
+                            class="text-red-600 hover:text-red-800 font-bold"
+                        >
+                            {{ $t("Delete") }}
+                        </button>
+                    </li>
+                </ul>
+
+                <!-- 部署がない場合のメッセージ -->
+                <p v-if="units.length === 0" class="text-gray-500 mt-4">
+                    {{ $t("No units available.") }}
+                </p>
+            </div>
         </div>
-    </div>
+    </AuthenticatedLayout>
 </template>

--- a/resources/js/Pages/Unit/Register.vue
+++ b/resources/js/Pages/Unit/Register.vue
@@ -1,7 +1,10 @@
 <script setup>
-import { ref } from "vue";
 import { Head } from "@inertiajs/vue3";
-import { useForm } from "@inertiajs/vue3";
+import { useForm, usePage } from "@inertiajs/vue3";
+
+defineProps({
+    units: Array,
+});
 
 const form = useForm({
     name: "",
@@ -10,13 +13,25 @@ const form = useForm({
 const submit = () => {
     form.post(route("units.store"));
 };
+
+// 現在の部署一覧を取得
+const { units = [] } = usePage().props;
+console.log("units", units);
+
+// 部署削除機能
+const deleteUnit = (id) => {
+    if (confirm("本当に削除しますか？")) {
+        form.delete(route("units.destroy", id));
+    }
+};
 </script>
 
 <template>
     <Head :title="$t('Unit Registration')" />
-    <div class="max-w-2xl mx-auto py-10">
+    <div class="max-w-2xl mx-auto py-10 space-y-8">
         <h1 class="text-2xl font-bold mb-6">{{ $t("Unit Registration") }}</h1>
 
+        <!-- 部署登録フォーム -->
         <form @submit.prevent="submit" class="bg-white p-6 rounded-lg shadow">
             <div class="mb-4">
                 <label
@@ -42,5 +57,31 @@ const submit = () => {
                 {{ $t("Register Unit") }}
             </button>
         </form>
+
+        <!-- 部署一覧 -->
+        <div class="bg-white p-6 rounded-lg shadow">
+            <h2 class="text-xl font-bold mb-4">{{ $t("Unit List") }}</h2>
+
+            <ul class="divide-y divide-gray-200">
+                <li
+                    v-for="unit in units"
+                    :key="unit.id"
+                    class="flex justify-between items-center py-4"
+                >
+                    <span class="text-gray-800">{{ unit.name }}</span>
+                    <button
+                        @click="deleteUnit(unit.id)"
+                        class="text-red-600 hover:text-red-800 font-bold"
+                    >
+                        {{ $t("Delete") }}
+                    </button>
+                </li>
+            </ul>
+
+            <!-- 部署がない場合のメッセージ -->
+            <p v-if="units.length === 0" class="text-gray-500 mt-4">
+                {{ $t("No units available.") }}
+            </p>
+        </div>
     </div>
 </template>

--- a/resources/js/Pages/Unit/Register.vue
+++ b/resources/js/Pages/Unit/Register.vue
@@ -31,16 +31,15 @@ const deleteUnit = (id) => {
     <AuthenticatedLayout>
         <Head :title="$t('Unit Registration')" />
         <div class="max-w-2xl mx-auto py-10 space-y-8 mt-16">
-            <h1 class="text-2xl font-bold mb-6">
-                {{ $t("Unit Registration") }}
-            </h1>
-
             <!-- 部署登録フォーム -->
             <form
                 @submit.prevent="submit"
                 class="bg-white p-6 rounded-lg shadow"
             >
                 <div class="mb-4">
+                    <h2 class="text-xl font-bold mb-6">
+                        {{ $t("Unit Registration") }}
+                    </h2>
                     <label
                         for="name"
                         class="block text-sm font-medium text-gray-700"

--- a/resources/js/Pages/Unit/Register.vue
+++ b/resources/js/Pages/Unit/Register.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { ref } from "vue";
+import { Head } from "@inertiajs/vue3";
 import { useForm } from "@inertiajs/vue3";
 
 const form = useForm({
@@ -12,15 +13,16 @@ const submit = () => {
 </script>
 
 <template>
+    <Head :title="$t('Unit Registration')" />
     <div class="max-w-2xl mx-auto py-10">
-        <h1 class="text-2xl font-bold mb-6">Unit Registration</h1>
+        <h1 class="text-2xl font-bold mb-6">{{ $t("Unit Registration") }}</h1>
 
         <form @submit.prevent="submit" class="bg-white p-6 rounded-lg shadow">
             <div class="mb-4">
                 <label
                     for="name"
                     class="block text-sm font-medium text-gray-700"
-                    >Unit Name</label
+                    >{{ $t("Unit Name") }}</label
                 >
                 <input
                     type="text"
@@ -37,7 +39,7 @@ const submit = () => {
                 type="submit"
                 class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline"
             >
-                Register Unit
+                {{ $t("Register Unit") }}
             </button>
         </form>
     </div>

--- a/resources/js/Pages/Unit/Register.vue
+++ b/resources/js/Pages/Unit/Register.vue
@@ -1,0 +1,44 @@
+<script setup>
+import { ref } from "vue";
+import { useForm } from "@inertiajs/vue3";
+
+const form = useForm({
+    name: "",
+});
+
+const submit = () => {
+    form.post(route("units.store"));
+};
+</script>
+
+<template>
+    <div class="max-w-2xl mx-auto py-10">
+        <h1 class="text-2xl font-bold mb-6">Unit Registration</h1>
+
+        <form @submit.prevent="submit" class="bg-white p-6 rounded-lg shadow">
+            <div class="mb-4">
+                <label
+                    for="name"
+                    class="block text-sm font-medium text-gray-700"
+                    >Unit Name</label
+                >
+                <input
+                    type="text"
+                    id="name"
+                    v-model="form.name"
+                    class="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+                />
+                <div v-if="form.errors.name" class="text-red-600 text-sm mt-1">
+                    {{ form.errors.name }}
+                </div>
+            </div>
+
+            <button
+                type="submit"
+                class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline"
+            >
+                Register Unit
+            </button>
+        </form>
+    </div>
+</template>

--- a/resources/js/Pages/Users/Show.vue
+++ b/resources/js/Pages/Users/Show.vue
@@ -7,11 +7,26 @@ export default {
             type: Object,
             required: true,
         },
+        units: {
+            type: Array,
+            required: true,
+        },
     },
-    setup() {
+    setup(props) {
         const page = usePage();
         const authUser = page.props.auth.user; // ログインユーザー情報を取得
-        return { page, authUser };
+
+        // デバッグ用のログを追加
+        console.log("User data:", props.user);
+        console.log("Auth user data:", authUser);
+        console.log("Units data:", props.units);
+
+        // 部署名を取得
+        const unitName =
+            props.units.find((unit) => unit.id === props.user.unit_id)?.name ||
+            "未所属";
+
+        return { page, authUser, unitName };
     },
     methods: {
         profileEdit() {
@@ -60,7 +75,7 @@ export default {
             <div class="info mb-4 text-left">
                 <label class="font-bold">所属部署</label>
                 <div class="border border-gray-300 p-2 rounded bg-gray-100">
-                    {{ user.unit ? user.unit.name : "未所属" }}
+                    {{ unitName }}
                 </div>
             </div>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\CommentController;
 use App\Http\Controllers\UserController;
 use App\Http\Controllers\AdminController;
 use App\Http\Controllers\DashboardController;
+use App\Http\Controllers\UnitController;
 
 // テナント識別をスキップするルート
 Route::middleware([])->group(function () {
@@ -55,6 +56,7 @@ Route::middleware([App\Http\Middleware\InitializeTenancyCustom::class])->group(f
         Route::middleware(['role:admin'])->group(function () {
             Route::get('/admin', [AdminController::class, 'index'])->name('admin.dashboard');
         });
+        Route::resource('units', UnitController::class);
     });
     Route::post('/logout', [AuthenticatedSessionController::class, 'destroy'])->name('logout');
 });


### PR DESCRIPTION
## 目的
部署の登録・管理をより効率的に行えるよう、部署のCRUD操作を一つの画面で実施できる部署管理ページを実装しました。これに伴い、サイドバーやナビゲーションバーのレイアウトを含め、他の管理ページと統一感のあるレイアウトを実現することを目的としています。

## 達成条件
- 部署の登録・削除が同一ページ内で可能であること
- サイドバーやナビゲーションバーのレイアウトが統一されていること
- 部署情報の表示が適切に反映されること
- モバイル・デスクトップの表示でレイアウトが自動調整されること

## 実装の概要
1. **ユニットコントローラー作成**  
   ユニットのCRUD操作を実装するため、`UnitController`を作成し、`create`メソッドでユニット登録ページを表示できるようにしました。

2. **ユニット登録ページの実装とCRUD操作の実装**  
   ユーザーがユニット名を登録できる入力フォーム、登録された部署一覧、部署削除機能を追加しました。削除操作には確認メッセージを追加し、削除後はダッシュボードにリダイレクトして完了メッセージを表示するようにしました。

3. **ルート設定とリンク先の見直し**  
   `Route::resource`でユニットのルートを一括追加し、ページ遷移時にルート名指定が利用できるように変更しました。また、部署管理リンクの表記を「管理ページ」とし、登録ページへのリンク先もルート名`index`で統一しました。

4. **サイドバーとナビゲーションバーの改善**  
   サイドバーの表示が検索バーより前面に出るよう`z-index`を設定し、モバイル版ではオーバーレイを表示してサイドバーを強調するようにしました。また、サイドバーの上部マージンが画面サイズに応じて変わるように調整し、ナビゲーションバーもスクロール時に固定されるようにしました。

5. **国際化対応の強化**  
   部署管理に必要な文言を各国対応させるため、翻訳キーを`Unit List`や`Delete Unit`など必要な分だけ追加しました。

6. **見出しの構造調整**  
   視覚的な階層を明確にするため、ユニット登録フォームのタイトルをh2タグに変更し、内容をフォーム内に配置しました。

## レビューしてほしいところ
- データの取得と渡し方に問題がないか（例: 部署情報の取得・表示）
- サイドバーやナビゲーションバーのレイアウトが適切か
- 国際化対応が正しく実装されているか

## 不安に思っていること
- **命名規則について**  
  部署管理ページのリンクやコントローラーのメソッド名について、既存の`create`や`index`メソッドと区別を図るため、「管理」に関連する命名規則を再検討しています。現在、CRUD操作を一画面で行う設計ですが、将来的な拡張も考慮し、役割や処理を明確にするための方法を模索中です。

- **レイアウト・動作**  
  サイドバーの表示切り替えやオーバーレイ処理がデバイスの解像度により適切に動作するか

## 保留していること
- ユニットの詳細表示機能（詳細画面は今後の拡張として検討中）
- 他の管理機能とのさらなる連携
