### PR TITLE
右サイドバーにユニットメンバーを表示する機能を追加

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,9 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Inertia\Inertia;
+use App\Models\Unit;
+use App\Models\User;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -19,6 +22,9 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        Inertia::share([
+            'units' => fn () => Unit::all(),
+            'users' => fn () => User::all(),
+        ]);
     }
 }

--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -7,6 +7,17 @@ import DropdownLink from "@/Components/DropdownLink.vue";
 import NavLink from "@/Components/NavLink.vue";
 import ResponsiveNavLink from "@/Components/ResponsiveNavLink.vue";
 
+const props = defineProps({
+    units: {
+        type: Array,
+        required: true,
+    },
+    users: {
+        type: Array,
+        required: true,
+    },
+});
+
 // CSRFトークンを取得
 const csrfToken = ref(
     document.querySelector('meta[name="csrf-token"]').getAttribute("content")
@@ -34,10 +45,24 @@ const handleLogoClick = async () => {
         }
 
         const forumId = data.forum_id;
+        const userUnitId = auth.user.unit_id;
+        const unit = props.units.find((u) => u.id === userUnitId);
+        // usersを`unit_id`でフィルタリングしてユニットの職員リストを取得
+        const unitUsers = props.users.filter(
+            (user) => user.unit_id === userUnitId
+        );
+
+        if (unit) {
+            sessionStorage.setItem(
+                "selectedUnitUsers",
+                JSON.stringify(unitUsers)
+            );
+            sessionStorage.setItem("selectedUnitName", unit.name);
+        }
 
         // 所属ユニットの掲示板に遷移して状態をリセット
         router.get(route("forum.index", { forum_id: forumId }), {
-            preserveState: false, // 既存の状態をリセットしてビューを更新
+            preserveState: false,
         });
     } catch (error) {
         console.error("Error fetching user forum ID:", error);

--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -1,22 +1,15 @@
 <script setup>
 import { ref } from "vue";
-import { router, usePage } from "@inertiajs/vue3";
+import { usePage, router } from "@inertiajs/vue3";
 import ApplicationLogo from "@/Components/ApplicationLogo.vue";
 import Dropdown from "@/Components/Dropdown.vue";
 import DropdownLink from "@/Components/DropdownLink.vue";
 import NavLink from "@/Components/NavLink.vue";
 import ResponsiveNavLink from "@/Components/ResponsiveNavLink.vue";
 
-const props = defineProps({
-    units: {
-        type: Array,
-        required: true,
-    },
-    users: {
-        type: Array,
-        required: true,
-    },
-});
+const page = usePage();
+const units = page.props.units; // Inertiaから`units`を取得
+const users = page.props.users; // Inertiaから`users`を取得
 
 // CSRFトークンを取得
 const csrfToken = ref(
@@ -25,8 +18,8 @@ const csrfToken = ref(
 
 const showingNavigationDropdown = ref(false);
 
-// Inertiaからpropsを取得
-const auth = usePage().props.auth || {};
+// Inertiaからユーザー情報を取得
+const auth = page.props.auth || {};
 // ユーザーの情報を確認
 console.log("Logged in user data:", auth.user);
 console.log("auth.user.unit_id", auth.user.unit_id);
@@ -46,11 +39,9 @@ const handleLogoClick = async () => {
 
         const forumId = data.forum_id;
         const userUnitId = auth.user.unit_id;
-        const unit = props.units.find((u) => u.id === userUnitId);
-        // usersを`unit_id`でフィルタリングしてユニットの職員リストを取得
-        const unitUsers = props.users.filter(
-            (user) => user.unit_id === userUnitId
-        );
+        const unit = units.find((u) => u.id === userUnitId);
+        // `unit_id`で`users`をフィルタリングしてユニットの職員リストを取得
+        const unitUsers = users.filter((user) => user.unit_id === userUnitId);
 
         if (unit) {
             sessionStorage.setItem(

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -25,6 +25,7 @@ const users = pageProps.users || []; // ユーザーのデータ
 const sidebar = ref(null); // サイドバーのコンポーネントインスタンス
 const selectedForumId = ref(pageProps.selectedForumId || null); // 選択された掲示板のID
 const selectedUnitUsers = ref([]); // 選択されたユニットのユーザーリスト
+const selectedUnitName = ref(""); // 選択されたユニットの名前
 
 // マウント時にselectedForumIdを設定
 onMounted(() => {
@@ -53,7 +54,11 @@ const onForumSelected = async (unitId) => {
     const unit = units.value.find((u) => u.id === unitId);
     if (unit && unit.forum) {
         selectedForumId.value = unit.forum.id;
+        selectedUnitName.value = unit.name; // 選択されたユニットの名前を設定
         localStorage.setItem("lastSelectedUnitId", unitId);
+
+        // ユニット名を保存
+        sessionStorage.setItem("selectedUnitName", selectedUnitName.value);
 
         // ユーザーリストを取得して一時保存
         selectedUnitUsers.value = users.filter(
@@ -78,6 +83,11 @@ onMounted(() => {
     const storedUsers = sessionStorage.getItem("selectedUnitUsers");
     if (storedUsers) {
         selectedUnitUsers.value = JSON.parse(storedUsers);
+    }
+    // 保存されたユニット名を復元
+    const storedUnitName = sessionStorage.getItem("selectedUnitName");
+    if (storedUnitName) {
+        selectedUnitName.value = storedUnitName;
     }
 });
 
@@ -438,6 +448,7 @@ const search = ref(pageProps.search || "");
             <!-- 右サイドバー -->
             <RightSidebar
                 :unit-users="selectedUnitUsers"
+                :unit-name="selectedUnitName"
                 class="p-4 lg:mt-16 lg:block"
                 @user-selected="onUserSelected"
             />

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -11,6 +11,7 @@ import { getCsrfToken } from "@/Utils/csrf";
 import Show from "./Users/Show.vue";
 import SearchForm from "@/Components/SearchForm.vue";
 import ListForSidebar from "./Unit/ListForSidebar.vue";
+import RightSidebar from "./Unit/RightSidebar.vue";
 
 // propsからページのデータを取得
 const pageProps = usePage().props; // ページのデータ
@@ -23,6 +24,7 @@ const sidebarVisible = ref(false); // サイドバーの表示状態
 const users = pageProps.users || []; // ユーザーのデータ
 const sidebar = ref(null); // サイドバーのコンポーネントインスタンス
 const selectedForumId = ref(pageProps.selectedForumId || null); // 選択された掲示板のID
+const selectedUnitUsers = ref([]); // 選択されたユニットのユーザーリスト
 
 // マウント時にselectedForumIdを設定
 onMounted(() => {
@@ -49,13 +51,20 @@ const onUserSelected = (user) => {
 // サイドバーからのユニット選択イベント
 const onForumSelected = (unitId) => {
     const unit = units.value.find((u) => u.id === unitId);
+
     if (unit && unit.forum) {
+        // 1. フォーラムを切り替える
         selectedForumId.value = unit.forum.id;
         localStorage.setItem("lastSelectedUnitId", unitId);
 
         router.get(route("forum.index", { forum_id: selectedForumId.value }), {
             preserveState: true,
         });
+
+        // 2. 右サイドバー用のユーザーリストを更新
+        selectedUnitUsers.value = users.filter(
+            (user) => user.unit_id === unitId
+        );
     } else {
         console.error("対応する掲示板が見つかりませんでした");
     }
@@ -414,6 +423,9 @@ const search = ref(pageProps.search || "");
                     class="mt-4"
                 />
             </div>
+
+            <!-- 右サイドバー -->
+            <RightSidebar :unit-users="selectedUnitUsers" />
 
             <!-- 選択された投稿のユーザーの詳細ページを表示 -->
             <div

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -436,7 +436,10 @@ const search = ref(pageProps.search || "");
             </div>
 
             <!-- 右サイドバー -->
-            <RightSidebar :unit-users="selectedUnitUsers" />
+            <RightSidebar
+                :unit-users="selectedUnitUsers"
+                class="p-4 lg:mt-16 lg:block"
+            />
 
             <!-- 選択された投稿のユーザーの詳細ページを表示 -->
             <div

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -439,6 +439,7 @@ const search = ref(pageProps.search || "");
             <RightSidebar
                 :unit-users="selectedUnitUsers"
                 class="p-4 lg:mt-16 lg:block"
+                @user-selected="onUserSelected"
             />
 
             <!-- 選択された投稿のユーザーの詳細ページを表示 -->

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -284,7 +284,7 @@ const search = ref(pageProps.search || "");
 <template>
     <Head :title="$t('Forum')" />
 
-    <AuthenticatedLayout :units="units" :users="users">
+    <AuthenticatedLayout>
         <div class="flex mt-16">
             <!-- オーバーレイ (サイドバー表示時のみ) -->
             <div

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -32,6 +32,26 @@ onMounted(() => {
     selectedForumId.value = pageProps.selectedForumId;
 });
 
+onMounted(() => {
+    const storedUsers = sessionStorage.getItem("selectedUnitUsers");
+
+    // `storedUsers`がnullや"undefined"ではなく、有効なJSONかをチェック
+    if (storedUsers && storedUsers !== "undefined") {
+        try {
+            selectedUnitUsers.value = JSON.parse(storedUsers);
+        } catch (error) {
+            console.error("Error parsing selectedUnitUsers:", error);
+            selectedUnitUsers.value = []; // パースエラー時には空配列を代入
+        }
+    } else {
+        selectedUnitUsers.value = []; // nullまたは"undefined"の場合は空配列を代入
+    }
+
+    // 保存されたユニット名を復元
+    const storedUnitName = sessionStorage.getItem("selectedUnitName");
+    selectedUnitName.value = storedUnitName || ""; // nullの場合は空文字列を代入
+});
+
 // selectedForumIdの変更を監視し、変更があるたびに投稿を再取得
 watch(selectedForumId, (newForumId) => {
     if (newForumId) {
@@ -77,19 +97,6 @@ const onForumSelected = async (unitId) => {
         console.error("対応する掲示板が見つかりませんでした");
     }
 };
-
-// ページが読み込まれたときに保存されたユーザーリストを復元
-onMounted(() => {
-    const storedUsers = sessionStorage.getItem("selectedUnitUsers");
-    if (storedUsers) {
-        selectedUnitUsers.value = JSON.parse(storedUsers);
-    }
-    // 保存されたユニット名を復元
-    const storedUnitName = sessionStorage.getItem("selectedUnitName");
-    if (storedUnitName) {
-        selectedUnitName.value = storedUnitName;
-    }
-});
 
 const onPageChange = (url) => {
     router.get(url, {
@@ -277,7 +284,7 @@ const search = ref(pageProps.search || "");
 <template>
     <Head :title="$t('Forum')" />
 
-    <AuthenticatedLayout>
+    <AuthenticatedLayout :units="units" :users="users">
         <div class="flex mt-16">
             <!-- オーバーレイ (サイドバー表示時のみ) -->
             <div

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -48,27 +48,38 @@ const onUserSelected = (user) => {
     isUserProfileVisible.value = true; // ユーザープロファイルのポップアップを表示
 };
 
-// サイドバーからのユニット選択イベント
-const onForumSelected = (unitId) => {
+// ユニット選択イベント
+const onForumSelected = async (unitId) => {
     const unit = units.value.find((u) => u.id === unitId);
-
     if (unit && unit.forum) {
-        // 1. フォーラムを切り替える
         selectedForumId.value = unit.forum.id;
         localStorage.setItem("lastSelectedUnitId", unitId);
 
-        router.get(route("forum.index", { forum_id: selectedForumId.value }), {
-            preserveState: true,
-        });
-
-        // 2. 右サイドバー用のユーザーリストを更新
+        // ユーザーリストを取得して一時保存
         selectedUnitUsers.value = users.filter(
             (user) => user.unit_id === unitId
         );
+        sessionStorage.setItem(
+            "selectedUnitUsers",
+            JSON.stringify(selectedUnitUsers.value)
+        );
+
+        // 掲示板を更新
+        router.get(route("forum.index", { forum_id: selectedForumId.value }), {
+            preserveState: false, // 状態を再レンダリング
+        });
     } else {
         console.error("対応する掲示板が見つかりませんでした");
     }
 };
+
+// ページが読み込まれたときに保存されたユーザーリストを復元
+onMounted(() => {
+    const storedUsers = sessionStorage.getItem("selectedUnitUsers");
+    if (storedUsers) {
+        selectedUnitUsers.value = JSON.parse(storedUsers);
+    }
+});
 
 const onPageChange = (url) => {
     router.get(url, {

--- a/resources/js/Pages/Unit/ListForSidebar.vue
+++ b/resources/js/Pages/Unit/ListForSidebar.vue
@@ -46,6 +46,10 @@ export default {
             this.isFetchingData = true; // フラグをセット
             this.toggleUnit(unit.id);
             console.log("call fetchUnitData");
+
+            // 選択されたユニットIDを親コンポーネントに伝えるイベントを発火
+            this.$emit("forum-selected", unit.id);
+
             await this.fetchUnitData(unit.id);
             this.isFetchingData = false; // フラグをリセット
         },

--- a/resources/js/Pages/Unit/ListForSidebar.vue
+++ b/resources/js/Pages/Unit/ListForSidebar.vue
@@ -72,7 +72,7 @@ export default {
 </script>
 
 <template>
-    <div class="sidebar bg-gray-100 w-60 h-screen p-4 shadow-lg">
+    <div class="sidebar bg-gray-100 w-56 h-screen p-4 shadow-lg">
         <h2 class="text-xl font-bold mb-4">部署一覧</h2>
         <ul>
             <li

--- a/resources/js/Pages/Unit/ListForSidebar.vue
+++ b/resources/js/Pages/Unit/ListForSidebar.vue
@@ -21,20 +21,10 @@ export default {
     },
     data() {
         return {
-            selectedUnitId: null,
             isFetchingData: false, // データ取得中かどうかを判定するフラグ
         };
     },
-    computed: {
-        filteredUsers() {
-            if (this.selectedUnitId) {
-                return this.users.filter(
-                    (user) => user.unit_id === this.selectedUnitId
-                );
-            }
-            return [];
-        },
-    },
+
     methods: {
         async handleUnitClick(unit) {
             if (this.isFetchingData) {
@@ -77,9 +67,6 @@ export default {
         openUserProfile(user) {
             this.$emit("user-profile-clicked", user); // 親にイベントを伝播
         },
-        resetDropdown() {
-            this.selectedUnitId = null; // ドロップダウンをリセット
-        },
     },
 };
 </script>
@@ -94,11 +81,7 @@ export default {
                 class="mb-2 p-2 rounded hover:bg-gray-200 cursor-pointer"
                 @click="handleUnitClick(unit)"
             >
-                <div class="flex items-center justify-between">
-                    <span class="font-bold">{{ unit.name }}</span>
-                    <span v-if="selectedUnitId === unit.id">&#9660;</span>
-                    <span v-else>&#9654;</span>
-                </div>
+                <span class="font-bold">{{ unit.name }}</span>
             </li>
         </ul>
     </div>

--- a/resources/js/Pages/Unit/RightSidebar.vue
+++ b/resources/js/Pages/Unit/RightSidebar.vue
@@ -20,7 +20,7 @@ console.log("props.unitUsers", props.unitUsers);
             <li
                 v-for="user in unitUsers"
                 :key="user.id"
-                class="mb-2 p-2 rounded hover:bg-gray-200 cursor-pointer flex items-center space-x-2"
+                class="mb-2 p-2 rounded hover:bg-gray-200 cursor-pointer flex items-center space-x-4 font-bold"
                 @click="$emit('user-selected', user)"
             >
                 <img
@@ -31,13 +31,13 @@ console.log("props.unitUsers", props.unitUsers);
                             : `/storage/${user.icon}`
                     "
                     alt="User Icon"
-                    class="w-6 h-6 rounded-full"
+                    class="w-12 h-12 rounded-full"
                 />
                 <img
                     v-else
                     src="https://via.placeholder.com/40"
                     alt="Default Icon"
-                    class="w-6 h-6 rounded-full"
+                    class="w-12 h-12 rounded-full"
                 />
                 <span>{{ user.name }}</span>
             </li>

--- a/resources/js/Pages/Unit/RightSidebar.vue
+++ b/resources/js/Pages/Unit/RightSidebar.vue
@@ -7,15 +7,22 @@ const props = defineProps({
         type: Array,
         default: () => [],
     },
+    unitName: {
+        type: String,
+        default: "",
+    },
 });
 console.log("props.unitUsers", props.unitUsers);
+console.log("props.unitName", props.unitName);
 </script>
 
 <template>
     <div
         class="right-sidebar desktop-only bg-gray-100 w-56 h-screen p-4 shadow-lg"
     >
-        <h2 class="text-lg font-bold mb-4">部署メンバー</h2>
+        <h2 class="text-lg font-bold mb-4">
+            {{ unitName + "職員" || "部署メンバー" }}
+        </h2>
         <ul v-if="unitUsers && unitUsers.length > 0">
             <li
                 v-for="user in unitUsers"

--- a/resources/js/Pages/Unit/RightSidebar.vue
+++ b/resources/js/Pages/Unit/RightSidebar.vue
@@ -20,7 +20,8 @@ console.log("props.unitUsers", props.unitUsers);
             <li
                 v-for="user in unitUsers"
                 :key="user.id"
-                class="mb-2 p-2 rounded hover:bg-gray-200 cursor-pointe flex items-center space-x-2"
+                class="mb-2 p-2 rounded hover:bg-gray-200 cursor-pointer flex items-center space-x-2"
+                @click="$emit('user-selected', user)"
             >
                 <img
                     v-if="user.icon"

--- a/resources/js/Pages/Unit/RightSidebar.vue
+++ b/resources/js/Pages/Unit/RightSidebar.vue
@@ -12,13 +12,15 @@ console.log("props.unitUsers", props.unitUsers);
 </script>
 
 <template>
-    <div class="right-sidebar desktop-only">
-        <h2>ユニットメンバー</h2>
+    <div
+        class="right-sidebar desktop-only bg-gray-100 w-56 h-screen p-4 shadow-lg"
+    >
+        <h2 class="text-lg font-bold mb-4">部署メンバー</h2>
         <ul v-if="unitUsers && unitUsers.length > 0">
             <li
                 v-for="user in unitUsers"
                 :key="user.id"
-                class="p-1 cursor-pointer hover:bg-blue-300 flex items-center space-x-2"
+                class="mb-2 p-2 rounded hover:bg-gray-200 cursor-pointe flex items-center space-x-2"
             >
                 <img
                     v-if="user.icon"
@@ -47,6 +49,10 @@ console.log("props.unitUsers", props.unitUsers);
 .right-sidebar {
     padding: 16px;
     background-color: #f8f9fa;
+    position: fixed;
+    right: 0;
+    top: 0;
+    background-color: #f7fafc;
 }
 
 /* デスクトップ画面にのみ表示 */

--- a/resources/js/Pages/Unit/RightSidebar.vue
+++ b/resources/js/Pages/Unit/RightSidebar.vue
@@ -1,0 +1,63 @@
+<!-- RightSidebar.vue -->
+<script setup>
+import { defineProps } from "vue";
+
+const props = defineProps({
+    unitUsers: {
+        type: Array,
+        default: () => [],
+    },
+});
+console.log("props.unitUsers", props.unitUsers);
+</script>
+
+<template>
+    <div class="right-sidebar desktop-only">
+        <h2>ユニットメンバー</h2>
+        <ul v-if="unitUsers && unitUsers.length > 0">
+            <li
+                v-for="user in unitUsers"
+                :key="user.id"
+                class="p-1 cursor-pointer hover:bg-blue-300 flex items-center space-x-2"
+            >
+                <img
+                    v-if="user.icon"
+                    :src="
+                        user.icon.startsWith('/storage/')
+                            ? user.icon
+                            : `/storage/${user.icon}`
+                    "
+                    alt="User Icon"
+                    class="w-6 h-6 rounded-full"
+                />
+                <img
+                    v-else
+                    src="https://via.placeholder.com/40"
+                    alt="Default Icon"
+                    class="w-6 h-6 rounded-full"
+                />
+                <span>{{ user.name }}</span>
+            </li>
+        </ul>
+        <p v-else>メンバーが見つかりません。</p>
+    </div>
+</template>
+
+<style scoped>
+.right-sidebar {
+    padding: 16px;
+    background-color: #f8f9fa;
+}
+
+/* デスクトップ画面にのみ表示 */
+.desktop-only {
+    display: block;
+}
+
+@media (max-width: 1024px) {
+    /* モバイル画面では非表示 */
+    .desktop-only {
+        display: none;
+    }
+}
+</style>


### PR DESCRIPTION
## 目的
ユーザーが選択したユニットに所属するメンバーを右サイドバーに表示し、選択ユニット名やメンバーリストが安定して表示されるようにすることで、ユーザー体験を向上させることを目的としています。また、Inertiaを使用して`units`と`users`を共有データとして設定することで、コードの簡略化とメンテナンス性向上も図ります。

## 達成条件
- ユニットメンバーを右サイドバーに表示する機能を追加
- ユニット切り替え時にユーザーリストを保持・復元できる
- ロゴマークをクリックした際、ユーザーの所属ユニット掲示板とメンバーリストが表示される
- 右サイドバーと左サイドバーの幅を統一
- 不要なドロップダウンマークと関連機能を削除し、構造を簡略化
- Inertiaの共有データ機能で`units`と`users`のプロップ受け渡しを不要にする

## 実装の概要
1. **右サイドバーにユニットメンバー表示機能を追加**
   - RightSidebar.vueに、選択されたユニットのメンバーリストを表示する機能を追加しました。右サイドバーはデスクトップ画面でのみ表示され、モバイル画面では非表示となるよう設定しました。
   - メンバーが一瞬表示されてすぐに消える問題を解決するため、`sessionStorage`を使用し、ユニット選択時にユーザーリストを保持・復元する機能を追加しました。

2. **右サイドバーのユーザークリックイベント追加とクラス名の修正**
   - ユーザー名をクリックすると詳細ページが表示されるようにRightSidebar.vueにクリックイベントを追加し、親コンポーネントにユーザー情報を伝達する仕組みを実装しました。

3. **ユニット名の一時保存と復元機能を追加**
   - `sessionStorage`を活用し、選択ユニット名がページリロード時にも保持されるようにしました。これにより、右サイドバーに選択ユニット名が安定して表示され、ユーザーリストの見出しが選択ユニット名と連動します。

4. **ロゴマーククリック時の右サイドバー更新**
   - ロゴマークをクリックした際、自身の所属ユニット掲示板と右サイドバーが更新され、所属ユニット名およびユニットメンバー一覧が表示されるように改善しました。これにより、ダッシュボードやアカウント情報画面からも直接ユニット掲示板にアクセス可能になりました。

5. **不要なドロップダウンマークと関連機能の削除**
   - ユニット掲示板や右サイドバー表示切り替えに必要な`toggleUnit`は残し、不要なドロップダウンマークや`resetDropdown`メソッドを削除しました。これにより、構造がシンプルになり、不要なドロップダウン要素が整理されました。

6. **左右サイドバーの幅を調整**
   - 左サイドバーの幅を右サイドバーと一致させるため、幅を`w-60`から`w-56`に変更しました。

7. **Inertia共有データとして`units`と`users`を設定**
   - Inertiaの共有データとして`units`と`users`を`AppServiceProvider`で設定し、全ページで共有するようにしました。これにより、`AuthenticatedLayout`や`Forum.vue`などでのプロップ受け渡しが不要となり、コードの可読性と保守性が向上しました。

## レビューしてほしいところ
- RightSidebarの表示内容が安定して表示されるか（ユニット選択・ページリロード時の確認）
- `sessionStorage`を利用したユニット名およびユーザーリストの保持・復元が適切に動作しているか
- ロゴマーククリック時に、意図した掲示板とメンバーリストが表示されるか

## 不安に思っていること
- `sessionStorage`を利用しているため、ブラウザのセッション制約に関する動作確認が必要かと思いますが、他に懸念があるかどうかを確認したいです。
- Inertiaの共有データの影響で、他のコンポーネントで意図せぬデータ競合やパフォーマンス低下が発生しないか。

## 保留していること
- 現在のところモバイル画面でのサイドバー非表示設定を適用していますが、将来的にモバイル対応が必要になる場合に備えてサイドバー表示方法の検討を進める予定です。
