### PR TITLE
フラッシュメッセージの改善と文言の調整に関する修正

### DIFF
--- a/app/Http/Controllers/UnitController.php
+++ b/app/Http/Controllers/UnitController.php
@@ -56,7 +56,7 @@ class UnitController extends Controller
             'visibility' => 'public',
             'status' => 'active',
         ]);
-        return redirect()->route("dashboard")->with(["success" => "ユニット登録が完了しました。"]);
+        return redirect()->route("dashboard")->with(["success" => "部署登録が完了しました。"]);
     }
 
     /**

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -15,7 +15,7 @@
     "Update Password": "パスワードの更新",
     "Ensure your account is using a long, random password to stay secure.": "十分に長くランダムなパスワードを使用して、アカウントのセキュリティを高めましょう",
     "Save": "保存",
-    "Saved.": "保存されました",
+    "Saved.": "変更が保存されました",
     "Already registered?": "既に登録済みの方",
     "Register": "登録",
     "Remember me": "このブラウザに認証情報を記憶",

--- a/resources/js/Pages/Admin/EmployeeList.vue
+++ b/resources/js/Pages/Admin/EmployeeList.vue
@@ -38,7 +38,7 @@ watchEffect(() => {
     if (flashMessage.value) {
         const timeout = setTimeout(() => {
             flashMessage.value = null;
-        }, 3000);
+        }, 8000);
 
         // クリーンアップでタイマーをクリア
         return () => clearTimeout(timeout);

--- a/resources/js/Pages/Admin/TransferAdmin.vue
+++ b/resources/js/Pages/Admin/TransferAdmin.vue
@@ -27,7 +27,7 @@ const addFlashMessage = (message) => {
     flashMessages.value.push(message);
     setTimeout(() => {
         flashMessages.value.shift();
-    }, 3000);
+    }, 8000);
 };
 
 // 管理者権限の譲渡

--- a/resources/js/Pages/Dashboard.vue
+++ b/resources/js/Pages/Dashboard.vue
@@ -14,13 +14,13 @@ const flashType = ref(
     flash.success ? "success" : flash.error ? "error" : "info"
 );
 
-// 3秒後にフラッシュメッセージをフェードアウトさせる
+// 8秒後にフラッシュメッセージをフェードアウトさせる
 const showFlashMessage = ref(true);
 onMounted(() => {
     if (flashMessage.value) {
         setTimeout(() => {
             showFlashMessage.value = false;
-        }, 3000);
+        }, 8000);
     }
 });
 

--- a/resources/js/Pages/Profile/Edit.vue
+++ b/resources/js/Pages/Profile/Edit.vue
@@ -33,7 +33,7 @@ watch(successMessage, (newVal) => {
     if (newVal) {
         setTimeout(() => {
             successMessage.value = null;
-        }, 3000);
+        }, 8000);
     }
 });
 </script>

--- a/resources/js/Pages/Profile/Partials/IconEditForm.vue
+++ b/resources/js/Pages/Profile/Partials/IconEditForm.vue
@@ -45,10 +45,10 @@ const handleImageChange = (e) => {
             localErrorMessage.value =
                 "対応していないファイル形式です。png, jpg, gif, webpのいずれかを選択してください。";
 
-            // 5秒後にエラーメッセージを自動的に消す処理
+            // 8秒後にエラーメッセージを自動的に消す処理
             setTimeout(() => {
                 localErrorMessage.value = null;
-            }, 5000);
+            }, 8000);
 
             return;
         }
@@ -85,10 +85,10 @@ const submit = () => {
             // 成功メッセージを設定
             localSuccessMessage.value = "プロフィール画像が更新されました";
 
-            // 5秒後にサクセスメッセージを自動的に消す
+            // 8秒後にサクセスメッセージを自動的に消す
             setTimeout(() => {
                 localSuccessMessage.value = null;
-            }, 5000);
+            }, 8000);
 
             // オーバーレイを閉じる
             emit("close");

--- a/resources/js/Pages/Profile/Partials/IconEditForm.vue
+++ b/resources/js/Pages/Profile/Partials/IconEditForm.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { useForm, usePage } from "@inertiajs/vue3";
-import { computed, watch, ref, defineEmits, defineProps } from "vue";
+import { ref } from "vue";
 
 const props = defineProps({
     user: Object,

--- a/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
+++ b/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
@@ -66,6 +66,31 @@ const handleOpenIconEdit = () => {
             </p>
         </header>
 
+        <!-- プロフィール画像更新成功メッセージ表示 -->
+        <div
+            v-if="successMessage"
+            class="bg-green-100 text-green-700 p-3 mt-4 mb-6 rounded"
+        >
+            {{ successMessage }}
+        </div>
+
+        <!-- プロフィール情報更新成功メッセージ表示 -->
+        <Transition
+            enter-active-class="transition ease-in-out"
+            enter-from-class="opacity-0"
+            leave-active-class="transition ease-in-out"
+            leave-to-class="opacity-0"
+        >
+            <div
+                v-if="form.recentlySuccessful"
+                class="bg-green-100 text-green-700 p-3 mt-4 mb-6 rounded"
+            >
+                <p class="font-medium text-center">
+                    {{ $t("Saved.") }}
+                </p>
+            </div>
+        </Transition>
+
         <form
             @submit.prevent="form.patch(route('profile.update'))"
             class="mt-6 space-y-6"
@@ -114,14 +139,6 @@ const handleOpenIconEdit = () => {
                         </svg>
                     </div>
                 </button>
-            </div>
-
-            <!-- 成功メッセージ表示 -->
-            <div
-                v-if="successMessage"
-                class="bg-green-100 text-green-700 p-3 mb-6 rounded"
-            >
-                {{ successMessage }}
             </div>
 
             <!-- フォーム項目 -->
@@ -203,23 +220,6 @@ const handleOpenIconEdit = () => {
                         {{ $t("Save") }}
                     </PrimaryButton>
                 </div>
-
-                <!-- フラッシュメッセージ -->
-                <Transition
-                    enter-active-class="transition ease-in-out"
-                    enter-from-class="opacity-0"
-                    leave-active-class="transition ease-in-out"
-                    leave-to-class="opacity-0"
-                >
-                    <div
-                        v-if="form.recentlySuccessful"
-                        class="bg-green-100 text-green-700 p-3 mt-4 mb-6 rounded"
-                    >
-                        <p class="font-bold text-center">
-                            {{ $t("Saved.") }}
-                        </p>
-                    </div>
-                </Transition>
             </div>
         </form>
     </section>

--- a/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
+++ b/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
@@ -196,23 +196,29 @@ const handleOpenIconEdit = () => {
                 </select>
             </div>
 
-            <div class="flex items-center gap-4">
-                <PrimaryButton :disabled="form.processing">
-                    {{ $t("Save") }}
-                </PrimaryButton>
+            <div>
+                <!-- 保存ボタン -->
+                <div>
+                    <PrimaryButton :disabled="form.processing">
+                        {{ $t("Save") }}
+                    </PrimaryButton>
+                </div>
 
+                <!-- フラッシュメッセージ -->
                 <Transition
                     enter-active-class="transition ease-in-out"
                     enter-from-class="opacity-0"
                     leave-active-class="transition ease-in-out"
                     leave-to-class="opacity-0"
                 >
-                    <p
+                    <div
                         v-if="form.recentlySuccessful"
-                        class="text-sm text-gray-600"
+                        class="bg-green-100 text-green-700 p-3 mt-4 mb-6 rounded"
                     >
-                        {{ $t("Saved.") }}
-                    </p>
+                        <p class="font-bold text-center">
+                            {{ $t("Saved.") }}
+                        </p>
+                    </div>
                 </Transition>
             </div>
         </form>

--- a/resources/js/Pages/Unit/Register.vue
+++ b/resources/js/Pages/Unit/Register.vue
@@ -48,7 +48,7 @@ watchEffect(() => {
     if (flashMessage.value) {
         const timeout = setTimeout(() => {
             flashMessage.value = null;
-        }, 3000);
+        }, 8000);
 
         // クリーンアップでタイマーをクリア
         return () => clearTimeout(timeout);


### PR DESCRIPTION
## 目的

ユーザーがシステムの操作結果を正確かつ分かりやすく認識できるよう、以下の点について改善を行いました：

- フラッシュメッセージの文言をユーザーにとってより適切な表現に修正。
- メッセージ表示時間を統一し、適切に認識できる時間を確保。
- メッセージのデザインと構造を調整して視認性を向上。

***

## 達成条件

- フラッシュメッセージの文言が適切に変更されていること。
- プロフィール画像更新時とプロフィール情報更新時のメッセージがそれぞれ独立して表示されること。
- フラッシュメッセージが適切な視認性を持つデザインで表示されること。

***

## 実装の概要

1. **フラッシュメッセージの文言変更**

   - 「ユニット」を「部署」に変更し、表現をより正確に修正。
   - 「保存されました」を「変更が保存されました」に変更。

2. **フラッシュメッセージのデザイン調整**

   - 強調表示のためにスタイルを改善し、視認性を向上。

3. **成功メッセージの分離**

   - プロフィール画像更新時とプロフィール情報更新時で異なるメッセージを表示するよう分離しました。
   - 本来であれば、同じコンポーネント内で条件分岐により使い分ける形が望ましいですが、現時点ではコードの簡潔さと保守性を考慮し、それぞれ別のロジックとして実装しています。

4. **表示時間に関する制限について**

   - Breeze のデフォルトのフラッシュメッセージ機能（`recentlySuccessful`）を使用しているため、表示時間を完全にカスタマイズすることができませんでした。将来的には、この仕組みを使用せず、自作のフラッシュメッセージコンポーネントを実装することで、より柔軟なカスタマイズを可能にする予定です。

***

## レビューしてほしいところ

- 文言の変更が意図通りに行われているか。
- プロフィール画像とプロフィール情報の成功メッセージが適切に分離されているか。
- デザイン改善が他のコンポーネントや機能に影響を与えていないか。

***

## 不安に思っていること

- 表示時間が短い場合、ユーザーにとって十分に認識しやすいか不安が残ります。
- 成功メッセージの分離について、同一コンポーネントで条件分岐を行う形に変更した方が、保守性や再利用性が向上する可能性があります。必要に応じて再検討が必要です。
- Breeze の `recentlySuccessful` を使用したままでは、表示時間や動作をカスタマイズする柔軟性が不足しています。

***

## 保留していること

- `recentlySuccessful` を使用しない自作フラッシュメッセージの実装を検討しています。
