### PR TITLE
不要なdefinePropsインポートの削除

### DIFF
--- a/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
+++ b/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
@@ -4,7 +4,7 @@ import InputLabel from "@/Components/InputLabel.vue";
 import PrimaryButton from "@/Components/PrimaryButton.vue";
 import TextInput from "@/Components/TextInput.vue";
 import { useForm } from "@inertiajs/vue3";
-import { defineProps, defineEmits, computed } from "vue";
+import { defineEmits, computed } from "vue";
 
 const props = defineProps({
     user: {

--- a/resources/js/Pages/Unit/RightSidebar.vue
+++ b/resources/js/Pages/Unit/RightSidebar.vue
@@ -1,6 +1,5 @@
 <!-- RightSidebar.vue -->
 <script setup>
-import { defineProps } from "vue";
 
 const props = defineProps({
     unitUsers: {


### PR DESCRIPTION
***

## 目的

Vue 3.3以降では `defineProps` がインポート不要なコンパイラマクロとして扱われるようになったため、プロジェクト全体でこの仕様に対応し、不要なコードを削除することで可読性とメンテナンス性を向上させる。

***

## 達成条件

1. Vueファイルで使用されているすべての `defineProps` のインポートを削除する。
2. 削除後も、既存の機能が正常に動作することを確認する。
3. テストおよびビルドがエラーなく完了すること。

***

## 実装の概要

- 次のファイルから `defineProps` のインポートを削除しました：

  - `UpdateProfileInformationForm.vue`：

    ```
    import { defineProps, defineEmits, computed } from "vue";
    ↓
    import { defineEmits, computed } from "vue";
    ```

  - `RightSidebar.vue`：

    ```
    - import { defineProps } from "vue";
    ```

- 各ファイル内では `defineProps` をそのまま使用しています（Vue 3.3以降ではインポート不要）。

- ローカル環境での動作確認、およびCIテストを実施済みです。

***

## レビューしてほしいところ

- `defineProps` の削除により、コンポーネントの動作に影響が出ていないかをご確認ください。
- プロジェクト内で他に同様のケースが残っていないか、見落としがないかも確認していただけると助かります。

***

## 不安に思っていること

- 現在の変更がすべての環境で正常に動作することは確認済みですが、Vueのバージョンが古い場合に問題が発生する可能性があるため、使用しているVueのバージョンが 3.3 以上であることを再確認してください。

***

## 保留していること

- 今回の変更は `defineProps` のインポート削除に限定しています。他のVueコンパイラマクロ（例：`defineEmits` や `defineExpose`）に関する最適化は別タスクとして保留しています。

***

## 補足

開発サーバーを起動する際に以下のメッセージが表示されました：

```
[@vue/compiler-sfc] `defineProps` is a compiler macro and no longer needs to be imported.
```

このメッセージに従い、`defineProps` をインポートする必要がなくなったため、今回の対応を実施しました。