### PR TITLE
掲示板UIの改善と機能調整

### DIFF
--- a/lang/ja.json
+++ b/lang/ja.json
@@ -178,5 +178,6 @@
     "Transfer page": "管理者権限移動ページへ",
     "Select a user to transfer admin privileges.": "管理者権限を移動する社員を選択してください。",
     "Transfer": "移動",
-    "Current Admin": "現在の管理者"
+    "Current Admin": "現在の管理者",
+    "Go to Forum": "掲示板へ"
 }

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -180,5 +180,7 @@
     "Transfer": "移動",
     "Current Admin": "現在の管理者",
     "Go to Forum": "掲示板へ",
-    "By setting your unit, you can access the forum.": "所属部署を設定すると、掲示板にアクセスできます"
+    "By setting your unit, you can access the forum.": "所属部署を設定すると、掲示板にアクセスできます",
+    "Unassigned": "未所属",
+    "Select your unit": "所属部署を選択してください"
 }

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -179,5 +179,6 @@
     "Select a user to transfer admin privileges.": "管理者権限を移動する社員を選択してください。",
     "Transfer": "移動",
     "Current Admin": "現在の管理者",
-    "Go to Forum": "掲示板へ"
+    "Go to Forum": "掲示板へ",
+    "By setting your unit, you can access the forum.": "所属部署を設定すると、掲示板にアクセスできます"
 }

--- a/lang/ja/validation.php
+++ b/lang/ja/validation.php
@@ -265,5 +265,6 @@ return [
         'business_name' => '事業所名',
         'tenant_domain_id' => 'テナントID',
         'icon' => 'プロフィール画像',
+        'username_id' => 'ユーザーID',
     ],
 ];

--- a/resources/js/Components/ChildComment.vue
+++ b/resources/js/Components/ChildComment.vue
@@ -63,6 +63,7 @@ const props = defineProps({
                             )
                         "
                         class="px-2 py-1 rounded bg-green-500 text-white font-bold link-hover cursor-pointer"
+                        title="返信"
                     >
                         <i class="bi bi-reply"></i>
                     </button>
@@ -72,6 +73,7 @@ const props = defineProps({
                         v-if="isCommentAuthor(comment)"
                         @click="deleteItem('comment', comment.id)"
                         class="px-2 py-1 rounded bg-red-500 text-white font-bold link-hover cursor-pointer"
+                        title="コメントの削除"
                     >
                         <i class="bi bi-trash"></i>
                     </button>

--- a/resources/js/Components/ParentComment.vue
+++ b/resources/js/Components/ParentComment.vue
@@ -118,6 +118,7 @@ const getCommentCountRecursive = (comments) => {
                             )
                         "
                         class="px-2 py-1 rounded bg-green-500 text-white font-bold link-hover cursor-pointer"
+                        title="返信"
                     >
                         <i class="bi bi-reply"></i>
                     </button>
@@ -127,6 +128,7 @@ const getCommentCountRecursive = (comments) => {
                         v-if="isCommentAuthor(comment)"
                         @click="deleteItem('comment', comment.id)"
                         class="px-2 py-1 rounded bg-red-500 text-white font-bold link-hover cursor-pointer"
+                        title="コメントの削除"
                     >
                         <i class="bi bi-trash"></i>
                     </button>

--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -1,11 +1,12 @@
 <script setup>
 import { ref } from "vue";
-import { usePage, router } from "@inertiajs/vue3";
+import { usePage } from "@inertiajs/vue3";
 import ApplicationLogo from "@/Components/ApplicationLogo.vue";
 import Dropdown from "@/Components/Dropdown.vue";
 import DropdownLink from "@/Components/DropdownLink.vue";
 import NavLink from "@/Components/NavLink.vue";
 import ResponsiveNavLink from "@/Components/ResponsiveNavLink.vue";
+import { redirectToForum } from "@/Utils/redirectToForum";
 
 const page = usePage();
 const units = page.props.units || []; // Inertiaから`units`を取得
@@ -31,50 +32,8 @@ const userUnitId = auth.user?.unit_id || null;
 console.log("Logged in user data:", auth.user);
 console.log("auth.user.unit_id:", userUnitId);
 
-const handleLogoClick = async () => {
-    try {
-        const response = await fetch(`/user-forum-id`, {
-            headers: {
-                Accept: "application/json",
-            },
-        });
-        const data = await response.json();
-
-        if (!response.ok) {
-            throw new Error(data.error || "Failed to fetch forum ID");
-        }
-
-        const forumId = data.forum_id || null;
-
-        if (userUnitId) {
-            const unit = units.find((u) => u.id === userUnitId);
-            const unitUsers = users.filter(
-                (user) => user.unit_id === userUnitId
-            );
-
-            if (unit) {
-                sessionStorage.setItem(
-                    "selectedUnitUsers",
-                    JSON.stringify(unitUsers)
-                );
-                sessionStorage.setItem("selectedUnitName", unit.name);
-            }
-        } else {
-            console.warn("User does not belong to a unit.");
-        }
-
-        // 所属ユニットの掲示板に遷移して状態をリセット
-        if (forumId) {
-            router.get(route("forum.index", { forum_id: forumId }), {
-                preserveState: false,
-            });
-        } else {
-            console.warn("Forum ID not found. Navigation skipped.");
-        }
-    } catch (error) {
-        console.error("Error fetching user forum ID:", error);
-        alert(error.message); // エラーメッセージをアラートで表示
-    }
+const navigateToForum = () => {
+    redirectToForum(units, users, userUnitId);
 };
 
 // ゲストログアウト時の確認アラート
@@ -103,7 +62,7 @@ const confirmGuestLogout = (event) => {
                             <!-- Logo -->
                             <div class="shrink-0 flex items-center">
                                 <div
-                                    @click="handleLogoClick"
+                                    @click="navigateToForum"
                                     class="cursor-pointer"
                                 >
                                     <ApplicationLogo

--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -107,7 +107,7 @@ const confirmGuestLogout = (event) => {
                                     class="cursor-pointer"
                                 >
                                     <ApplicationLogo
-                                        class="block h-9 w-auto fill-current text-gray-800"
+                                        class="block h-9 w-auto fill-current text-blue-900"
                                     />
                                 </div>
                             </div>

--- a/resources/js/Pages/Auth/Login.vue
+++ b/resources/js/Pages/Auth/Login.vue
@@ -79,15 +79,11 @@ const submit = () => {
                 </label>
             </div>
 
-            <div class="flex items-center justify-end mt-4">
-                <Link
-                    v-if="canResetPassword"
-                    :href="route('password.request')"
-                    class="underline text-sm text-gray-600 hover:text-gray-900 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
-                >
-                    {{ $t("Forgot your password?") }}
-                </Link>
+            <div class="mt-6 text-sm text-gray-600">
+                ユーザーID、並びにパスワードを忘れた場合は、管理者にお問い合わせください。
+            </div>
 
+            <div class="flex items-center justify-end mt-4">
                 <PrimaryButton
                     class="ms-4"
                     :class="{ 'opacity-25': form.processing }"

--- a/resources/js/Pages/Dashboard.vue
+++ b/resources/js/Pages/Dashboard.vue
@@ -3,6 +3,7 @@ import AuthenticatedLayout from "@/Layouts/AuthenticatedLayout.vue";
 import { Head, usePage } from "@inertiajs/vue3";
 import { ref, onMounted } from "vue";
 import AdminDashboard from "@/Pages/Admin/Dashboard.vue";
+import { redirectToForum } from "@/Utils/redirectToForum";
 
 const { props } = usePage();
 const isAdmin = props.isAdmin;
@@ -24,6 +25,10 @@ onMounted(() => {
     }
 });
 
+const navigateToForum = () => {
+    redirectToForum(props.units, props.users, props.auth.user.unit_id);
+};
+
 console.log("User data:", props.auth.user);
 </script>
 
@@ -41,11 +46,20 @@ console.log("User data:", props.auth.user);
         <div class="py-12 px-4 sm:px-8 lg:px-16">
             <div class="max-w-6xl mx-auto">
                 <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
-                    <div v-if="!isGuest" class="p-6 text-gray-900">
-                        {{ $t("You're logged in") }}
-                    </div>
-                    <div v-else class="p-6 text-gray-900">
-                        {{ $t("Logged in as guest user") }}
+                    <div class="p-6 text-gray-900 flex items-center space-x-4">
+                        <div v-if="!isGuest">
+                            {{ $t("You're logged in") }}
+                        </div>
+                        <div v-else>
+                            {{ $t("Logged in as guest user") }}
+                        </div>
+                        <!-- 掲示板へのリンクボタン -->
+                        <button
+                            @click="navigateToForum"
+                            class="text-blue-500 link-hover"
+                        >
+                            {{ $t("Go to Forum") }}
+                        </button>
                     </div>
                 </div>
             </div>
@@ -77,10 +91,15 @@ console.log("User data:", props.auth.user);
 </template>
 
 <style>
+.link-hover:hover {
+    color: #007bff;
+}
+
 .fade-enter-active,
 .fade-leave-active {
     transition: opacity 0.5s;
 }
+
 .fade-enter,
 .fade-leave-to {
     opacity: 0;

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -307,7 +307,7 @@ const isCommentAuthor = (comment) => {
             <ListForSidebar
                 :units="units"
                 :users="users"
-                class="sidebar-mobile p-4 lg:mt-16 lg:block"
+                class="sidebar-mobile p-4 sm:mt-16 lg:block"
                 :class="{ visible: sidebarVisible }"
                 ref="sidebar"
                 @user-profile-clicked="onUserSelected"
@@ -535,7 +535,7 @@ const isCommentAuthor = (comment) => {
             <RightSidebar
                 :unit-users="selectedUnitUsers"
                 :unit-name="selectedUnitName"
-                class="p-4 lg:mt-16 lg:block"
+                class="p-4 lg:mt-16 sm:block"
                 @user-selected="onUserSelected"
             />
 
@@ -573,13 +573,15 @@ const isCommentAuthor = (comment) => {
 }
 
 /* モバイルサイズ用のスタイル（切り替え可能） */
-@media (max-width: 1024px) {
+@media (max-width: 767px) {
     .sidebar-mobile {
         width: 70%; /* モバイル時のサイドバー幅 */
         transform: translateX(-100%); /* デフォルトで非表示 */
         transition: transform 0.3s ease-in-out;
         z-index: 50;
-        background-color: #ffffff; /* サイドバーの背景色 */
+        background-color: #ffffff; /* 背景色 */
+        position: absolute;
+        height: 100%;
     }
     .sidebar-mobile.visible {
         transform: translateX(0); /* 表示 */
@@ -595,6 +597,35 @@ const isCommentAuthor = (comment) => {
         background-color: rgba(0, 0, 0, 0.5); /* 背景を半透明に */
         z-index: 40;
         transition: opacity 0.3s ease-in-out;
+    }
+}
+
+/* iPadサイズ専用（768px ～ 1024px） */
+@media (min-width: 768px) and (max-width: 1024px) {
+    .sidebar-mobile {
+        width: 220px; /* iPadサイズではサイドバーを狭くする */
+    }
+
+    .flex-1 {
+        margin-left: 220px; /* サイドバーの幅分余白を調整 */
+    }
+}
+
+/* iPad Proサイズ以上（1024px以上） */
+@media (min-width: 1025px) {
+    .sidebar-mobile {
+        width: 250px; /* 通常のサイドバー幅 */
+    }
+
+    .flex-1 {
+        margin-left: 250px; /* 通常の余白 */
+    }
+}
+
+/* 全画面表示専用（デスクトップサイズ以上） */
+@media (min-width: 1366px) {
+    .flex-1 {
+        margin-left: 280px; /* サイドバー幅より広い余白を設定 */
     }
 }
 </style>

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -319,7 +319,7 @@ const isCommentAuthor = (comment) => {
             <div class="flex-1 max-w-4xl mx-auto p-4">
                 <div class="flex justify-between items-center mb-4">
                     <h1
-                        class="text-xl font-bold cursor-pointer sm:hidden"
+                        class="text-xl font-bold cursor-pointer toggle-button"
                         @click="toggleSidebar"
                     >
                         {{ $t("Unit List") }}
@@ -626,6 +626,20 @@ const isCommentAuthor = (comment) => {
 @media (min-width: 1366px) {
     .flex-1 {
         margin-left: 280px; /* サイドバー幅より広い余白を設定 */
+    }
+}
+
+/* モバイルサイズのトグルボタン */
+@media (max-width: 767px) {
+    .toggle-button {
+        display: block; /* 767px以下でトグルボタンを表示 */
+    }
+}
+    
+/* デスクトップサイズのトグルボタン */
+@media (min-width: 768px) {
+    .toggle-button {
+        display: none; /* 768px以上では非表示 */
     }
 }
 </style>

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -635,11 +635,18 @@ const isCommentAuthor = (comment) => {
         display: block; /* 767px以下でトグルボタンを表示 */
     }
 }
-    
+
 /* デスクトップサイズのトグルボタン */
 @media (min-width: 768px) {
     .toggle-button {
         display: none; /* 768px以上では非表示 */
+    }
+}
+
+@media (min-width: 640px) and (max-width: 767px) {
+    .sidebar-mobile {
+        margin-top: 0 !important; /* この範囲ではmt-16を無効化 */
+        width: 50% !important;
     }
 }
 </style>

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -349,6 +349,7 @@ const isCommentAuthor = (comment) => {
                     v-if="selectedForumId"
                     :forum-id="Number(selectedForumId)"
                     class="mb-6"
+                    title="投稿"
                 />
 
                 <!-- 投稿一覧 -->
@@ -465,6 +466,7 @@ const isCommentAuthor = (comment) => {
                                     )
                                 "
                                 class="px-2 py-1 rounded bg-green-500 text-white font-bold link-hover cursor-pointer"
+                                title="返信"
                             >
                                 <i class="bi bi-reply"></i>
                             </button>
@@ -485,6 +487,7 @@ const isCommentAuthor = (comment) => {
                                 "
                                 @click.prevent="deleteItem('post', post.id)"
                                 class="px-2 py-1 ml-2 rounded bg-red-500 text-white font-bold link-hover cursor-pointer"
+                                title="投稿の削除"
                             >
                                 <i class="bi bi-trash"></i>
                             </button>
@@ -503,6 +506,7 @@ const isCommentAuthor = (comment) => {
                                     ?.replyToName
                             "
                             class="mt-4"
+                            title="返信"
                         />
                     </div>
 

--- a/resources/js/Pages/Profile/Partials/IconEditForm.vue
+++ b/resources/js/Pages/Profile/Partials/IconEditForm.vue
@@ -94,8 +94,13 @@ const submit = () => {
             emit("close");
         },
         onError: (errors) => {
-            console.log("アイコン更新エラー", errors);
-            localErrorMessage.value = "アイコン更新に失敗しました";
+            console.log("プロフィール画像更新エラー", errors);
+
+            if (errors.icon) {
+                localErrorMessage.value = errors.icon;
+            } else {
+                localErrorMessage.value = "プロフィール画像の更新に失敗しました";
+            }
         },
     });
 };

--- a/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
+++ b/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
@@ -211,6 +211,9 @@ const handleOpenIconEdit = () => {
                         {{ unit.name }}
                     </option>
                 </select>
+                <p class="text-sm text-gray-600 mt-2">
+                    {{ $t("By setting your unit, you can access the forum.") }}
+                </p>
             </div>
 
             <div>

--- a/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
+++ b/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
@@ -203,6 +203,12 @@ const handleOpenIconEdit = () => {
                     id="unit_id"
                     class="w-full border border-gray-300 p-2 rounded"
                 >
+                    <!-- プレースホルダー（選択を促す） -->
+                    <option value="" disabled hidden>
+                        {{ $t("Select your unit") }}
+                    </option>
+
+                    <!-- 部署リスト -->
                     <option
                         v-for="unit in units"
                         :key="unit.id"

--- a/resources/js/Pages/Unit/ListForSidebar.vue
+++ b/resources/js/Pages/Unit/ListForSidebar.vue
@@ -103,13 +103,6 @@ export default {
     transition: width 0.3s ease-in-out; /* アニメーションを追加 */
 }
 
-/* iPadサイズ以上で余白を減らす */
-@media (min-width: 768px) and (max-width: 1024px) {
-    .sidebar {
-        width: 200px; /* 余白を減らす */
-    }
-}
-
 /* モバイルサイズでの設定 */
 @media (max-width: 767px) {
     .sidebar {

--- a/resources/js/Pages/Unit/ListForSidebar.vue
+++ b/resources/js/Pages/Unit/ListForSidebar.vue
@@ -96,6 +96,30 @@ export default {
     position: fixed;
     left: 0;
     top: 0;
+    width: 220px; /* デフォルトの幅を少し狭める */
+    height: 100vh; /* 全画面高さ */
     background-color: #f7fafc;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+    transition: width 0.3s ease-in-out; /* アニメーションを追加 */
+}
+
+/* iPadサイズ以上で余白を減らす */
+@media (min-width: 768px) and (max-width: 1024px) {
+    .sidebar {
+        width: 200px; /* 余白を減らす */
+    }
+}
+
+/* モバイルサイズでの設定 */
+@media (max-width: 767px) {
+    .sidebar {
+        width: 70%; /* モバイルでは画面の70%を占める */
+        position: absolute; /* トグルで表示されるため絶対配置 */
+        transform: translateX(-100%); /* 初期状態で非表示 */
+        transition: transform 0.3s ease-in-out;
+    }
+    .sidebar.visible {
+        transform: translateX(0); /* 表示状態に切り替え */
+    }
 }
 </style>

--- a/resources/js/Pages/Unit/RightSidebar.vue
+++ b/resources/js/Pages/Unit/RightSidebar.vue
@@ -67,7 +67,7 @@ console.log("props.unitName", props.unitName);
     display: block;
 }
 
-@media (max-width: 1024px) {
+@media (max-width: 1366px) {
     /* モバイル画面では非表示 */
     .desktop-only {
         display: none;

--- a/resources/js/Utils/redirectToForum.js
+++ b/resources/js/Utils/redirectToForum.js
@@ -1,0 +1,51 @@
+import { router } from "@inertiajs/vue3";
+
+export const redirectToForum = async (
+    units,
+    users,
+    userUnitId,
+    routeName = "forum.index"
+) => {
+    try {
+        const response = await fetch(`/user-forum-id`, {
+            headers: {
+                Accept: "application/json",
+            },
+        });
+        const data = await response.json();
+
+        if (!response.ok) {
+            throw new Error(data.error || "Failed to fetch forum ID");
+        }
+
+        const forumId = data.forum_id || null;
+
+        if (userUnitId) {
+            const unit = units.find((u) => u.id === userUnitId);
+            const unitUsers = users.filter(
+                (user) => user.unit_id === userUnitId
+            );
+
+            if (unit) {
+                sessionStorage.setItem(
+                    "selectedUnitUsers",
+                    JSON.stringify(unitUsers)
+                );
+                sessionStorage.setItem("selectedUnitName", unit.name);
+            }
+        } else {
+            console.warn("User does not belong to a unit.");
+        }
+
+        if (forumId) {
+            router.get(route(routeName, { forum_id: forumId }), {
+                preserveState: false,
+            });
+        } else {
+            console.warn("Forum ID not found. Navigation skipped.");
+        }
+    } catch (error) {
+        console.error("Error fetching user forum ID:", error);
+        alert(error.message);
+    }
+};


### PR DESCRIPTION
## 目的

掲示板およびサイドバーのUIやユーザビリティを向上させ、画面幅や利用状況に応じた最適な挙動を提供することを目的としています。また、コードの再利用性を高める変更も含まれています。

## 達成条件

- 掲示板とサイドバーが異なる画面サイズに応じて最適に表示されること。
- ロゴクリック時の掲示板遷移や部署選択時のサイドバー表示がスムーズに行えること。
- 必要なエラーメッセージや説明文が適切に表示されること。

## 実装の概要

### 1. 掲示板UIの調整

- **掲示板へのリダイレクト処理をユーティリティ関数化**  
  `redirectToForum` 関数を導入し、ロゴクリック時や部署選択時の掲示板遷移処理を一元化しました。

- **ログイン成功メッセージに掲示板へのリンクを追加**  
  ユーザー体験を向上させるため、ログイン後に掲示板へのリンクを追加しました。リンクテキストの日本語翻訳も含まれています。

### 2. サイドバーの改善

- **部署ごとのユーザー表示切り替え**  
  左サイドバーの部署選択時に、選択した部署に属するユーザーのみが右サイドバーに表示されるように調整しました。

- **サイドバーのレスポンシブ調整**  
  画面幅に応じてサイドバーの幅や表示方法を変更しました。具体的には以下の対応を実施しました：

  - 1366px以下で右サイドバーを非表示。
  - 640px～767pxの画面幅で余白を調整し、サイドバー幅を50%に変更。
  - トグルボタンの表示タイミングを修正。

### 3. その他の変更点

- **ボタンに説明用`title`属性を追加**  
  ボタンのホバー時に機能を説明するテキストが表示されるようにしました。

- **部署選択プルダウンに「未所属」プレースホルダーを追加**  
  所属部署が未設定の状態を明示するため、プレースホルダーを追加しました。

- **アイコン更新時のエラーメッセージ表示を修正**  
  更新失敗時にサーバーから返されるエラーメッセージ（例: 画像サイズ超過）を表示するよう改善しました。

## レビューしてほしいところ

1. サイドバーのユーザー表示切り替えが期待通り動作するか。
2. `redirectToForum` 関数の実装が冗長でないか。
3. ログイン後の掲示板リンクの文言やデザインが適切か。

## 不安に思っていること

- ユニット選択時に表示される右サイドバーのアイコンが、更新直後に即時反映されないケースがある可能性。

## 保留していること

- アイコン更新後の即時反映の完全な解決は見送りました。再検討の余地あり。