### PR TITLE
掲示板操作性と表示改善に関する修正

### DIFF
--- a/resources/js/Components/ChildComment.vue
+++ b/resources/js/Components/ChildComment.vue
@@ -10,6 +10,7 @@ const props = defineProps({
     toggleCommentForm: Function, // コメントフォームの表示切替関数
     commentFormVisibility: Object, // コメントフォームの表示状態
     openUserProfile: Function, // ユーザープロフィールを開く関数
+    selectedForumId: Number, // 選択されたフォーラムのID
 });
 </script>
 
@@ -106,6 +107,7 @@ const props = defineProps({
                     :toggleCommentForm="toggleCommentForm"
                     :commentFormVisibility="commentFormVisibility"
                     :openUserProfile="openUserProfile"
+                    :selectedForumId="selectedForumId"
                 />
             </div>
         </div>

--- a/resources/js/Components/CommentForm.vue
+++ b/resources/js/Components/CommentForm.vue
@@ -7,6 +7,7 @@ const props = defineProps({
     postId: Number, // 親投稿のID
     parentId: { type: Number, default: null }, // 親コメントのID
     replyToName: { type: String, default: "" }, // 返信先のユーザー名
+    selectedForumId: Number, // 選択されたフォーラムのID
 });
 
 // コメントデータを管理するref
@@ -41,7 +42,9 @@ const submitComment = () => {
                     parent_id: props.parentId,
                     message: "",
                 };
-                router.get(route("forum.index")); // getで履歴を置き換え
+                router.get(
+                    route("forum.index", { forum_id: props.selectedForumId })
+                ); // getで履歴を置き換え
             },
             onError: (errors) => {
                 console.error("コメントの投稿に失敗しました:", errors);

--- a/resources/js/Components/ParentComment.vue
+++ b/resources/js/Components/ParentComment.vue
@@ -13,6 +13,7 @@ const props = defineProps({
     toggleCommentForm: Function, // コメントフォームの表示切替関数
     commentFormVisibility: Object, // コメントフォームの表示状態
     openUserProfile: Function, // ユーザープロフィールを開く関数
+    selectedForumId: Number, // 選択されたフォーラムのID
 });
 
 // 子コメントの折りたたみ状態を管理
@@ -144,6 +145,7 @@ const getCommentCountRecursive = (comments) => {
                     "
                     :postId="postId"
                     :parentId="comment.id"
+                    :selectedForumId="selectedForumId"
                     :replyToName="comment.user?.name || ''"
                     class="mt-4"
                     title="返信"
@@ -167,6 +169,7 @@ const getCommentCountRecursive = (comments) => {
                         :toggleCommentForm="toggleCommentForm"
                         :commentFormVisibility="commentFormVisibility"
                         :openUserProfile="openUserProfile"
+                        :selectedForumId="selectedForumId"
                     />
                 </div>
             </div>

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -158,7 +158,7 @@ const onDeleteItem = (type, id) => {
             handleCommentDeletion(deletedId);
         }
 
-        router.get(route("forum.index"), {
+        router.get(route("forum.index", { forum_id: selectedForumId.value }), {
             preserveState: false,
             preserveScroll: true,
         });

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -472,6 +472,7 @@ const isCommentAuthor = (comment) => {
                         :toggleCommentForm="toggleCommentForm"
                         :commentFormVisibility="commentFormVisibility"
                         :openUserProfile="openUserProfile"
+                        :selectedForumId="Number(selectedForumId)"
                     />
                 </div>
 

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -448,6 +448,7 @@ const isCommentAuthor = (comment) => {
                             "
                             :postId="post.id"
                             :parentId="null"
+                            :selected-forum-id="Number(selectedForumId)"
                             :replyToName="
                                 commentFormVisibility[post.id]?.['post']
                                     ?.replyToName

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -275,6 +275,7 @@ const isCommentAuthor = (comment) => {
 
                 <!-- 投稿一覧 -->
                 <div
+                    v-if="posts.data && posts.data.length > 0"
                     v-for="post in posts.data"
                     :key="post.id"
                     class="bg-white rounded-md shadow-md mb-6 p-4"
@@ -471,6 +472,14 @@ const isCommentAuthor = (comment) => {
                         :commentFormVisibility="commentFormVisibility"
                         :openUserProfile="openUserProfile"
                     />
+                </div>
+
+                <!-- 投稿がない場合のメッセージ -->
+                <div
+                    v-else
+                    class="text-center text-gray-500 text-lg font-semibold mt-6"
+                >
+                    投稿がありません。
                 </div>
 
                 <!-- 下部ページネーション -->

--- a/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
+++ b/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
@@ -100,7 +100,7 @@ const handleOpenIconEdit = () => {
                 <button
                     type="button"
                     @click="handleOpenIconEdit"
-                    class="absolute inset-0 w-24 h-24 flex items-center justify-center bg-gray-800 text-white p-1 rounded-full hover:bg-gray-600 transition-opacity duration-300"
+                    class="absolute inset-0 w-24 h-24 flex items-center justify-center bg-transparent text-white p-1 rounded-ful transition-opacity duration-300"
                     title="プロフィール画像を編集"
                 >
                     <!-- プロフィール画像 -->
@@ -115,7 +115,7 @@ const handleOpenIconEdit = () => {
                                 : 'https://via.placeholder.com/100'
                         "
                         alt="ユーザーのプロフィール写真"
-                        class="w-24 h-24 rounded-full object-cover transition-opacity duration-300 group-hover:opacity-70"
+                        class="w-full h-full rounded-full object-cover transition-opacity duration-300 group-hover:opacity-70"
                     />
 
                     <!-- ペンのマーク -->


### PR DESCRIPTION
## 目的

本プルリクエストでは、掲示板の操作性と表示品質を向上させるため、以下の問題点を修正しました。

1. プロフィール画像のスタイル不整合を修正し、表示品質を向上。
2. 投稿がない場合に「投稿がありません。」と適切に表示。
3. 投稿・コメント後に選択中の掲示板から意図せずリダイレクトされる問題を解決。
4. 子コメントの返信後にも同様の問題が発生する不具合を修正。

これにより、ユーザー体験の向上と掲示板操作の一貫性を実現します。

## 達成条件

- プロフィール画像のスタイルがレスポンシブ対応され、全画面で適切に表示されること。
- 投稿がない場合、ユーザーにわかりやすいフィードバックが表示されること。
- 投稿・コメント後も、選択した掲示板が維持されること。
- 子コメントへの返信後も意図しない掲示板にリダイレクトされないこと。

## 実装の概要

### 1. プロフィール画像の幅とスタイルを調整
- **変更点**:
  - 画像の幅を `w-full` に設定し、スタイルを統一しました。
  - レスポンシブ対応を考慮し、デバイス間での見た目を改善。

### 2. 投稿がない場合の「投稿がありません。」メッセージを追加
- **変更点**:
  - 投稿一覧表示部分に条件分岐を追加。
  - 投稿がない場合、「投稿がありません。」と表示。

### 3. 投稿後に意図しない掲示板にリダイレクトされる問題を修正
- **変更点**:
  - `CommentForm` に `selectedForumId` プロパティを追加。
  - `Number(selectedForumId)` で正確な型を渡すように変更。
  - サーバーリクエストでクエリパラメータに `forum_id` を渡し、正しい掲示板を維持。

### 4. 子コメントの返信後に意図しない掲示板にリダイレクトされる問題を修正
- **変更点**:
  - `ParentComment.vue` と `ChildComment.vue` に `selectedForumId` を `props` として追加。
  - `Forum.vue` から `selectedForumId` を各コメントコンポーネントに渡す処理を実装。
  - 型を明示的に `Number` に指定し、型不一致エラーを防止。

## レビューしてほしいところ

1. プロフィール画像のスタイル変更がすべての画面サイズで正しく機能しているか。
2. 投稿がない場合のメッセージが意図通りに表示されているか。
3. 投稿・コメント後のリダイレクトが正しい掲示板に留まる動作を実現しているか。
4. 子コメント返信時にもリダイレクトの問題が解消されているか。

## 不安に思っていること

- `selectedForumId` の管理が各コンポーネントで冗長になっていないか。
- クライアント側でのローカルデータ更新が抜け漏れなく実装されているか。

## 保留していること

- コメントの非同期追加処理の最適化（完全なリアルタイム対応は未検討）。
- 必要に応じた追加テストケースの実装。
