### PR TITLE
リダイレクト処理の改善および419エラー防止対応、掲示板ナビゲーション不具合修正

### DIFF
--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -24,10 +24,13 @@ class AuthenticatedSessionController extends Controller
         ]);
     }
 
-    /**
-     * Handle an incoming authentication request.
+   /**
+ * Handle an incoming authentication request.
+     *
+     * @param  \App\Http\Requests\Auth\LoginRequest  $request
+     * @return \Inertia\Response|\Illuminate\Http\RedirectResponse
      */
-    public function store(LoginRequest $request): RedirectResponse
+    public function store(LoginRequest $request)
     {
         $credentials = $request->only('username_id', 'password');
 
@@ -41,7 +44,7 @@ class AuthenticatedSessionController extends Controller
             // セッションにリロードフラグを設定
             session()->flash('reload_page', true);
 
-            return redirect()->route('dashboard');
+            return inertia::location('dashboard');
         }
 
         return back()->withErrors([

--- a/app/Http/Controllers/ForumController.php
+++ b/app/Http/Controllers/ForumController.php
@@ -64,7 +64,9 @@ class ForumController extends Controller
         }
 
         // 検索結果の投稿をページネーションで取得し、必要なデータを整形
-        $posts = $query->latest()->paginate(5)->through(function ($post) use ($user) {
+        $posts = $query->latest()->paginate(5)
+            ->appends(['forum_id' => $forumId, 'search' => $search])  // ページネーションのクエリパラメータとしてforum_idとsearchをURLに追加
+            ->through(function ($post) use ($user) {
             return [
                 'id' => $post->id,
                 'title' => $post->title,

--- a/resources/js/Pages/Unit/ListForSidebar.vue
+++ b/resources/js/Pages/Unit/ListForSidebar.vue
@@ -67,6 +67,10 @@ export default {
         openUserProfile(user) {
             this.$emit("user-profile-clicked", user); // 親にイベントを伝播
         },
+        resetDropdown() {
+            this.selectedUnitId = null; // 選択されたユニットをリセット
+            this.isFetchingData = false; // データ取得中フラグをリセット
+        },
     },
 };
 </script>

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -39,19 +39,28 @@ createInertiaApp({
 
         app.mount(el);
 
-        // Inertia.jsのカスタムイベントでリロードをトリガーする
         document.addEventListener("inertia:finish", (event) => {
             console.log("Inertia:finish イベントが発火しました");
 
-            // 現在のURLを取得
-            const currentUrl = window.location.href;
+            // HTTPレスポンスのステータスコードを確認
+            const statusCode = event.detail?.response?.status;
 
-            // ログイン後またはダッシュボードでのリダイレクトを処理
-            if (currentUrl.includes("localhost/home")) {
+            if (statusCode === 419) {
+                // セッション切れの場合の処理
                 console.log(
-                    "URLが 'localhost/home'または'localhost/dashboard'を含んでいます。ページをリロードします。"
+                    "セッション切れが検出されました。リロードを実行します。"
                 );
+                alert("セッションが切れています。リロードします。");
                 window.location.reload();
+            } else {
+                // 特定のページでリロードする場合（例: ダッシュボード）
+                const currentPath = window.location.pathname;
+                if (currentPath === "/home" || currentPath === "/dashboard") {
+                    console.log(
+                        "ホームまたはダッシュボードにリダイレクトされました。リロードします。"
+                    );
+                    window.location.reload();
+                }
             }
         });
     },


### PR DESCRIPTION
## 目的

- ユーザーがスムーズにアプリケーションを利用できるように、419エラーの防止および関連するリダイレクト処理の改善を行う。
- ページネーションで他ユニットに遷移する不具合を修正し、現在の掲示板が正しく表示されるようにする。
- サイドバーの状態を適切にリセットする機能を追加し、不要なデータ状態が残る問題を防ぐ。
- セッション切れ時のユーザー体験を向上させるため、自動リロード機能を実装する。

## 達成条件

- リダイレクト処理に `Inertia::location` を使用して419エラーを防止する。
- ページネーション操作時に正しい掲示板が維持される。
- サイドバー非表示時に状態をリセットする機能が正常に動作する。
- セッション切れ時に自動リロードが実行され、操作が中断されない。

## 実装の概要

1. **リダイレクト処理の改善**:

   - `Inertia::location` を使用して、フルリロードを強制することで419エラーを防止。
   - `store` メソッドの型ヒントを削除し、リダイレクト処理との互換性を確保。

2. **ページネーションの不具合修正**:

   - 現在の掲示板IDと検索条件をURLクエリパラメータに追加。
   - ページ移動後も適切な掲示板が表示されるよう修正。

3. **サイドバー状態のリセット機能追加**:

   - `resetDropdown` メソッドを追加し、サイドバー非表示時に選択状態やデータ取得フラグをリセット。
   - 不要な状態が残らないように調整。

4. **セッション切れ時の自動リロード機能**:

   - 419エラーを検知し、自動的にページをリロードする処理を実装。
   - ユーザー操作中断の回避を目的とした改善。

## レビューしてほしいところ

- `Inertia::location` を利用したリダイレクト処理が他の機能に影響を与えていないか。
- ページネーションのクエリパラメータの追加が正しく動作し、掲示板の遷移に問題がないか。
- `resetDropdown` メソッドが期待通りにサイドバーの状態をリセットできているか。
- セッション切れ時の自動リロード機能が正常に動作しているか。

## 不安に思っていること

- セッション切れ時の自動リロード処理が、エラー検知のタイミングによって他機能に影響を及ぼす可能性がある。
- ページネーションのクエリパラメータ追加が特定条件下で意図しない動作を引き起こさないか。

## 保留していること

- サイドバーの状態リセット機能のさらなる拡張（必要に応じて、他の状態管理に対応）。
- 419エラーの原因となる全てのケースを網羅的に防止するための追加調査。