### PR TITLE
Vue コンポーネントのリファクタリングとユーティリティ関数導入による可読性と再利用性の向上

### DIFF
--- a/resources/js/Components/ChildComment.vue
+++ b/resources/js/Components/ChildComment.vue
@@ -6,7 +6,7 @@ const props = defineProps({
     postId: Number, // 親投稿のID
     formatDate: Function, // 日付フォーマット用関数
     isCommentAuthor: Function, // コメント作成者かを確認する関数
-    deleteItem: Function, // コメント削除用関数
+    onDeleteItem: Function, // コメント削除用関数
     toggleCommentForm: Function, // コメントフォームの表示切替関数
     commentFormVisibility: Object, // コメントフォームの表示状態
     openUserProfile: Function, // ユーザープロフィールを開く関数
@@ -75,7 +75,7 @@ const props = defineProps({
                     <!-- コメント削除ボタン -->
                     <button
                         v-if="isCommentAuthor(comment)"
-                        @click="deleteItem('comment', comment.id)"
+                        @click="onDeleteItem('comment', comment.id)"
                         class="px-2 py-1 rounded bg-red-500 text-white font-bold link-hover cursor-pointer"
                         title="コメントの削除"
                     >
@@ -102,7 +102,7 @@ const props = defineProps({
                     :postId="postId"
                     :formatDate="formatDate"
                     :isCommentAuthor="isCommentAuthor"
-                    :deleteItem="deleteItem"
+                    :onDeleteItem="onDeleteItem"
                     :toggleCommentForm="toggleCommentForm"
                     :commentFormVisibility="commentFormVisibility"
                     :openUserProfile="openUserProfile"

--- a/resources/js/Components/ParentComment.vue
+++ b/resources/js/Components/ParentComment.vue
@@ -9,7 +9,7 @@ const props = defineProps({
     postId: Number, // 親投稿のID
     formatDate: Function, // 日付フォーマット用関数
     isCommentAuthor: Function, // コメント作成者かを確認する関数
-    deleteItem: Function, // コメント削除用関数
+    onDeleteItem: Function, // コメント削除用関数
     toggleCommentForm: Function, // コメントフォームの表示切替関数
     commentFormVisibility: Object, // コメントフォームの表示状態
     openUserProfile: Function, // ユーザープロフィールを開く関数
@@ -129,7 +129,7 @@ const getCommentCountRecursive = (comments) => {
                     <!-- コメント削除 -->
                     <button
                         v-if="isCommentAuthor(comment)"
-                        @click="deleteItem('comment', comment.id)"
+                        @click="onDeleteItem('comment', comment.id)"
                         class="px-2 py-1 rounded bg-red-500 text-white font-bold link-hover cursor-pointer flex items-center"
                         title="コメント削除"
                     >
@@ -163,7 +163,7 @@ const getCommentCountRecursive = (comments) => {
                         :postId="postId"
                         :formatDate="formatDate"
                         :isCommentAuthor="isCommentAuthor"
-                        :deleteItem="deleteItem"
+                        :onDeleteItem="onDeleteItem"
                         :toggleCommentForm="toggleCommentForm"
                         :commentFormVisibility="commentFormVisibility"
                         :openUserProfile="openUserProfile"

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -125,11 +125,6 @@ const closeUserProfile = () => {
     isUserProfileVisible.value = false;
 };
 
-// 投稿を選択する関数
-const selectPost = (post) => {
-    selectedPost.value = post;
-};
-
 const toggleSidebar = () => {
     sidebarVisible.value = !sidebarVisible.value;
     console.log("sidebarVisible.value:", sidebarVisible.value);

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -2,7 +2,6 @@
 import { ref, onMounted, watch } from "vue";
 import { usePage, router, Head } from "@inertiajs/vue3";
 import AuthenticatedLayout from "@/Layouts/AuthenticatedLayout.vue";
-import dayjs from "dayjs";
 import PostForm from "@/Components/PostForm.vue";
 import CommentForm from "@/Components/CommentForm.vue";
 import ParentComment from "@/Components/ParentComment.vue"; // 新しいコンポーネント
@@ -14,6 +13,7 @@ import ListForSidebar from "./Unit/ListForSidebar.vue";
 import RightSidebar from "./Unit/RightSidebar.vue";
 import LikeButton from "@/Components/LikeButton.vue";
 import QuotePostForm from "@/Components/QuotePostForm.vue";
+import { formatDate } from "@/Utils/dateUtils";
 
 // propsからページのデータを取得
 const pageProps = usePage().props; // ページのデータ
@@ -164,8 +164,6 @@ const toggleCommentForm = (postId, parentId = "post", replyToName = "") => {
         !commentFormVisibility.value[postId][parentId].isVisible;
     commentFormVisibility.value[postId][parentId].replyToName = replyToName;
 };
-
-const formatDate = (date) => dayjs(date).format("YYYY-MM-DD HH:mm:ss");
 
 // 再帰的にコメントを検索する関数
 const findCommentRecursive = (comments, commentId) => {

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -18,6 +18,7 @@ import {
     findCommentRecursive,
     deleteCommentRecursive,
 } from "@/Utils/commentUtils";
+import { restoreSelectedUnitUsers } from "@/Utils/sessionUtils";
 
 // propsからページのデータを取得
 const pageProps = usePage().props; // ページのデータ
@@ -46,24 +47,9 @@ onMounted(() => {
     selectedForumId.value = pageProps.selectedForumId;
 });
 
+// マウント時に選択されたユニットのユーザーと名前を復元
 onMounted(() => {
-    const storedUsers = sessionStorage.getItem("selectedUnitUsers");
-
-    // `storedUsers`がnullや"undefined"ではなく、有効なJSONかをチェック
-    if (storedUsers && storedUsers !== "undefined") {
-        try {
-            selectedUnitUsers.value = JSON.parse(storedUsers);
-        } catch (error) {
-            console.error("Error parsing selectedUnitUsers:", error);
-            selectedUnitUsers.value = []; // パースエラー時には空配列を代入
-        }
-    } else {
-        selectedUnitUsers.value = []; // nullまたは"undefined"の場合は空配列を代入
-    }
-
-    // 保存されたユニット名を復元
-    const storedUnitName = sessionStorage.getItem("selectedUnitName");
-    selectedUnitName.value = storedUnitName || ""; // nullの場合は空文字列を代入
+    restoreSelectedUnitUsers(selectedUnitUsers, selectedUnitName);
 });
 
 // selectedForumIdの変更を監視し、変更があるたびに投稿を再取得

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -138,18 +138,11 @@ const commentFormVisibility = ref({});
 
 // コメントフォームの表示・非表示を切り替える関数
 const toggleCommentForm = (postId, parentId = "post", replyToName = "") => {
-    // postIdでコメントフォームの状態が初期化されているか確認
-    if (!commentFormVisibility.value[postId]) {
-        commentFormVisibility.value[postId] = {};
-    }
-
-    // コメントフォームがparentIdで初期化されているか確認
-    if (!commentFormVisibility.value[postId][parentId]) {
-        commentFormVisibility.value[postId][parentId] = {
-            isVisible: false,
-            replyToName: "",
-        };
-    }
+    commentFormVisibility.value[postId] ??= {}; // 投稿IDが存在しない場合は空のオブジェクトを初期化
+    commentFormVisibility.value[postId][parentId] ??= { // 親IDが存在しない場合は初期化
+        isVisible: false,
+        replyToName: "",
+    };
 
     // コメントフォームの表示・非表示を切り替え
     commentFormVisibility.value[postId][parentId].isVisible =

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -42,13 +42,10 @@ const quotePost = (post) => {
     showPostForm.value = true;
 };
 
-// マウント時にselectedForumIdを設定
 onMounted(() => {
+    // マウント時にselectedForumIdを設定
     selectedForumId.value = pageProps.selectedForumId;
-});
-
-// マウント時に選択されたユニットのユーザーと名前を復元
-onMounted(() => {
+    // マウント時に選択されたユニットのユーザーと名前を復元
     restoreSelectedUnit(selectedUnitUsers, selectedUnitName);
 });
 

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -4,7 +4,7 @@ import { usePage, router, Head } from "@inertiajs/vue3";
 import AuthenticatedLayout from "@/Layouts/AuthenticatedLayout.vue";
 import PostForm from "@/Components/PostForm.vue";
 import CommentForm from "@/Components/CommentForm.vue";
-import ParentComment from "@/Components/ParentComment.vue"; // 新しいコンポーネント
+import ParentComment from "@/Components/ParentComment.vue";
 import Pagination from "@/Components/Pagination.vue";
 import Show from "./Users/Show.vue";
 import SearchForm from "@/Components/SearchForm.vue";
@@ -22,21 +22,29 @@ import { initSelectedForumId } from "@/Utils/initUtils";
 import { fetchPostsByForumId } from "@/Utils/fetchPosts";
 import { deleteItem } from "@/Utils/deleteItem";
 
+// props を構造分解して取得
+const {
+    posts: initialPosts = { data: [], links: [] }, // 投稿のデータ
+    auth, // ログインユーザー情報
+    units: initialUnits = [], // 部署のデータ
+    users: initialUsers = [], // ユーザーのデータ
+    selectedForumId: forumIdFromProps = null, // 選択された掲示板のID
+    search: initialSearch = "", // 検索結果の表示状態
+} = usePage().props;
+
 // propsからページのデータを取得
-const pageProps = usePage().props; // ページのデータ
-const posts = ref(pageProps.posts || { data: [], links: [] }); // 投稿のデータ
-const auth = pageProps.auth; // ログインユーザー情報
-const units = ref(pageProps.units || []); // 部署のデータ
+const posts = ref(initialPosts); // 投稿のデータ
+const units = ref(initialUnits); // 部署のデータ
 const selectedPost = ref(null); // 選択された投稿
 const isUserProfileVisible = ref(false); // ユーザーの詳細ページの表示状態
 const sidebarVisible = ref(false); // サイドバーの表示状態
-const users = pageProps.users || []; // ユーザーのデータ
+const users = ref(initialUsers); // ユーザーのデータ
 const sidebar = ref(null); // サイドバーのコンポーネントインスタンス
-const selectedForumId = ref(pageProps.selectedForumId || null); // 選択された掲示板のID
+const selectedForumId = ref(forumIdFromProps); // 選択された掲示板のID
 const selectedUnitUsers = ref([]); // 選択されたユニットのユーザーリスト
 const selectedUnitName = ref(""); // 選択されたユニットの名前
-const search = ref(pageProps.search || ""); // 検索結果の表示状態
-const quotedPost = ref(null);
+const search = ref(initialSearch); // 検索結果の表示状態
+const quotedPost = ref(null); // 引用投稿
 const showPostForm = ref(false); // 引用投稿フォームの表示制御
 
 const quotePost = (post) => {
@@ -46,7 +54,7 @@ const quotePost = (post) => {
 
 onMounted(() => {
     // マウント時にselectedForumIdを初期化
-    initSelectedForumId(selectedForumId, pageProps);
+    initSelectedForumId(selectedForumId);
     // マウント時に選択されたユニットのユーザーと名前を復元
     restoreSelectedUnit(selectedUnitUsers, selectedUnitName);
 });

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -74,30 +74,27 @@ const onUserSelected = (user) => {
 // ユニット選択イベント
 const onForumSelected = async (unitId) => {
     const unit = units.value.find((u) => u.id === unitId);
-    if (unit && unit.forum) {
-        selectedForumId.value = unit.forum.id;
-        selectedUnitName.value = unit.name; // 選択されたユニットの名前を設定
-        localStorage.setItem("lastSelectedUnitId", unitId);
-
-        // ユニット名を保存
-        sessionStorage.setItem("selectedUnitName", selectedUnitName.value);
-
-        // ユーザーリストを取得して一時保存
-        selectedUnitUsers.value = users.filter(
-            (user) => user.unit_id === unitId
-        );
-        sessionStorage.setItem(
-            "selectedUnitUsers",
-            JSON.stringify(selectedUnitUsers.value)
-        );
-
-        // 掲示板を更新
-        router.get(route("forum.index", { forum_id: selectedForumId.value }), {
-            preserveState: false, // 状態を再レンダリング
-        });
-    } else {
+    if (!unit || !unit.forum) {
         console.error("対応する掲示板が見つかりませんでした");
+        return;
     }
+
+    // users が配列であることを確認しつつフィルタリング
+    const filteredUsers = Array.isArray(users.value)
+        ? users.value.filter((user) => user.unit_id === unitId)
+        : [];
+
+    selectedForumId.value = unit.forum.id;
+    selectedUnitName.value = unit.name;
+    selectedUnitUsers.value = filteredUsers;
+
+    sessionStorage.setItem("selectedUnitName", selectedUnitName.value);
+    sessionStorage.setItem("selectedUnitUsers", JSON.stringify(filteredUsers));
+    localStorage.setItem("lastSelectedUnitId", unitId);
+
+    router.get(route("forum.index", { forum_id: selectedForumId.value }), {
+        preserveState: false,
+    });
 };
 
 const onPageChange = (url) => {
@@ -139,7 +136,8 @@ const commentFormVisibility = ref({});
 // コメントフォームの表示・非表示を切り替える関数
 const toggleCommentForm = (postId, parentId = "post", replyToName = "") => {
     commentFormVisibility.value[postId] ??= {}; // 投稿IDが存在しない場合は空のオブジェクトを初期化
-    commentFormVisibility.value[postId][parentId] ??= { // 親IDが存在しない場合は初期化
+    commentFormVisibility.value[postId][parentId] ??= {
+        // 親IDが存在しない場合は初期化
         isVisible: false,
         replyToName: "",
     };

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -19,6 +19,7 @@ import {
     deleteCommentRecursive,
 } from "@/Utils/commentUtils";
 import { restoreSelectedUnit } from "@/Utils/sessionUtils";
+import { initSelectedForumId } from "@/Utils/initUtils";
 
 // propsからページのデータを取得
 const pageProps = usePage().props; // ページのデータ
@@ -43,8 +44,8 @@ const quotePost = (post) => {
 };
 
 onMounted(() => {
-    // マウント時にselectedForumIdを設定
-    selectedForumId.value = pageProps.selectedForumId;
+    // マウント時にselectedForumIdを初期化
+    initSelectedForumId(selectedForumId, pageProps);
     // マウント時に選択されたユニットのユーザーと名前を復元
     restoreSelectedUnit(selectedUnitUsers, selectedUnitName);
 });

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -20,6 +20,7 @@ import {
 } from "@/Utils/commentUtils";
 import { restoreSelectedUnit } from "@/Utils/sessionUtils";
 import { initSelectedForumId } from "@/Utils/initUtils";
+import { fetchPostsByForumId } from "@/Utils/fetchPosts";
 
 // propsからページのデータを取得
 const pageProps = usePage().props; // ページのデータ
@@ -52,12 +53,7 @@ onMounted(() => {
 
 // selectedForumIdの変更を監視し、変更があるたびに投稿を再取得
 watch(selectedForumId, (newForumId) => {
-    if (newForumId) {
-        router.get(route("forum.index", { forum_id: newForumId }), {
-            preserveState: true,
-            only: ["posts"],
-        });
-    }
+    fetchPostsByForumId(router, newForumId);
 });
 
 // サイドバーのユーザー選択イベントを受け取る関数

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -18,7 +18,7 @@ import {
     findCommentRecursive,
     deleteCommentRecursive,
 } from "@/Utils/commentUtils";
-import { restoreSelectedUnitUsers } from "@/Utils/sessionUtils";
+import { restoreSelectedUnit } from "@/Utils/sessionUtils";
 
 // propsからページのデータを取得
 const pageProps = usePage().props; // ページのデータ
@@ -49,7 +49,7 @@ onMounted(() => {
 
 // マウント時に選択されたユニットのユーザーと名前を復元
 onMounted(() => {
-    restoreSelectedUnitUsers(selectedUnitUsers, selectedUnitName);
+    restoreSelectedUnit(selectedUnitUsers, selectedUnitName);
 });
 
 // selectedForumIdの変更を監視し、変更があるたびに投稿を再取得

--- a/resources/js/Utils/commentUtils.js
+++ b/resources/js/Utils/commentUtils.js
@@ -1,0 +1,38 @@
+// 再帰的にコメントを検索する関数
+export const findCommentRecursive = (comments, commentId) => {
+    for (let i = 0; i < comments.length; i++) {
+        if (comments[i].id === commentId) {
+            return comments[i];
+        }
+        if (comments[i].children && comments[i].children.length > 0) {
+            const foundComment = findCommentRecursive(
+                comments[i].children,
+                commentId
+            );
+            if (foundComment) {
+                return foundComment;
+            }
+        }
+    }
+    return null;
+};
+
+// 再帰的にコメントを削除
+export const deleteCommentRecursive = (comments, commentId) => {
+    for (let i = 0; i < comments.length; i++) {
+        if (comments[i].id === commentId) {
+            comments.splice(i, 1); // コメント削除
+            return true; // 削除成功
+        }
+        if (comments[i].children && comments[i].children.length > 0) {
+            const deleted = deleteCommentRecursive(
+                comments[i].children,
+                commentId
+            );
+            if (deleted) {
+                return true; // 子コメント削除成功
+            }
+        }
+    }
+    return false; // 削除対象が見つからなかった場合
+};

--- a/resources/js/Utils/dateUtils.js
+++ b/resources/js/Utils/dateUtils.js
@@ -1,0 +1,3 @@
+import dayjs from "dayjs";
+
+export const formatDate = (date) => dayjs(date).format("YYYY-MM-DD HH:mm:ss");

--- a/resources/js/Utils/deleteItem.js
+++ b/resources/js/Utils/deleteItem.js
@@ -1,7 +1,12 @@
-
 import { router } from "@inertiajs/vue3";
 import { getCsrfToken } from "@/Utils/csrf";
 
+/**
+ * 汎用的な削除ロジック
+ * @param {string} type 削除対象の種類 ('post', 'comment', 'user' など)
+ * @param {number|string} id 削除対象のID
+ * @param {Function} onSuccessCallback 成功時に実行するコールバック関数
+ */
 export const deleteItem = (type, id, onSuccessCallback) => {
     const confirmMessage =
         type === "post"

--- a/resources/js/Utils/fetchPosts.js
+++ b/resources/js/Utils/fetchPosts.js
@@ -1,0 +1,8 @@
+export const fetchPostsByForumId = (router, forumId) => {
+    if (forumId) {
+        router.get(route("forum.index", { forum_id: forumId }), {
+            preserveState: true,
+            only: ["posts"],
+        });
+    }
+};

--- a/resources/js/Utils/initUtils.js
+++ b/resources/js/Utils/initUtils.js
@@ -1,3 +1,10 @@
-export const initSelectedForumId = (selectedForumId, pageProps) => {
-    selectedForumId.value = pageProps.selectedForumId || null;
+import { usePage } from "@inertiajs/vue3";
+
+export const initSelectedForumId = (selectedForumId) => {
+    const pageProps = usePage().props;
+    if (!selectedForumId) {
+        console.warn("selectedForumId が無効です");
+        return;
+    }
+    selectedForumId.value = pageProps?.selectedForumId || null; // デフォルト値を設定
 };

--- a/resources/js/Utils/initUtils.js
+++ b/resources/js/Utils/initUtils.js
@@ -1,0 +1,3 @@
+export const initSelectedForumId = (selectedForumId, pageProps) => {
+    selectedForumId.value = pageProps.selectedForumId || null;
+};

--- a/resources/js/Utils/sessionUtils.js
+++ b/resources/js/Utils/sessionUtils.js
@@ -1,22 +1,26 @@
-export const restoreSelectedUnitUsers = (
-    selectedUnitUsers,
-    selectedUnitName
-) => {
-    const storedUsers = sessionStorage.getItem("selectedUnitUsers");
+const SESSION_KEYS = {
+    SELECTED_UNIT_USERS: "selectedUnitUsers",
+    SELECTED_UNIT_NAME: "selectedUnitName",
+};
 
-    // `storedUsers`がnullや"undefined"ではなく、有効なJSONかをチェック
+export const restoreSelectedUnit = (selectedUnitUsers, selectedUnitName) => {
+    const storedUsers = sessionStorage.getItem(
+        SESSION_KEYS.SELECTED_UNIT_USERS
+    );
+
     if (storedUsers && storedUsers !== "undefined") {
         try {
             selectedUnitUsers.value = JSON.parse(storedUsers);
         } catch (error) {
             console.error("Error parsing selectedUnitUsers:", error);
-            selectedUnitUsers.value = []; // パースエラー時には空配列を代入
+            selectedUnitUsers.value = [];
         }
     } else {
-        selectedUnitUsers.value = []; // nullまたは"undefined"の場合は空配列を代入
+        selectedUnitUsers.value = [];
     }
 
-    // 保存されたユニット名を復元
-    const storedUnitName = sessionStorage.getItem("selectedUnitName");
-    selectedUnitName.value = storedUnitName || ""; // nullの場合は空文字列を代入
+    const storedUnitName = sessionStorage.getItem(
+        SESSION_KEYS.SELECTED_UNIT_NAME
+    );
+    selectedUnitName.value = storedUnitName || "";
 };

--- a/resources/js/Utils/sessionUtils.js
+++ b/resources/js/Utils/sessionUtils.js
@@ -1,0 +1,22 @@
+export const restoreSelectedUnitUsers = (
+    selectedUnitUsers,
+    selectedUnitName
+) => {
+    const storedUsers = sessionStorage.getItem("selectedUnitUsers");
+
+    // `storedUsers`がnullや"undefined"ではなく、有効なJSONかをチェック
+    if (storedUsers && storedUsers !== "undefined") {
+        try {
+            selectedUnitUsers.value = JSON.parse(storedUsers);
+        } catch (error) {
+            console.error("Error parsing selectedUnitUsers:", error);
+            selectedUnitUsers.value = []; // パースエラー時には空配列を代入
+        }
+    } else {
+        selectedUnitUsers.value = []; // nullまたは"undefined"の場合は空配列を代入
+    }
+
+    // 保存されたユニット名を復元
+    const storedUnitName = sessionStorage.getItem("selectedUnitName");
+    selectedUnitName.value = storedUnitName || ""; // nullの場合は空文字列を代入
+};


### PR DESCRIPTION
## 目的

本プルリクエストでは、以下の目的を達成するためにコードをリファクタリングしました：

1. 冗長なロジックを排除し、Vue コンポーネントの責務を明確化。
2. ユーティリティ関数の活用により、コードの再利用性と保守性を向上。
3. フォーラムやコメント操作に関わる処理の一貫性と安全性を向上。

***

## 達成条件

- `Forum.vue` 内の複雑なロジックを適切に分離し、可読性を向上させる。
- 投稿やコメント削除、選択処理を安全かつ簡潔に実装。
- `onMounted` やイベント処理を整理し、コードをシンプルに保つ。

***

## 実装の概要

### **1. コメントフォームの初期化処理を簡潔化**

- コメントフォームの状態初期化ロジックに `nullish coalescing assignment（??=）` を導入。
- 冗長なコードを削減し、シンプルで可読性の高い実装に変更。

変更後の例：

```
commentFormVisibility.value[postId] ??= {}; 
commentFormVisibility.value[postId][parentId] ??= {
    isVisible: false,
    replyToName: "",
};
```

***

### **2. ユニット選択時の処理を改善**

- ユニット選択イベントで `users` 配列のチェックとフィルタリング処理を追加。
- 不正なデータやエラーの発生を防ぎ、安全性を向上。

変更後の例：

```
const filteredUsers = Array.isArray(users.value)
    ? users.value.filter((user) => user.unit_id === unitId)
    : [];
selectedUnitUsers.value = filteredUsers;
selectedUnitName.value = unit.name;
```

***

### **3. selectedForumId の初期化処理をユーティリティ関数に分離**

- `selectedForumId` の初期化ロジックを専用のユーティリティ関数 `initSelectedForumId` に移行。
- これにより、Vue コンポーネント外での再利用が可能になり、コードが整理されました。

移行後の例：

```
export const initSelectedForumId = (selectedForumId) => {
    const pageProps = usePage().props;
    selectedForumId.value = pageProps?.selectedForumId || null;
};
```

***

### **4. 投稿とコメント削除ロジックを共通化**

- 投稿とコメント削除処理を `deleteItem` ユーティリティに統一。
- 再利用性を向上させ、削除時のコールバックを柔軟に設定可能にしました。

移行後の例：

```
export const deleteItem = (type, id, callback) => {
    axios.delete(route(`${type}.destroy`, id)).then(() => {
        callback(id);
    });
};
```

***

### **5. onMounted 内の処理を統合**

- `onMounted` 内で行っていた処理を整理し、一箇所でまとめて管理するよう変更。
- 初期化処理を関数化し、ライフサイクル管理を簡潔にしました。

変更後の例：

```
onMounted(() => {
    initSelectedForumId(selectedForumId);
    restoreSelectedUnit(selectedUnitUsers, selectedUnitName);
});
```

***

## レビューしてほしいところ

1. コメントフォームやユニット選択処理の簡潔化により、機能に影響がないか。
2. `deleteItem` の統一的な実装が安全かつ拡張性を持っているか。
3. `initSelectedForumId` のユーティリティ関数化が、他コンポーネントでの利用を見越した設計になっているか。

***

## 不安に思っていること

- `deleteItem` のコールバック設定が複雑化した場合に、現状の設計で十分対応できるか。
- 今後 `fetchPostsByForumId` を他の箇所でも活用する際、期待通りに動作するか。

***

## 保留していること

- ユーティリティ関数に対する単体テストの追加。
- コメントフォームや削除処理を他コンポーネントに適用する際の追加調整。