### PR TITLE
サイドバーのユーザー表示機能実装

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -6,6 +6,7 @@ use Inertia\Inertia;
 use App\Models\Post;
 use Illuminate\Http\Request;
 use App\Models\Unit;
+use App\Models\User;
 
 class PostController extends Controller
 {
@@ -30,11 +31,13 @@ class PostController extends Controller
     ->paginate(5);
 
     $units = Unit::all();
+    $users = User::all();
 
     return Inertia::render('Forum', [
         'posts' => $posts,
         'search' => $search, // 検索ワードを渡す
         'units' => $units,
+        'users' => $users,
     ]);
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
             "dependencies": {
                 "bootstrap-icons": "^1.11.3",
                 "dayjs": "^1.11.13",
-                "vue-i18n": "^9.14.0"
+                "vue-i18n": "^9.14.0",
+                "vue-slide-up-down": "^3.0.0"
             },
             "devDependencies": {
                 "@inertiajs/vue3": "^1.0.0",
@@ -623,9 +624,9 @@
             }
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.21.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.21.3.tgz",
-            "integrity": "sha512-MmKSfaB9GX+zXl6E8z4koOr/xU63AMVleLEa64v7R0QF/ZloMs5vcD1sHgM64GXXS1csaJutG+ddtzcueI/BLg==",
+            "version": "4.24.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.24.3.tgz",
+            "integrity": "sha512-ufb2CH2KfBWPJok95frEZZ82LtDl0A6QKTa8MoM+cWwDZvVGl5/jNb79pIhRvAalUu+7LD91VYR0nwRD799HkQ==",
             "cpu": [
                 "arm"
             ],
@@ -636,9 +637,9 @@
             ]
         },
         "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.21.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.21.3.tgz",
-            "integrity": "sha512-zrt8ecH07PE3sB4jPOggweBjJMzI1JG5xI2DIsUbkA+7K+Gkjys6eV7i9pOenNSDJH3eOr/jLb/PzqtmdwDq5g==",
+            "version": "4.24.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.24.3.tgz",
+            "integrity": "sha512-iAHpft/eQk9vkWIV5t22V77d90CRofgR2006UiCjHcHJFVI1E0oBkQIAbz+pLtthFw3hWEmVB4ilxGyBf48i2Q==",
             "cpu": [
                 "arm64"
             ],
@@ -649,9 +650,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.21.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.21.3.tgz",
-            "integrity": "sha512-P0UxIOrKNBFTQaXTxOH4RxuEBVCgEA5UTNV6Yz7z9QHnUJ7eLX9reOd/NYMO3+XZO2cco19mXTxDMXxit4R/eQ==",
+            "version": "4.24.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.24.3.tgz",
+            "integrity": "sha512-QPW2YmkWLlvqmOa2OwrfqLJqkHm7kJCIMq9kOz40Zo9Ipi40kf9ONG5Sz76zszrmIZZ4hgRIkez69YnTHgEz1w==",
             "cpu": [
                 "arm64"
             ],
@@ -662,9 +663,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.21.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.21.3.tgz",
-            "integrity": "sha512-L1M0vKGO5ASKntqtsFEjTq/fD91vAqnzeaF6sfNAy55aD+Hi2pBI5DKwCO+UNDQHWsDViJLqshxOahXyLSh3EA==",
+            "version": "4.24.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.24.3.tgz",
+            "integrity": "sha512-KO0pN5x3+uZm1ZXeIfDqwcvnQ9UEGN8JX5ufhmgH5Lz4ujjZMAnxQygZAVGemFWn+ZZC0FQopruV4lqmGMshow==",
             "cpu": [
                 "x64"
             ],
@@ -674,10 +675,36 @@
                 "darwin"
             ]
         },
+        "node_modules/@rollup/rollup-freebsd-arm64": {
+            "version": "4.24.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.24.3.tgz",
+            "integrity": "sha512-CsC+ZdIiZCZbBI+aRlWpYJMSWvVssPuWqrDy/zi9YfnatKKSLFCe6fjna1grHuo/nVaHG+kiglpRhyBQYRTK4A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-freebsd-x64": {
+            "version": "4.24.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.24.3.tgz",
+            "integrity": "sha512-F0nqiLThcfKvRQhZEzMIXOQG4EeX61im61VYL1jo4eBxv4aZRmpin6crnBJQ/nWnCsjH5F6J3W6Stdm0mBNqBg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.21.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.21.3.tgz",
-            "integrity": "sha512-btVgIsCjuYFKUjopPoWiDqmoUXQDiW2A4C3Mtmp5vACm7/GnyuprqIDPNczeyR5W8rTXEbkmrJux7cJmD99D2g==",
+            "version": "4.24.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.24.3.tgz",
+            "integrity": "sha512-KRSFHyE/RdxQ1CSeOIBVIAxStFC/hnBgVcaiCkQaVC+EYDtTe4X7z5tBkFyRoBgUGtB6Xg6t9t2kulnX6wJc6A==",
             "cpu": [
                 "arm"
             ],
@@ -688,9 +715,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.21.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.21.3.tgz",
-            "integrity": "sha512-zmjbSphplZlau6ZTkxd3+NMtE4UKVy7U4aVFMmHcgO5CUbw17ZP6QCgyxhzGaU/wFFdTfiojjbLG3/0p9HhAqA==",
+            "version": "4.24.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.24.3.tgz",
+            "integrity": "sha512-h6Q8MT+e05zP5BxEKz0vi0DhthLdrNEnspdLzkoFqGwnmOzakEHSlXfVyA4HJ322QtFy7biUAVFPvIDEDQa6rw==",
             "cpu": [
                 "arm"
             ],
@@ -701,9 +728,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.21.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.21.3.tgz",
-            "integrity": "sha512-nSZfcZtAnQPRZmUkUQwZq2OjQciR6tEoJaZVFvLHsj0MF6QhNMg0fQ6mUOsiCUpTqxTx0/O6gX0V/nYc7LrgPw==",
+            "version": "4.24.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.24.3.tgz",
+            "integrity": "sha512-fKElSyXhXIJ9pqiYRqisfirIo2Z5pTTve5K438URf08fsypXrEkVmShkSfM8GJ1aUyvjakT+fn2W7Czlpd/0FQ==",
             "cpu": [
                 "arm64"
             ],
@@ -714,9 +741,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.21.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.21.3.tgz",
-            "integrity": "sha512-MnvSPGO8KJXIMGlQDYfvYS3IosFN2rKsvxRpPO2l2cum+Z3exiExLwVU+GExL96pn8IP+GdH8Tz70EpBhO0sIQ==",
+            "version": "4.24.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.24.3.tgz",
+            "integrity": "sha512-YlddZSUk8G0px9/+V9PVilVDC6ydMz7WquxozToozSnfFK6wa6ne1ATUjUvjin09jp34p84milxlY5ikueoenw==",
             "cpu": [
                 "arm64"
             ],
@@ -727,9 +754,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-            "version": "4.21.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.21.3.tgz",
-            "integrity": "sha512-+W+p/9QNDr2vE2AXU0qIy0qQE75E8RTwTwgqS2G5CRQ11vzq0tbnfBd6brWhS9bCRjAjepJe2fvvkvS3dno+iw==",
+            "version": "4.24.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.24.3.tgz",
+            "integrity": "sha512-yNaWw+GAO8JjVx3s3cMeG5Esz1cKVzz8PkTJSfYzE5u7A+NvGmbVFEHP+BikTIyYWuz0+DX9kaA3pH9Sqxp69g==",
             "cpu": [
                 "ppc64"
             ],
@@ -740,9 +767,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.21.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.21.3.tgz",
-            "integrity": "sha512-yXH6K6KfqGXaxHrtr+Uoy+JpNlUlI46BKVyonGiaD74ravdnF9BUNC+vV+SIuB96hUMGShhKV693rF9QDfO6nQ==",
+            "version": "4.24.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.24.3.tgz",
+            "integrity": "sha512-lWKNQfsbpv14ZCtM/HkjCTm4oWTKTfxPmr7iPfp3AHSqyoTz5AgLemYkWLwOBWc+XxBbrU9SCokZP0WlBZM9lA==",
             "cpu": [
                 "riscv64"
             ],
@@ -753,9 +780,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.21.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.21.3.tgz",
-            "integrity": "sha512-R8cwY9wcnApN/KDYWTH4gV/ypvy9yZUHlbJvfaiXSB48JO3KpwSpjOGqO4jnGkLDSk1hgjYkTbTt6Q7uvPf8eg==",
+            "version": "4.24.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.24.3.tgz",
+            "integrity": "sha512-HoojGXTC2CgCcq0Woc/dn12wQUlkNyfH0I1ABK4Ni9YXyFQa86Fkt2Q0nqgLfbhkyfQ6003i3qQk9pLh/SpAYw==",
             "cpu": [
                 "s390x"
             ],
@@ -766,9 +793,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.21.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.21.3.tgz",
-            "integrity": "sha512-kZPbX/NOPh0vhS5sI+dR8L1bU2cSO9FgxwM8r7wHzGydzfSjLRCFAT87GR5U9scj2rhzN3JPYVC7NoBbl4FZ0g==",
+            "version": "4.24.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.24.3.tgz",
+            "integrity": "sha512-mnEOh4iE4USSccBOtcrjF5nj+5/zm6NcNhbSEfR3Ot0pxBwvEn5QVUXcuOwwPkapDtGZ6pT02xLoPaNv06w7KQ==",
             "cpu": [
                 "x64"
             ],
@@ -779,9 +806,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.21.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.21.3.tgz",
-            "integrity": "sha512-S0Yq+xA1VEH66uiMNhijsWAafffydd2X5b77eLHfRmfLsRSpbiAWiRHV6DEpz6aOToPsgid7TI9rGd6zB1rhbg==",
+            "version": "4.24.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.24.3.tgz",
+            "integrity": "sha512-rMTzawBPimBQkG9NKpNHvquIUTQPzrnPxPbCY1Xt+mFkW7pshvyIS5kYgcf74goxXOQk0CP3EoOC1zcEezKXhw==",
             "cpu": [
                 "x64"
             ],
@@ -792,9 +819,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.21.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.21.3.tgz",
-            "integrity": "sha512-9isNzeL34yquCPyerog+IMCNxKR8XYmGd0tHSV+OVx0TmE0aJOo9uw4fZfUuk2qxobP5sug6vNdZR6u7Mw7Q+Q==",
+            "version": "4.24.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.24.3.tgz",
+            "integrity": "sha512-2lg1CE305xNvnH3SyiKwPVsTVLCg4TmNCF1z7PSHX2uZY2VbUpdkgAllVoISD7JO7zu+YynpWNSKAtOrX3AiuA==",
             "cpu": [
                 "arm64"
             ],
@@ -805,9 +832,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.21.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.21.3.tgz",
-            "integrity": "sha512-nMIdKnfZfzn1Vsk+RuOvl43ONTZXoAPUUxgcU0tXooqg4YrAqzfKzVenqqk2g5efWh46/D28cKFrOzDSW28gTA==",
+            "version": "4.24.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.24.3.tgz",
+            "integrity": "sha512-9SjYp1sPyxJsPWuhOCX6F4jUMXGbVVd5obVpoVEi8ClZqo52ViZewA6eFz85y8ezuOA+uJMP5A5zo6Oz4S5rVQ==",
             "cpu": [
                 "ia32"
             ],
@@ -818,9 +845,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.21.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.21.3.tgz",
-            "integrity": "sha512-fOvu7PCQjAj4eWDEuD8Xz5gpzFqXzGlxHZozHP4b9Jxv9APtdxL6STqztDzMLuRXEc4UpXGGhx029Xgm91QBeA==",
+            "version": "4.24.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.24.3.tgz",
+            "integrity": "sha512-HGZgRFFYrMrP3TJlq58nR1xy8zHKId25vhmm5S9jETEfDf6xybPxsavFTJaufe2zgOGYJBskGlj49CwtEuFhWQ==",
             "cpu": [
                 "x64"
             ],
@@ -843,9 +870,9 @@
             }
         },
         "node_modules/@types/estree": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-            "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+            "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
             "dev": true
         },
         "node_modules/@vitejs/plugin-vue": {
@@ -2336,12 +2363,12 @@
             }
         },
         "node_modules/rollup": {
-            "version": "4.21.3",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.21.3.tgz",
-            "integrity": "sha512-7sqRtBNnEbcBtMeRVc6VRsJMmpI+JU1z9VTvW8D4gXIYQFz0aLcsE6rRkyghZkLfEgUZgVvOG7A5CVz/VW5GIA==",
+            "version": "4.24.3",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.24.3.tgz",
+            "integrity": "sha512-HBW896xR5HGmoksbi3JBDtmVzWiPAYqp7wip50hjQ67JbDz61nyoMPdqu1DvVW9asYb2M65Z20ZHsyJCMqMyDg==",
             "dev": true,
             "dependencies": {
-                "@types/estree": "1.0.5"
+                "@types/estree": "1.0.6"
             },
             "bin": {
                 "rollup": "dist/bin/rollup"
@@ -2351,22 +2378,24 @@
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.21.3",
-                "@rollup/rollup-android-arm64": "4.21.3",
-                "@rollup/rollup-darwin-arm64": "4.21.3",
-                "@rollup/rollup-darwin-x64": "4.21.3",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.21.3",
-                "@rollup/rollup-linux-arm-musleabihf": "4.21.3",
-                "@rollup/rollup-linux-arm64-gnu": "4.21.3",
-                "@rollup/rollup-linux-arm64-musl": "4.21.3",
-                "@rollup/rollup-linux-powerpc64le-gnu": "4.21.3",
-                "@rollup/rollup-linux-riscv64-gnu": "4.21.3",
-                "@rollup/rollup-linux-s390x-gnu": "4.21.3",
-                "@rollup/rollup-linux-x64-gnu": "4.21.3",
-                "@rollup/rollup-linux-x64-musl": "4.21.3",
-                "@rollup/rollup-win32-arm64-msvc": "4.21.3",
-                "@rollup/rollup-win32-ia32-msvc": "4.21.3",
-                "@rollup/rollup-win32-x64-msvc": "4.21.3",
+                "@rollup/rollup-android-arm-eabi": "4.24.3",
+                "@rollup/rollup-android-arm64": "4.24.3",
+                "@rollup/rollup-darwin-arm64": "4.24.3",
+                "@rollup/rollup-darwin-x64": "4.24.3",
+                "@rollup/rollup-freebsd-arm64": "4.24.3",
+                "@rollup/rollup-freebsd-x64": "4.24.3",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.24.3",
+                "@rollup/rollup-linux-arm-musleabihf": "4.24.3",
+                "@rollup/rollup-linux-arm64-gnu": "4.24.3",
+                "@rollup/rollup-linux-arm64-musl": "4.24.3",
+                "@rollup/rollup-linux-powerpc64le-gnu": "4.24.3",
+                "@rollup/rollup-linux-riscv64-gnu": "4.24.3",
+                "@rollup/rollup-linux-s390x-gnu": "4.24.3",
+                "@rollup/rollup-linux-x64-gnu": "4.24.3",
+                "@rollup/rollup-linux-x64-musl": "4.24.3",
+                "@rollup/rollup-win32-arm64-msvc": "4.24.3",
+                "@rollup/rollup-win32-ia32-msvc": "4.24.3",
+                "@rollup/rollup-win32-x64-msvc": "4.24.3",
                 "fsevents": "~2.3.2"
             }
         },
@@ -2825,6 +2854,14 @@
             },
             "peerDependencies": {
                 "vue": "^3.0.0"
+            }
+        },
+        "node_modules/vue-slide-up-down": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/vue-slide-up-down/-/vue-slide-up-down-3.0.0.tgz",
+            "integrity": "sha512-4ckwKgpkPfjDmwVKdu5UANvxt7nKemIKpqbRGhcekgDuvEwep8YFwkb8G9dix4lL+Wt2G73X1Z90c1oPJvXdOQ==",
+            "peerDependencies": {
+                "vue": ">=3.0.0"
             }
         },
         "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "dependencies": {
         "bootstrap-icons": "^1.11.3",
         "dayjs": "^1.11.13",
-        "vue-i18n": "^9.14.0"
+        "vue-i18n": "^9.14.0",
+        "vue-slide-up-down": "^3.0.0"
     }
 }

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -65,8 +65,6 @@ const toggleCommentForm = (postId, parentId = "post", replyToName = "") => {
     commentFormVisibility.value[postId][parentId].replyToName = replyToName;
 };
 
-const appName = "CommuniCare"; // アプリ名
-
 const formatDate = (date) => dayjs(date).format("YYYY-MM-DD HH:mm:ss");
 
 // 再帰的にコメントを検索する関数
@@ -213,10 +211,10 @@ const search = ref(pageProps.search || "");
             <div class="flex-1 max-w-4xl mx-auto p-4">
                 <div class="flex justify-between items-center mb-4">
                     <h1
-                        class="text-xl font-bold cursor-pointer"
+                        class="text-xl font-bold cursor-pointer sm:hidden"
                         @click="toggleSidebar"
                     >
-                        {{ appName }}
+                        {{ $t("Unit List") }}
                     </h1>
 
                     <!-- 検索フォーム -->

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -21,6 +21,7 @@ const selectedPost = ref(null); // 選択された投稿
 const isUserProfileVisible = ref(false); // ユーザーの詳細ページの表示状態
 const sidebarVisible = ref(false); // サイドバーの表示状態
 const users = pageProps.users || []; // ユーザーのデータ
+const sidebar = ref(null); // サイドバーのコンポーネントインスタンス
 
 const openUserProfile = (post) => {
     selectedPost.value = post;
@@ -39,6 +40,17 @@ const selectPost = (post) => {
 const toggleSidebar = () => {
     sidebarVisible.value = !sidebarVisible.value;
     console.log("sidebarVisible.value:", sidebarVisible.value);
+
+    // サイドバーを非表示にする際にドロップダウンを閉じる
+    if (!sidebarVisible.value) {
+        if (sidebar.value && sidebar.value.resetDropdown) {
+            sidebar.value.resetDropdown();
+        } else {
+            console.error(
+                "Sidebar component reference not found or resetDropdown method is undefined."
+            );
+        }
+    }
 };
 
 // コメントフォーム表示状態を管理するためのオブジェクト
@@ -213,6 +225,7 @@ const onUserSelected = (user) => {
                 :class="{ visible: sidebarVisible }"
                 ref="sidebar"
                 @user-profile-clicked="onUserSelected"
+                v-model:sidebarVisible="sidebarVisible"
             />
 
             <!-- メインコンテンツエリア -->

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -20,6 +20,7 @@ const units = pageProps.units; // 部署のデータ
 const selectedPost = ref(null); // 選択された投稿
 const isUserProfileVisible = ref(false); // ユーザーの詳細ページの表示状態
 const sidebarVisible = ref(false); // サイドバーの表示状態
+const users = pageProps.users || []; // ユーザーのデータ
 
 const openUserProfile = (post) => {
     selectedPost.value = post;
@@ -202,6 +203,7 @@ const search = ref(pageProps.search || "");
             <!-- サイドバー -->
             <ListForSidebar
                 :units="units"
+                :users="users"
                 class="sidebar-mobile p-4 lg:mt-16 lg:block"
                 :class="{ visible: sidebarVisible }"
                 ref="sidebar"

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -184,6 +184,13 @@ const isCommentAuthor = (comment) => {
 
 // 検索結果の表示状態
 const search = ref(pageProps.search || "");
+
+// サイドバーのユーザー選択イベントを受け取る関数
+const onUserSelected = (user) => {
+    console.log("User selected:", user);
+    selectedPost.value = { user }; // `selectedPost`に選択したユーザーをセット
+    isUserProfileVisible.value = true; // ユーザープロファイルのポップアップを表示
+};
 </script>
 
 <template>
@@ -205,6 +212,7 @@ const search = ref(pageProps.search || "");
                 class="sidebar-mobile p-4 lg:mt-16 lg:block"
                 :class="{ visible: sidebarVisible }"
                 ref="sidebar"
+                @user-profile-clicked="onUserSelected"
             />
 
             <!-- メインコンテンツエリア -->

--- a/resources/js/Pages/Unit/ListForSidebar.vue
+++ b/resources/js/Pages/Unit/ListForSidebar.vue
@@ -58,7 +58,7 @@ export default {
                 <slide-up-down
                     :active="selectedUnitId === unit.id"
                     :duration="300"
-                    class="mt-2 ml-4"
+                    class="ml-4"
                 >
                     <ul v-if="filteredUsers.length > 0">
                         <li

--- a/resources/js/Pages/Unit/ListForSidebar.vue
+++ b/resources/js/Pages/Unit/ListForSidebar.vue
@@ -1,34 +1,81 @@
+<script>
+export default {
+    props: {
+        units: {
+            type: Array,
+            required: true,
+        },
+        users: {
+            type: Array,
+            required: false,
+            default: () => [],
+        },
+    },
+    data() {
+        return {
+            selectedUnitId: null,
+        };
+    },
+    computed: {
+        filteredUsers() {
+            if (this.selectedUnitId) {
+                return this.users.filter(
+                    (user) => user.unit_id === this.selectedUnitId
+                );
+            }
+            return [];
+        },
+    },
+    methods: {
+        toggleUnit(unitId) {
+            this.selectedUnitId =
+                this.selectedUnitId === unitId ? null : unitId;
+        },
+    },
+};
+</script>
+
 <template>
     <div class="sidebar bg-gray-100 w-60 h-screen p-4 shadow-lg">
-      <h2 class="text-xl font-bold mb-4">部署一覧</h2>
-      <ul>
-        <li 
-          v-for="unit in units" 
-          :key="unit.id" 
-          class="mb-2 p-2 rounded hover:bg-gray-200 cursor-pointer">
-          {{ unit.name }}
-        </li>
-      </ul>
+        <h2 class="text-xl font-bold mb-4">部署一覧</h2>
+        <ul>
+            <li
+                v-for="unit in units"
+                :key="unit.id"
+                class="mb-2 p-2 rounded hover:bg-gray-200 cursor-pointer"
+                @click="toggleUnit(unit.id)"
+            >
+                <div class="flex items-center justify-between">
+                    <span>{{ unit.name }}</span>
+                    <span v-if="selectedUnitId === unit.id">&#9660;</span>
+                    <span v-else>&#9654;</span>
+                </div>
+                <div
+                    v-if="
+                        selectedUnitId === unit.id && filteredUsers.length > 0
+                    "
+                    class="mt-2 ml-4"
+                >
+                    <ul>
+                        <li
+                            v-for="user in filteredUsers"
+                            :key="user.id"
+                            class="p-1"
+                        >
+                            {{ user.name }}
+                        </li>
+                    </ul>
+                </div>
+            </li>
+        </ul>
     </div>
-  </template>
-  
-  <script>
-  export default {
-    props: {
-      units: {
-        type: Array,
-        required: true,
-      },
-    },
-  };
-  </script>
-  
-  <style scoped>
-  .sidebar {
+</template>
+
+<style scoped>
+.sidebar {
     position: fixed;
     left: 0;
     top: 0;
     background-color: #f7fafc;
-  }
-  </style>
-  
+}
+</style>

--- a/resources/js/Pages/Unit/ListForSidebar.vue
+++ b/resources/js/Pages/Unit/ListForSidebar.vue
@@ -21,7 +21,6 @@ export default {
     data() {
         return {
             selectedUnitId: null,
-            selectedUser: null,
         };
     },
     computed: {
@@ -40,10 +39,7 @@ export default {
                 this.selectedUnitId === unitId ? null : unitId;
         },
         openUserProfile(user) {
-            this.selectedUser = user;
-        },
-        closeUserProfile() {
-            this.selectedUser = null;
+            this.$emit("user-profile-clicked", user); // 親にイベントを伝播
         },
     },
 };
@@ -82,17 +78,6 @@ export default {
                 </slide-up-down>
             </li>
         </ul>
-
-        <!-- ユーザープロファイルポップアップ -->
-        <div
-            v-if="selectedUser"
-            class="fixed inset-0 bg-black/50 flex justify-center items-center z-50"
-            @click="closeUserProfile"
-        >
-            <div @click.stop>
-                <Show :user="selectedUser" :units="units" />
-            </div>
-        </div>
     </div>
 </template>
 

--- a/resources/js/Pages/Unit/ListForSidebar.vue
+++ b/resources/js/Pages/Unit/ListForSidebar.vue
@@ -1,9 +1,11 @@
 <script>
 import SlideUpDown from "vue-slide-up-down";
+import Show from "../Users/Show.vue";
 
 export default {
     components: {
         SlideUpDown,
+        Show,
     },
     props: {
         units: {
@@ -19,6 +21,7 @@ export default {
     data() {
         return {
             selectedUnitId: null,
+            selectedUser: null,
         };
     },
     computed: {
@@ -35,6 +38,12 @@ export default {
         toggleUnit(unitId) {
             this.selectedUnitId =
                 this.selectedUnitId === unitId ? null : unitId;
+        },
+        openUserProfile(user) {
+            this.selectedUser = user;
+        },
+        closeUserProfile() {
+            this.selectedUser = null;
         },
     },
 };
@@ -64,7 +73,8 @@ export default {
                         <li
                             v-for="user in filteredUsers"
                             :key="user.id"
-                            class="p-1"
+                            class="p-1 cursor-pointer hover:bg-gray-200"
+                            @click.stop="openUserProfile(user)"
                         >
                             {{ user.name }}
                         </li>
@@ -72,6 +82,17 @@ export default {
                 </slide-up-down>
             </li>
         </ul>
+
+        <!-- ユーザープロファイルポップアップ -->
+        <div
+            v-if="selectedUser"
+            class="fixed inset-0 bg-black/50 flex justify-center items-center z-50"
+            @click="closeUserProfile"
+        >
+            <div @click.stop>
+                <Show :user="selectedUser" :units="units" />
+            </div>
+        </div>
     </div>
 </template>
 

--- a/resources/js/Pages/Unit/ListForSidebar.vue
+++ b/resources/js/Pages/Unit/ListForSidebar.vue
@@ -41,6 +41,9 @@ export default {
         openUserProfile(user) {
             this.$emit("user-profile-clicked", user); // 親にイベントを伝播
         },
+        resetDropdown() {
+            this.selectedUnitId = null; // ドロップダウンをリセット
+        },
     },
 };
 </script>

--- a/resources/js/Pages/Unit/ListForSidebar.vue
+++ b/resources/js/Pages/Unit/ListForSidebar.vue
@@ -1,5 +1,10 @@
 <script>
+import SlideUpDown from "vue-slide-up-down";
+
 export default {
+    components: {
+        SlideUpDown,
+    },
     props: {
         units: {
             type: Array,
@@ -50,13 +55,12 @@ export default {
                     <span v-if="selectedUnitId === unit.id">&#9660;</span>
                     <span v-else>&#9654;</span>
                 </div>
-                <div
-                    v-if="
-                        selectedUnitId === unit.id && filteredUsers.length > 0
-                    "
+                <slide-up-down
+                    :active="selectedUnitId === unit.id"
+                    :duration="300"
                     class="mt-2 ml-4"
                 >
-                    <ul>
+                    <ul v-if="filteredUsers.length > 0">
                         <li
                             v-for="user in filteredUsers"
                             :key="user.id"
@@ -65,7 +69,7 @@ export default {
                             {{ user.name }}
                         </li>
                     </ul>
-                </div>
+                </slide-up-down>
             </li>
         </ul>
     </div>

--- a/resources/js/Pages/Unit/ListForSidebar.vue
+++ b/resources/js/Pages/Unit/ListForSidebar.vue
@@ -69,10 +69,28 @@ export default {
                         <li
                             v-for="user in filteredUsers"
                             :key="user.id"
-                            class="p-1 cursor-pointer hover:bg-gray-200"
+                            class="p-1 cursor-pointer hover:bg-gray-200 flex items-center space-x-2"
                             @click.stop="openUserProfile(user)"
                         >
-                            {{ user.name }}
+                            <!-- プロフィール画像を表示 -->
+                            <img
+                                v-if="user.icon"
+                                :src="
+                                    user.icon.startsWith('/storage/')
+                                        ? user.icon
+                                        : `/storage/${user.icon}`
+                                "
+                                alt="User Icon"
+                                class="w-6 h-6 rounded-full"
+                            />
+                            <img
+                                v-else
+                                src="https://via.placeholder.com/40"
+                                alt="Default Icon"
+                                class="w-6 h-6 rounded-full"
+                            />
+                            <!-- ユーザー名 -->
+                            <span>{{ user.name }}</span>
                         </li>
                     </ul>
                 </slide-up-down>

--- a/resources/js/Pages/Unit/ListForSidebar.vue
+++ b/resources/js/Pages/Unit/ListForSidebar.vue
@@ -56,7 +56,7 @@ export default {
                 @click="toggleUnit(unit.id)"
             >
                 <div class="flex items-center justify-between">
-                    <span>{{ unit.name }}</span>
+                    <span class="font-bold">{{ unit.name }}</span>
                     <span v-if="selectedUnitId === unit.id">&#9660;</span>
                     <span v-else>&#9654;</span>
                 </div>
@@ -69,7 +69,7 @@ export default {
                         <li
                             v-for="user in filteredUsers"
                             :key="user.id"
-                            class="p-1 cursor-pointer hover:bg-gray-200 flex items-center space-x-2"
+                            class="p-1 cursor-pointer hover:bg-blue-300 flex items-center space-x-2"
                             @click.stop="openUserProfile(user)"
                         >
                             <!-- プロフィール画像を表示 -->

--- a/resources/js/Pages/Users/Show.vue
+++ b/resources/js/Pages/Users/Show.vue
@@ -23,8 +23,9 @@ export default {
 
         // 部署名を取得
         const unitName =
-            props.units.find((unit) => unit.id === props.user.unit_id)?.name ||
-            "未所属";
+            Array.isArray(props.units) && props.units.length > 0
+                ? props.units.find((unit) => unit.id === props.user.unit_id)?.name || "未所属"
+                : "未所属";
 
         return { page, authUser, unitName };
     },

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -9,6 +9,8 @@ import { ZiggyVue } from "../../vendor/tightenco/ziggy";
 import { createI18n } from "vue-i18n"; // vue-i18nをインポート
 import ja from "../../lang/ja.json"; // Laravelのlangディレクトリからja.jsonを読み込み
 
+import SlideUpDown from "vue-slide-up-down"; // vue-slide-up-downをインポート
+
 const appName = import.meta.env.VITE_APP_NAME || "Laravel";
 
 // vue-i18nの設定
@@ -32,6 +34,9 @@ createInertiaApp({
             .use(ZiggyVue)
             .use(i18n); // vue-i18nを使用するように設定
 
+        // グローバルにSlideUpDownコンポーネントを登録
+        app.component("slide-up-down", SlideUpDown);
+
         app.mount(el);
 
         // Inertia.jsのカスタムイベントでリロードをトリガーする
@@ -42,9 +47,7 @@ createInertiaApp({
             const currentUrl = window.location.href;
 
             // ログイン後またはダッシュボードでのリダイレクトを処理
-            if (
-                currentUrl.includes("localhost/home")
-            ) {
+            if (currentUrl.includes("localhost/home")) {
                 console.log(
                     "URLが 'localhost/home'または'localhost/dashboard'を含んでいます。ページをリロードします。"
                 );

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,11 +1,11 @@
-import { defineConfig } from 'vite';
-import laravel from 'laravel-vite-plugin';
-import vue from '@vitejs/plugin-vue';
+import { defineConfig } from "vite";
+import laravel from "laravel-vite-plugin";
+import vue from "@vitejs/plugin-vue";
 
 export default defineConfig({
     plugins: [
         laravel({
-            input: 'resources/js/app.js',
+            input: "resources/js/app.js",
             refresh: true,
         }),
         vue({


### PR DESCRIPTION
## 目的
サイドバーのUI/UXを向上させるため、部署ごとのユーザーリストの表示機能、ユーザープロファイルのポップアップ機能、アコーディオン形式でのサイドバー開閉機能を追加し、サイドバーを閉じる際にドロップダウンを閉じる機能を実装しました。また、これらの変更によりサイドバーの使い勝手を向上させることを目指しました。

## 達成条件
1. 部署名をクリックすることで、部署ごとに所属するユーザーを表示できるようにすること。
2. サイドバーに部署とユーザーのデータを表示し、ユーザーリストを動的に表示できるようにすること。
3. サイドバーが非表示になった際に、開かれているドロップダウンを自動的に閉じること。
4. ユーザーの詳細情報を表示するプロファイルポップアップ機能を提供すること。

## 実装の概要
- **部署名のクリックで所属ユーザーを表示するプルダウン機能を追加**  
  部署名の横にプルダウンマークを追加し、クリック時に所属ユーザーを表示できるようにしました。これにより、サイドバーから各部署のユーザー情報を簡単に確認することが可能となります。

- **サイドバーに部署とユーザーのデータを表示する機能を追加**  
  サーバーサイドから取得した部署およびユーザーデータをサイドバーに表示し、ユーザーリストを動的に更新できるようにしました。

- **サーバーサイドでユーザー情報を取得しビューに渡す処理を追加**  
  Inertia を通じて `Forum` ビューにユーザー情報を渡し、フロントエンドで社員リストを活用できるようにしました。

- **アプリ名の表示を「部署一覧」に変更し、モバイル画面でのみ表示するように修正**  
  モバイル画面でユーザーに分かりやすくサイドバーの切り替えを示すため、見出しを「部署一覧」としました。

- **vue-slide-up-downパッケージの導入およびグローバル登録**  
  アコーディオン形式で部署ごとのユーザーリストを開閉するために `vue-slide-up-down` パッケージを導入し、グローバルに登録しました。これにより、ユーザーリストの開閉をスムーズに行うことが可能となりました。

- **アコーディオン開閉のスムーズ化のための不要なスタイルの削除**  
  開閉時の不自然な余白を改善するため、不要な `mt-2` スタイルを削除しました。

- **ユーザープロファイルポップアップ機能と部署情報取得ロジックの改善**  
  ユーザー名をクリックするとプロファイルがポップアップで表示されるようにし、ポップアップ外をクリックした際に閉じる機能を追加しました。

- **サイドバーからユーザープロファイル表示制御を親コンポーネントに移行**  
  サイドバーでのユーザー選択イベントを `Forum.vue` で処理することで、プロファイルの表示制御を一元化しました。これにより責務の分離を明確にし、メンテナンス性を向上させました。

- **ユーザーリストにプロフィール画像を追加**  
  サイドバーのユーザーリストにプロフィール画像を表示し、ユーザーが視覚的に情報を確認しやすくしました。

- **ユニット名のスタイル強調とユーザーリストのホバー色変更**  
  ユニット名を太字にし、ユーザーリストのホバー時の背景色を青色に変更しました。これにより視認性が向上し、操作が直感的になりました。

- **サイドバー非表示時にドロップダウンを閉じる機能を追加**  
  サイドバーが非表示になる際、ドロップダウンが開いたままにならないようにドロップダウンをリセットするロジックを追加しました。一時的にスライドアニメーションが失われましたが、`v-model` の導入によりスムーズなアニメーションを復元しました。

## レビューしてほしいところ
- サイドバーの表示/非表示切り替えがスムーズに動作するかどうか。
- サイドバーを閉じる際にドロップダウンが適切にリセットされているか。
- ユーザープロファイルのポップアップ表示が意図した通りに機能しているか。

## 不安に思っていること
- モバイル環境において、サイドバーの開閉がスムーズに行われるか。また、アニメーションの挙動に問題がないか。
- `v-model` の使用によりコードの可読性が適切に保たれているか。

## 保留していること
- サイドバー開閉の速度やホバー色の調整については、ユーザーフィードバックをもとに改善する可能性があります。