### PR TITLE
掲示板のコメント・投稿機能と削除処理の改善、画像スタイルの統一によるUI/UX向上

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,3 +1,11 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+
+img {
+    max-width: 100%; /* 親要素の幅に合わせる */
+    height: auto; /* アスペクト比を保ちながら高さを自動調整 */
+    object-fit: cover; /* アスペクト比を維持しながら、親要素に収める */
+    border-radius: 8px; /* デザインとして角を丸める（オプション） */
+}

--- a/resources/js/Components/ChildComment.vue
+++ b/resources/js/Components/ChildComment.vue
@@ -91,7 +91,9 @@ const props = defineProps({
                     "
                     :postId="postId"
                     :parentId="comment.id"
-                    :replyToName="comment.parent_id ? comment.user?.name : ''"
+                    :selected-forum-id="selectedForumId"
+                    :replyToName="comment.user?.name || ''"
+                    @cancel="toggleCommentForm(postId, comment.id)"
                     class="mt-4"
                 />
             </div>

--- a/resources/js/Components/ChildComment.vue
+++ b/resources/js/Components/ChildComment.vue
@@ -67,7 +67,7 @@ const props = defineProps({
                                 comment.user?.name || 'Unknown'
                             )
                         "
-                        class="px-2 py-1 rounded bg-green-500 text-white font-bold link-hover cursor-pointer"
+                        class="px-4 py-2 rounded-md bg-green-100 text-green-700 transition hover:bg-green-300 hover:text-white cursor-pointer flex items-center"
                         title="返信"
                     >
                         <i class="bi bi-reply"></i>
@@ -77,7 +77,7 @@ const props = defineProps({
                     <button
                         v-if="isCommentAuthor(comment)"
                         @click="onDeleteItem('comment', comment.id)"
-                        class="px-2 py-1 rounded bg-red-500 text-white font-bold link-hover cursor-pointer"
+                        class="px-4 py-2 rounded-md bg-red-100 text-red-700 transition hover:bg-red-300 hover:text-white cursor-pointer flex items-center"
                         title="コメントの削除"
                     >
                         <i class="bi bi-trash"></i>

--- a/resources/js/Components/CommentForm.vue
+++ b/resources/js/Components/CommentForm.vue
@@ -55,24 +55,23 @@ const submitComment = () => {
 </script>
 
 <template>
-    <form @submit.prevent="submitComment">
-        <!-- メッセージ入力 -->
-        <textarea
-            v-model="commentData.message"
-            class="border-gray-300 rounded-md mt-4 px-2 w-full"
-            required
-            :placeholder="
-                commentData.replyToName
-                    ? `@${commentData.replyToName} にメッセージを送信`
-                    : 'メッセージを入力してください'
-            "
-        ></textarea>
+    <form @submit.prevent="submitComment" class="relative">
+        <!-- メッセージ入力エリアと送信ボタンを横並びに -->
+        <div class="flex items-start gap-2">
+            <textarea
+                v-model="commentData.message"
+                class="flex-grow border-gray-300 rounded-md px-2 py-1 text-sm min-h-[2.5rem] max-h-32"
+                required
+                :placeholder="
+                    commentData.replyToName
+                        ? `@${commentData.replyToName} にメッセージを送信`
+                        : 'メッセージを入力してください'
+                "
+            ></textarea>
 
-        <!-- 送信ボタン -->
-        <div class="flex justify-end mt-2">
             <button
                 type="submit"
-                class="my-2 px-4 py-2 rounded-md bg-blue-100 text-blue-700 transition hover:bg-blue-300 hover:text-white cursor-pointer"
+                class="px-3 py-1 rounded-md bg-blue-100 text-blue-700 transition hover:bg-blue-300 hover:text-white cursor-pointer h-[2.5rem]"
             >
                 <i class="bi bi-send"></i>
             </button>

--- a/resources/js/Components/CommentForm.vue
+++ b/resources/js/Components/CommentForm.vue
@@ -84,11 +84,11 @@ const handleCancel = () => {
     commentData.value = {
         post_id: props.postId,
         parent_id: props.parentId,
-        message: '',
+        message: "",
         replyToName: props.replyToName,
     };
     // 親コンポーネントにキャンセルイベントを発行
-    emit('cancel');
+    emit("cancel");
 };
 </script>
 
@@ -106,15 +106,15 @@ const handleCancel = () => {
                 <button
                     type="button"
                     @click="handleCancel"
-                    class="px-4 py-2 rounded-md bg-gray-100 text-gray-700 hover:bg-gray-200"
+                    class="my-2 py-2 px-4 rounded-md bg-gray-300 text-gray-700 font-medium transition hover:bg-gray-500 hover:text-white focus:outline-none focus:shadow-outline"
                 >
                     <i class="bi bi-x-lg"></i>
                 </button>
                 <button
                     type="submit"
-                    class="px-4 py-2 rounded-md bg-blue-500 text-white hover:bg-blue-600"
+                    class="my-2 px-4 py-2 rounded-md bg-blue-100 text-blue-700 transition hover:bg-blue-300 hover:text-white cursor-pointer"
                 >
-                    送信
+                    <i class="bi bi-send"></i>
                 </button>
             </div>
         </form>

--- a/resources/js/Components/CommentForm.vue
+++ b/resources/js/Components/CommentForm.vue
@@ -94,7 +94,6 @@ const handleCancel = () => {
 
 <template>
     <div class="mt-4">
-        <h3 class="font-bold mb-2">{{ title }}</h3>
         <form @submit.prevent="submitComment">
             <textarea
                 v-model="commentData.message"

--- a/resources/js/Components/CommentForm.vue
+++ b/resources/js/Components/CommentForm.vue
@@ -72,7 +72,7 @@ const submitComment = () => {
         <div class="flex justify-end mt-2">
             <button
                 type="submit"
-                class="px-2 py-1 rounded bg-blue-500 text-white font-bold link-hover cursor-pointer"
+                class="my-2 px-4 py-2 rounded-md bg-blue-100 text-blue-700 transition hover:bg-blue-300 hover:text-white cursor-pointer"
             >
                 <i class="bi bi-send"></i>
             </button>

--- a/resources/js/Components/CommentForm.vue
+++ b/resources/js/Components/CommentForm.vue
@@ -1,14 +1,34 @@
 <script setup>
-import { ref, onMounted } from "vue";
+import { ref, defineProps, defineEmits, onMounted } from "vue";
 import { router } from "@inertiajs/vue3";
 import { getCsrfToken } from "@/Utils/csrf";
 
 const props = defineProps({
-    postId: Number, // 親投稿のID
-    parentId: { type: Number, default: null }, // 親コメントのID
-    replyToName: { type: String, default: "" }, // 返信先のユーザー名
-    selectedForumId: Number, // 選択されたフォーラムのID
+    postId: {
+        type: Number,
+        required: true,
+    },
+    parentId: {
+        type: Number,
+        default: null,
+    },
+    selectedForumId: {
+        type: Number,
+        required: true,
+    },
+    replyToName: {
+        type: String,
+        default: "",
+    },
+    title: {
+        type: String,
+        default: "返信",
+    },
 });
+
+const emit = defineEmits(["cancel"]);
+const message = ref("");
+const placeholder = ref(`@${props.replyToName} さんへの返信を入力`);
 
 // コメントデータを管理するref
 const commentData = ref({
@@ -57,29 +77,46 @@ const submitComment = () => {
         }
     );
 };
+
+// キャンセルハンドラーを追加
+const handleCancel = () => {
+    // フォームをリセット
+    commentData.value = {
+        post_id: props.postId,
+        parent_id: props.parentId,
+        message: '',
+        replyToName: props.replyToName,
+    };
+    // 親コンポーネントにキャンセルイベントを発行
+    emit('cancel');
+};
 </script>
 
 <template>
-    <form @submit.prevent="submitComment" class="relative">
-        <!-- メッセージ入力エリアと送信ボタンを横並びに -->
-        <div class="flex items-start gap-2">
+    <div class="mt-4">
+        <h3 class="font-bold mb-2">{{ title }}</h3>
+        <form @submit.prevent="submitComment">
             <textarea
                 v-model="commentData.message"
-                class="flex-grow border-gray-300 rounded-md px-2 py-1 text-sm min-h-[2.5rem] max-h-32"
-                required
-                :placeholder="
-                    commentData.replyToName
-                        ? `@${commentData.replyToName} にメッセージを送信`
-                        : 'メッセージを入力してください'
-                "
+                class="w-full p-2 border rounded-md"
+                :placeholder="placeholder"
+                rows="3"
             ></textarea>
-
-            <button
-                type="submit"
-                class="px-3 py-1 rounded-md bg-blue-100 text-blue-700 transition hover:bg-blue-300 hover:text-white cursor-pointer h-[2.5rem]"
-            >
-                <i class="bi bi-send"></i>
-            </button>
-        </div>
-    </form>
+            <div class="flex justify-end space-x-2 mt-2">
+                <button
+                    type="button"
+                    @click="handleCancel"
+                    class="px-4 py-2 rounded-md bg-gray-100 text-gray-700 hover:bg-gray-200"
+                >
+                    <i class="bi bi-x-lg"></i>
+                </button>
+                <button
+                    type="submit"
+                    class="px-4 py-2 rounded-md bg-blue-500 text-white hover:bg-blue-600"
+                >
+                    送信
+                </button>
+            </div>
+        </form>
+    </div>
 </template>

--- a/resources/js/Components/CommentForm.vue
+++ b/resources/js/Components/CommentForm.vue
@@ -28,13 +28,13 @@ onMounted(() => {
 // コメントの送信処理
 const submitComment = () => {
     commentData.value._token = getCsrfToken();
-    commentData.value.post_id = props.postId; // 送信対象の投稿IDをセット
+    commentData.value.post_id = props.postId;
 
-    // コメントデータをサーバーに送信
     router.post(
         route("comment.store", { post: props.postId }),
         commentData.value,
         {
+            preserveScroll: true,
             onSuccess: () => {
                 // フォームのリセット
                 commentData.value = {
@@ -42,9 +42,14 @@ const submitComment = () => {
                     parent_id: props.parentId,
                     message: "",
                 };
-                router.get(
-                    route("forum.index", { forum_id: props.selectedForumId })
-                ); // getで履歴を置き換え
+
+                router.visit(
+                    route("forum.index", { forum_id: props.selectedForumId }),
+                    {
+                        preserveScroll: true,
+                        replace: true,
+                    }
+                );
             },
             onError: (errors) => {
                 console.error("コメントの投稿に失敗しました:", errors);

--- a/resources/js/Components/CommentForm.vue
+++ b/resources/js/Components/CommentForm.vue
@@ -59,7 +59,7 @@ const submitComment = () => {
         <!-- メッセージ入力 -->
         <textarea
             v-model="commentData.message"
-            class="border rounded mt-4 px-2 w-full"
+            class="border-gray-300 rounded-md mt-4 px-2 w-full"
             required
             :placeholder="
                 commentData.replyToName

--- a/resources/js/Components/ParentComment.vue
+++ b/resources/js/Components/ParentComment.vue
@@ -23,7 +23,17 @@ const collapsedComments = ref({});
 onMounted(() => {
     props.comments.forEach((comment) => {
         if (comment.children && comment.children.length > 0) {
-            collapsedComments.value[comment.id] = true;
+            // 1週間（7日）をミリ秒で計算
+            const oneWeek = 7 * 24 * 60 * 60 * 1000;
+            const commentDate = new Date(comment.created_at);
+            const now = new Date();
+
+            // コメントが1週間以上前の場合は折りたたむ
+            if (now - commentDate > oneWeek) {
+                collapsedComments.value[comment.id] = false;
+            } else {
+                collapsedComments.value[comment.id] = true;
+            }
         }
     });
 });

--- a/resources/js/Components/ParentComment.vue
+++ b/resources/js/Components/ParentComment.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref } from "vue";
+import { ref, onMounted } from "vue";
 import ChildComment from "./ChildComment.vue";
 import CommentForm from "./CommentForm.vue"; // CommentFormをインポート
 import LikeButton from "./LikeButton.vue";
@@ -18,6 +18,15 @@ const props = defineProps({
 
 // 子コメントの折りたたみ状態を管理
 const collapsedComments = ref({});
+
+// コンポーネントのマウント時に初期値を設定
+onMounted(() => {
+    props.comments.forEach((comment) => {
+        if (comment.children && comment.children.length > 0) {
+            collapsedComments.value[comment.id] = true;
+        }
+    });
+});
 
 // 子コメントの表示・非表示を切り替える関数
 const toggleCollapse = (commentId) => {

--- a/resources/js/Components/ParentComment.vue
+++ b/resources/js/Components/ParentComment.vue
@@ -21,7 +21,12 @@ const collapsedComments = ref({});
 
 // 子コメントの表示・非表示を切り替える関数
 const toggleCollapse = (commentId) => {
-    collapsedComments.value[commentId] = !collapsedComments.value[commentId];
+    if (!(commentId in collapsedComments.value)) {
+        collapsedComments.value[commentId] = true;
+    } else {
+        collapsedComments.value[commentId] =
+            !collapsedComments.value[commentId];
+    }
 };
 
 // 再帰的にすべての子コメントを含めてコメント数を取得する関数
@@ -156,7 +161,8 @@ const getCommentCountRecursive = (comments) => {
                     v-if="
                         comment.children &&
                         comment.children.length > 0 &&
-                        collapsedComments[comment.id]
+                        (!(comment.id in collapsedComments) ||
+                            collapsedComments[comment.id])
                     "
                     class="mt-4 ml-4 border-l-2 border-gray-300 pl-2"
                 >

--- a/resources/js/Components/ParentComment.vue
+++ b/resources/js/Components/ParentComment.vue
@@ -122,7 +122,7 @@ const getCommentCountRecursive = (comments) => {
                                 comment.user?.name || 'Unknown'
                             )
                         "
-                        class="px-2 py-1 rounded bg-green-500 text-white font-bold link-hover cursor-pointer flex items-center"
+                        class="px-4 py-2 rounded-md bg-green-100 text-green-700 transition hover:bg-green-300 hover:text-white cursor-pointer flex items-center"
                         title="返信"
                     >
                         <i class="bi bi-reply"></i>
@@ -131,7 +131,7 @@ const getCommentCountRecursive = (comments) => {
                     <button
                         v-if="isCommentAuthor(comment)"
                         @click="onDeleteItem('comment', comment.id)"
-                        class="px-2 py-1 rounded bg-red-500 text-white font-bold link-hover cursor-pointer flex items-center"
+                        class="px-4 py-2 rounded-md bg-red-100 text-red-700 transition hover:bg-red-300 hover:text-white cursor-pointer flex items-center"
                         title="コメント削除"
                     >
                         <i class="bi bi-trash"></i>

--- a/resources/js/Components/ParentComment.vue
+++ b/resources/js/Components/ParentComment.vue
@@ -150,10 +150,10 @@ const getCommentCountRecursive = (comments) => {
                     "
                     :postId="postId"
                     :parentId="comment.id"
-                    :selectedForumId="selectedForumId"
+                    :selected-forum-id="selectedForumId"
                     :replyToName="comment.user?.name || ''"
+                    @cancel="toggleCommentForm(postId, comment.id)"
                     class="mt-4"
-                    title="返信"
                 />
 
                 <!-- 子コメント表示 -->

--- a/resources/js/Components/PostForm.vue
+++ b/resources/js/Components/PostForm.vue
@@ -75,7 +75,7 @@ const submitPost = () => {
             </div>
             <div class="flex justify-end mt-2">
                 <button
-                    class="my-2 px-2 py-1 rounded bg-blue-500 text-white font-bold link-hover cursor-pointer"
+                    class="my-2 px-2 py-1 rounded bg-blue-500 text-white font-bold hover:bg-opacity-80 cursor-pointer"
                 >
                     <i class="bi bi-send"></i>
                 </button>

--- a/resources/js/Components/PostForm.vue
+++ b/resources/js/Components/PostForm.vue
@@ -55,20 +55,20 @@ const submitPost = () => {
     <div class="bg-white rounded-md mt-5 p-3">
         <form @submit.prevent="submitPost">
             <div class="flex mt-2">
-                <p class="font-bold">件名</p>
+                <p class="font-medium">件名</p>
                 <input
                     v-model="postData.title"
-                    class="border rounded px-2 ml-2 flex-auto"
+                    class="border-gray-300 rounded-md px-2 ml-2 flex-auto"
                     type="text"
                     required
                     placeholder="件名を入力してください"
                 />
             </div>
             <div class="flex flex-col mt-2">
-                <p class="font-bold">本文</p>
+                <p class="font-medium">本文</p>
                 <textarea
                     v-model="postData.message"
-                    class="border rounded px-2"
+                    class="border-gray-300 rounded-md px-2"
                     required
                     placeholder="本文を入力してください"
                 ></textarea>

--- a/resources/js/Components/PostForm.vue
+++ b/resources/js/Components/PostForm.vue
@@ -75,10 +75,11 @@ const submitPost = () => {
             </div>
             <div class="flex justify-end mt-2">
                 <button
-                    class="my-2 px-2 py-1 rounded bg-blue-500 text-white font-bold hover:bg-opacity-80 cursor-pointer"
-                >
-                    <i class="bi bi-send"></i>
-                </button>
+    class="my-2 px-4 py-2 rounded-md bg-blue-100 text-blue-700 transition hover:bg-blue-300 hover:text-white cursor-pointer"
+>
+    <i class="bi bi-send"></i>
+</button>
+
             </div>
         </form>
     </div>

--- a/resources/js/Components/SearchForm.vue
+++ b/resources/js/Components/SearchForm.vue
@@ -29,7 +29,10 @@ const resetSearch = () => {
     search.value = "";
     router.get(
         route("forum.index"),
-        { selectedunit_id: selectedUnitId.value, forum_id: selectedForumId.value },
+        {
+            selectedunit_id: selectedUnitId.value,
+            forum_id: selectedForumId.value,
+        },
         { replace: true }
     ); // ユニットIDと掲示板IDを保持したまま検索リセット
 };
@@ -52,7 +55,7 @@ const compositionEnd = () => {
             v-model="search"
             type="text"
             placeholder="投稿を検索"
-            class="border-gray-300 p-2 w-full pr-12 rounded-md shadow-sm focus:ring-2 focus:ring-blue-500"
+            class="border-gray-300 p-2 w-full pr-12 rounded-md shadow-sm focus:border-blue-500"
             @keydown.enter="searchPosts"
             @compositionstart="compositionStart"
             @compositionend="compositionEnd"

--- a/resources/js/Components/SearchForm.vue
+++ b/resources/js/Components/SearchForm.vue
@@ -52,7 +52,7 @@ const compositionEnd = () => {
             v-model="search"
             type="text"
             placeholder="投稿を検索"
-            class="border p-2 w-full pr-12 rounded shadow-sm focus:ring-2 focus:ring-blue-500"
+            class="border-gray-300 p-2 w-full pr-12 rounded-md shadow-sm focus:ring-2 focus:ring-blue-500"
             @keydown.enter="searchPosts"
             @compositionstart="compositionStart"
             @compositionend="compositionEnd"

--- a/resources/js/Components/SearchForm.vue
+++ b/resources/js/Components/SearchForm.vue
@@ -55,22 +55,26 @@ const compositionEnd = () => {
             v-model="search"
             type="text"
             placeholder="投稿を検索"
-            class="border-gray-300 p-2 w-full pr-12 rounded-md shadow-sm focus:border-blue-500"
+            class="w-full rounded-md border-gray-300 shadow-sm pl-10 pr-10 focus:border-blue-500"
             @keydown.enter="searchPosts"
             @compositionstart="compositionStart"
             @compositionend="compositionEnd"
         />
 
         <!-- 検索アイコン -->
-        <i
-            class="bi bi-search absolute top-1/2 right-4 transform -translate-y-1/2 cursor-pointer text-gray-500 hover:text-gray-700"
-            @click="searchPosts"
-        ></i>
+        <div
+            class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none"
+        >
+            <i class="bi bi-search text-gray-400"></i>
+        </div>
+
         <!-- リセットアイコン（×ボタン） -->
-        <i
+        <div
             v-if="search"
-            class="bi bi-x absolute top-1/2 right-12 transform -translate-y-1/2 cursor-pointer text-gray-500 hover:text-gray-700"
+            class="absolute inset-y-0 right-0 pr-3 flex items-center cursor-pointer"
             @click="resetSearch"
-        ></i>
+        >
+            <i class="bi bi-x text-gray-400 hover:text-gray-600"></i>
+        </div>
     </div>
 </template>

--- a/resources/js/Components/SearchForm.vue
+++ b/resources/js/Components/SearchForm.vue
@@ -55,7 +55,7 @@ const compositionEnd = () => {
             v-model="search"
             type="text"
             placeholder="投稿を検索"
-            class="w-full rounded-md border-gray-300 shadow-sm pl-10 pr-10 focus:border-blue-500"
+            class="border p-2 w-full pr-12 rounded shadow-sm focus:ring-2 focus:border-blue-500"
             @keydown.enter="searchPosts"
             @compositionstart="compositionStart"
             @compositionend="compositionEnd"

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -425,7 +425,7 @@ const handleForumSelected = (unitId) => {
                                         post.user ? post.user.name : 'Unknown'
                                     )
                                 "
-                                class="px-2 py-1 rounded bg-green-500 text-white font-bold hover:bg-opacity-80 cursor-pointer"
+                                class="px-4 py-2 rounded-md bg-green-100 text-green-700 transition hover:bg-green-300 hover:text-white cursor-pointer"
                                 title="返信"
                             >
                                 <i class="bi bi-reply"></i>
@@ -434,7 +434,7 @@ const handleForumSelected = (unitId) => {
                             <button
                                 type="button"
                                 @click="quotePost(post)"
-                                class="px-2 py-1 rounded bg-blue-500 text-white font-bold hover:bg-opacity-80 cursor-pointer flex items-center"
+                                class="px-4 py-2 rounded-md bg-blue-100 text-blue-700 transition hover:bg-blue-300 hover:text-white cursor-pointer flex items-center"
                                 title="引用投稿"
                             >
                                 <i class="bi bi-chat-quote"></i>
@@ -446,7 +446,7 @@ const handleForumSelected = (unitId) => {
                                     post.user && post.user.id === auth.user.id
                                 "
                                 @click.prevent="onDeleteItem('post', post.id)"
-                                class="px-2 py-1 ml-2 rounded bg-red-500 text-white font-bold hover:bg-opacity-80 cursor-pointer"
+                                class="px-4 py-2 ml-2 rounded-md bg-red-100 text-red-700 transition hover:bg-red-300 hover:text-white cursor-pointer"
                                 title="投稿の削除"
                             >
                                 <i class="bi bi-trash"></i>

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -21,6 +21,7 @@ import { restoreSelectedUnit } from "@/Utils/sessionUtils";
 import { initSelectedForumId } from "@/Utils/initUtils";
 import { fetchPostsByForumId } from "@/Utils/fetchPosts";
 import { deleteItem } from "@/Utils/deleteItem";
+import axios from "axios";
 
 // props を構造分解して取得
 const {
@@ -151,6 +152,8 @@ const toggleCommentForm = (postId, parentId = "post", replyToName = "") => {
 };
 
 const onDeleteItem = (type, id) => {
+    const scrollPosition = window.scrollY;
+
     deleteItem(type, id, (deletedId) => {
         if (type === "post") {
             posts.value.data = posts.value.data.filter(
@@ -160,10 +163,22 @@ const onDeleteItem = (type, id) => {
             handleCommentDeletion(deletedId);
         }
 
-        router.get(route("forum.index", { forum_id: selectedForumId.value }), {
-            preserveState: false,
-            preserveScroll: true,
-        });
+        // 削除成功後にデータを再取得
+        axios
+            .get(route("forum.index", { forum_id: selectedForumId.value }))
+            .then((response) => {
+                posts.value = response.data.posts;
+
+                setTimeout(() => {
+                    window.scrollTo({
+                        top: scrollPosition,
+                        behavior: "instant",
+                    });
+                }, 100);
+            })
+            .catch((error) => {
+                console.error("データ取得エラー:", error);
+            });
     });
 };
 

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -131,16 +131,24 @@ const commentFormVisibility = ref({});
 
 // コメントフォームの表示・非表示を切り替える関数
 const toggleCommentForm = (postId, parentId = "post", replyToName = "") => {
-    commentFormVisibility.value[postId] ??= {};
-    commentFormVisibility.value[postId][parentId] ??= {
-        isVisible: false,
-        replyToName: "",
-    };
+    if (!commentFormVisibility.value[postId]) {
+        commentFormVisibility.value[postId] = {};
+    }
 
-    // コメントフォームの表示・非表示を切り替え
+    if (!commentFormVisibility.value[postId][parentId]) {
+        commentFormVisibility.value[postId][parentId] = {
+            isVisible: false,
+            replyToName: "",
+        };
+    }
+
+    // フォームの表示を反転
     commentFormVisibility.value[postId][parentId].isVisible =
         !commentFormVisibility.value[postId][parentId].isVisible;
     commentFormVisibility.value[postId][parentId].replyToName = replyToName;
+
+    // 強制的に再描画を促すため、オブジェクトを新しく作り直す
+    commentFormVisibility.value = { ...commentFormVisibility.value };
 };
 
 const onDeleteItem = (type, id) => {
@@ -164,7 +172,7 @@ const onDeleteItem = (type, id) => {
     });
 };
 
-// コメント削除を処理する関数
+// コメントの削除を処理する関数
 const handleCommentDeletion = (commentId) => {
     const postIndex = posts.value.data.findIndex((post) =>
         findCommentRecursive(post.comments, commentId)
@@ -464,6 +472,7 @@ const handleForumSelected = (unitId) => {
                                 commentFormVisibility[post.id]?.['post']
                                     ?.replyToName
                             "
+                            @cancel="toggleCommentForm(post.id, 'post')"
                             class="mt-4 comment-form"
                             title="返信"
                         />

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -123,17 +123,6 @@ const closeUserProfile = () => {
 const toggleSidebar = () => {
     sidebarVisible.value = !sidebarVisible.value;
     console.log("sidebarVisible.value:", sidebarVisible.value);
-
-    // サイドバーを非表示にする際にドロップダウンを閉じる
-    if (!sidebarVisible.value) {
-        if (sidebar.value && sidebar.value.resetDropdown) {
-            sidebar.value.resetDropdown();
-        } else {
-            console.error(
-                "Sidebar component reference not found or resetDropdown method is undefined."
-            );
-        }
-    }
 };
 
 // コメントフォーム表示状態を管理するためのオブジェクト

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -285,10 +285,10 @@ onUnmounted(() => {
 
             <!-- メインコンテンツエリア -->
             <div class="flex-1 max-w-4xl mx-auto p-4">
-                <!-- トグルボタンと検索フォーム -->
+                <!-- サイドバーのトグルボタンと検索フォーム -->
                 <div class="flex items-center mb-4 relative">
                     <h1
-                        class="text-xl font-bold cursor-pointer toggle-button"
+                        class="text-lg font-bold cursor-pointer toggle-button"
                         @click="toggleSidebar"
                     >
                         {{ $t("Unit List") }}

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -152,27 +152,31 @@ const toggleCommentForm = (postId, parentId = "post", replyToName = "") => {
 };
 
 const onDeleteItem = (type, id) => {
-    const scrollPosition = window.scrollY;
-
-    deleteItem(type, id, (deletedId) => {
+    deleteItem(type, id, async (deletedId) => {
         if (type === "post") {
+            // まずローカルでデータを更新
             posts.value.data = posts.value.data.filter(
                 (post) => post.id !== deletedId
             );
-            // 削除後に現在のフォーラムページにリダイレクト
-            router.get(
-                route("forum.index", { forum_id: selectedForumId.value }),
-                { preserveState: false }
-            );
+
+            // 削除後に正しいURLに遷移（履歴を置き換える）
+            const currentUrl = route("forum.index", {
+                forum_id: selectedForumId.value,
+            });
+
+            // ブラウザの履歴を置き換え
+            window.history.replaceState({}, "", currentUrl);
+
+            // Inertiaを使用してデータを更新
+            router.reload({
+                only: ["posts"],
+                preserveState: true,
+                preserveScroll: true,
+                replace: true,
+            });
         } else if (type === "comment") {
             handleCommentDeletion(deletedId);
         }
-
-        // スクロール位置を復元
-        window.scrollTo({
-            top: scrollPosition,
-            behavior: "instant",
-        });
     });
 };
 

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -634,11 +634,4 @@ const handleForumSelected = (unitId) => {
         width: 50% !important;
     }
 }
-
-img {
-    max-width: 100%; /* 親要素の幅に合わせる */
-    height: auto; /* アスペクト比を保ちながら高さを自動調整 */
-    object-fit: cover; /* アスペクト比を維持しながら、親要素に収める */
-    border-radius: 8px; /* デザインとして角を丸める（オプション） */
-}
 </style>

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -159,8 +159,12 @@ const onDeleteItem = (type, id) => {
             posts.value.data = posts.value.data.filter(
                 (post) => post.id !== deletedId
             );
+            // 削除後に現在のフォーラムページにリダイレクト
+            router.get(
+                route("forum.index", { forum_id: selectedForumId.value }),
+                { preserveState: false }
+            );
         } else if (type === "comment") {
-            // コメントの削除を即時反映
             handleCommentDeletion(deletedId);
         }
 

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, onMounted, watch, onUnmounted } from "vue";
+import { ref, onMounted, watch } from "vue";
 import { usePage, router, Head } from "@inertiajs/vue3";
 import AuthenticatedLayout from "@/Layouts/AuthenticatedLayout.vue";
 import PostForm from "@/Components/PostForm.vue";
@@ -64,8 +64,6 @@ onMounted(() => {
     if (savedUnitId) {
         activeUnitId.value = parseInt(savedUnitId);
     }
-    document.addEventListener("click", handleClickOutside);
-    window.addEventListener("click", handleClickOutside, true);
 });
 
 // selectedForumIdの変更を監視し、変更があるたびに投稿を再取得
@@ -139,15 +137,9 @@ const toggleCommentForm = (postId, parentId = "post", replyToName = "") => {
         replyToName: "",
     };
 
-    // 他のすべてのフォームを非表示にする
-    Object.keys(commentFormVisibility.value).forEach((pId) => {
-        Object.keys(commentFormVisibility.value[pId]).forEach((pParentId) => {
-            commentFormVisibility.value[pId][pParentId].isVisible = false;
-        });
-    });
-
-    // クリックされたフォームを表示
-    commentFormVisibility.value[postId][parentId].isVisible = true;
+    // コメントフォームの表示・非表示を切り替え
+    commentFormVisibility.value[postId][parentId].isVisible =
+        !commentFormVisibility.value[postId][parentId].isVisible;
     commentFormVisibility.value[postId][parentId].replyToName = replyToName;
 };
 
@@ -223,44 +215,6 @@ const handleForumSelected = (unitId) => {
     localStorage.setItem("lastSelectedUnitId", unitId); // ローカルストレージに保存
     onForumSelected(unitId);
 };
-
-// クリックイベントハンドラーを修正
-const handleClickOutside = (event) => {
-    const clickedElement = event.target;
-
-    // クリックされた要素とその親要素のスタイルを取得
-    const computedStyle = window.getComputedStyle(clickedElement);
-
-    // クリックを許可する条件
-    const shouldCloseForm =
-        // カーソルがポインターでない
-        computedStyle.cursor !== "pointer" &&
-        // フォーム要素でない
-        !clickedElement.closest("form") &&
-        // 入力要素でない
-        !clickedElement.closest("input, textarea, select") &&
-        // 特定のインタラクティブ要素でない
-        !clickedElement.closest(
-            ".reply-button, .bi-reply, .delete-button, .bi-trash"
-        );
-
-    if (shouldCloseForm) {
-        Object.keys(commentFormVisibility.value).forEach((postId) => {
-            Object.keys(commentFormVisibility.value[postId]).forEach(
-                (parentId) => {
-                    commentFormVisibility.value[postId][
-                        parentId
-                    ].isVisible = false;
-                }
-            );
-        });
-    }
-};
-
-// イベントリスナーの設定（キャプチャフェーズで実行）
-onUnmounted(() => {
-    window.removeEventListener("click", handleClickOutside, true);
-});
 </script>
 
 <template>
@@ -462,14 +416,14 @@ onUnmounted(() => {
                             />
                             <!-- 投稿に対する返信ボタン -->
                             <button
-                                @click.stop="
+                                @click="
                                     toggleCommentForm(
                                         post.id,
                                         'post',
                                         post.user ? post.user.name : 'Unknown'
                                     )
                                 "
-                                class="reply-button px-4 py-2 rounded-md bg-green-100 text-green-700 transition hover:bg-green-300 hover:text-white cursor-pointer"
+                                class="px-4 py-2 rounded-md bg-green-100 text-green-700 transition hover:bg-green-300 hover:text-white cursor-pointer"
                                 title="返信"
                             >
                                 <i class="bi bi-reply"></i>

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -306,11 +306,13 @@ onUnmounted(() => {
                 </div>
 
                 <!-- 上部ページネーション -->
-                <Pagination
-                    :links="posts?.links || []"
-                    @change="onPageChange"
-                    class="mb-4"
-                />
+                <div class="mb-4 h-12 flex items-center justify-center">
+                    <Pagination
+                        v-if="posts?.links?.length"
+                        :links="posts.links"
+                        @change="onPageChange"
+                    />
+                </div>
 
                 <!-- 投稿フォーム -->
                 <PostForm

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -285,7 +285,8 @@ onUnmounted(() => {
 
             <!-- メインコンテンツエリア -->
             <div class="flex-1 max-w-4xl mx-auto p-4">
-                <div class="flex justify-between items-center mb-4">
+                <!-- トグルボタンと検索フォーム -->
+                <div class="flex items-center mb-4 relative">
                     <h1
                         class="text-xl font-bold cursor-pointer toggle-button"
                         @click="toggleSidebar"
@@ -298,15 +299,17 @@ onUnmounted(() => {
                         :selected-forum-id="selectedForumId"
                         class="ml-auto"
                     />
-                </div>
 
-                <!-- 検索結果 -->
-                <div class="text-sm text-gray-600 mt-1 h-6 flex items-center">
-                    <p v-if="search">検索結果: {{ posts.total }}件</p>
+                    <!-- 検索結果 -->
+                    <div
+                        class="absolute top-full right-36 text-sm text-gray-600 mt-1 mb-16"
+                    >
+                        <p v-if="search">検索結果: {{ posts.total }}件</p>
+                    </div>
                 </div>
 
                 <!-- 上部ページネーション -->
-                <div class="mb-4 h-12 flex items-center justify-center">
+                <div class="mt-12 h-12 flex items-center justify-center">
                     <Pagination
                         v-if="posts?.links?.length"
                         :links="posts.links"

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -46,6 +46,7 @@ const selectedUnitName = ref(""); // 選択されたユニットの名前
 const search = ref(initialSearch); // 検索結果の表示状態
 const quotedPost = ref(null); // 引用投稿
 const showPostForm = ref(false); // 引用投稿フォームの表示制御
+const activeUnitId = ref(null); // 選択中の部署IDを管理
 
 const quotePost = (post) => {
     quotedPost.value = post; // post全体をセットする
@@ -57,6 +58,11 @@ onMounted(() => {
     initSelectedForumId(selectedForumId);
     // マウント時に選択されたユニットのユーザーと名前を復元
     restoreSelectedUnit(selectedUnitUsers, selectedUnitName);
+    // 保存された部署IDを復元
+    const savedUnitId = localStorage.getItem("lastSelectedUnitId");
+    if (savedUnitId) {
+        activeUnitId.value = parseInt(savedUnitId);
+    }
 });
 
 // selectedForumIdの変更を監視し、変更があるたびに投稿を再取得
@@ -210,6 +216,12 @@ const getCurrentCommentCount = (post) => {
 const isCommentAuthor = (comment) => {
     return auth.user && comment.user && auth.user.id === comment.user.id;
 };
+
+const handleForumSelected = (unitId) => {
+    activeUnitId.value = unitId; // 選択された部署IDを保存
+    localStorage.setItem("lastSelectedUnitId", unitId); // ローカルストレージに保存
+    onForumSelected(unitId);
+};
 </script>
 
 <template>
@@ -228,12 +240,13 @@ const isCommentAuthor = (comment) => {
             <ListForSidebar
                 :units="units"
                 :users="users"
+                :active-unit-id="activeUnitId"
                 class="sidebar-mobile p-4 sm:mt-16 lg:block"
                 :class="{ visible: sidebarVisible }"
                 ref="sidebar"
                 @user-profile-clicked="onUserSelected"
                 v-model:sidebarVisible="sidebarVisible"
-                @forum-selected="onForumSelected"
+                @forum-selected="handleForumSelected"
             />
 
             <!-- メインコンテンツエリア -->

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -634,4 +634,11 @@ const handleForumSelected = (unitId) => {
         width: 50% !important;
     }
 }
+
+img {
+    max-width: 100%; /* 親要素の幅に合わせる */
+    height: auto; /* アスペクト比を保ちながら高さを自動調整 */
+    object-fit: cover; /* アスペクト比を維持しながら、親要素に収める */
+    border-radius: 8px; /* デザインとして角を丸める（オプション） */
+}
 </style>

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -412,7 +412,7 @@ const isCommentAuthor = (comment) => {
                                         post.user ? post.user.name : 'Unknown'
                                     )
                                 "
-                                class="px-2 py-1 rounded bg-green-500 text-white font-bold link-hover cursor-pointer"
+                                class="px-2 py-1 rounded bg-green-500 text-white font-bold hover:bg-opacity-80 cursor-pointer"
                                 title="返信"
                             >
                                 <i class="bi bi-reply"></i>
@@ -421,7 +421,7 @@ const isCommentAuthor = (comment) => {
                             <button
                                 type="button"
                                 @click="quotePost(post)"
-                                class="px-2 py-1 rounded bg-blue-500 text-white font-bold link-hover cursor-pointer flex items-center"
+                                class="px-2 py-1 rounded bg-blue-500 text-white font-bold hover:bg-opacity-80 cursor-pointer flex items-center"
                                 title="引用投稿"
                             >
                                 <i class="bi bi-chat-quote"></i>
@@ -433,7 +433,7 @@ const isCommentAuthor = (comment) => {
                                     post.user && post.user.id === auth.user.id
                                 "
                                 @click.prevent="onDeleteItem('post', post.id)"
-                                class="px-2 py-1 ml-2 rounded bg-red-500 text-white font-bold link-hover cursor-pointer"
+                                class="px-2 py-1 ml-2 rounded bg-red-500 text-white font-bold hover:bg-opacity-80 cursor-pointer"
                                 title="投稿の削除"
                             >
                                 <i class="bi bi-trash"></i>
@@ -529,10 +529,6 @@ const isCommentAuthor = (comment) => {
 </template>
 
 <style>
-.link-hover:hover {
-    opacity: 70%;
-}
-
 /* モバイルサイズ用のスタイル（切り替え可能） */
 @media (max-width: 767px) {
     .sidebar-mobile {

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -479,7 +479,7 @@ const handleForumSelected = (unitId) => {
                     </div>
 
                     <h3 class="font-bold mt-8 mb-2">
-                        {{ getCurrentCommentCount(post) }}件のコメント
+                        {{ getCurrentCommentCount(post) }}件の返信
                     </h3>
 
                     <!-- 親コメントビュー -->

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -160,25 +160,15 @@ const onDeleteItem = (type, id) => {
                 (post) => post.id !== deletedId
             );
         } else if (type === "comment") {
+            // コメントの削除を即時反映
             handleCommentDeletion(deletedId);
         }
 
-        // 削除成功後にデータを再取得
-        axios
-            .get(route("forum.index", { forum_id: selectedForumId.value }))
-            .then((response) => {
-                posts.value = response.data.posts;
-
-                setTimeout(() => {
-                    window.scrollTo({
-                        top: scrollPosition,
-                        behavior: "instant",
-                    });
-                }, 100);
-            })
-            .catch((error) => {
-                console.error("データ取得エラー:", error);
-            });
+        // スクロール位置を復元
+        window.scrollTo({
+            top: scrollPosition,
+            behavior: "instant",
+        });
     });
 };
 

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -301,8 +301,8 @@ onUnmounted(() => {
                 </div>
 
                 <!-- 検索結果 -->
-                <div v-if="search" class="text-lg font-bold mb-4">
-                    <p>検索結果: {{ posts.total }}件</p>
+                <div class="text-sm text-gray-600 mt-1 h-6 flex items-center">
+                    <p v-if="search">検索結果: {{ posts.total }}件</p>
                 </div>
 
                 <!-- 上部ページネーション -->

--- a/resources/js/Pages/Unit/ListForSidebar.vue
+++ b/resources/js/Pages/Unit/ListForSidebar.vue
@@ -80,10 +80,6 @@ export default {
         openUserProfile(user) {
             this.$emit("user-profile-clicked", user);
         },
-        resetDropdown() {
-            this.$emit("forum-selected", null); // 親コンポーネントに通知
-            this.isFetchingData = false;
-        },
     },
 };
 </script>

--- a/resources/js/Pages/Unit/ListForSidebar.vue
+++ b/resources/js/Pages/Unit/ListForSidebar.vue
@@ -86,7 +86,7 @@ export default {
 
 <template>
     <div class="sidebar bg-gray-100 w-56 h-screen p-4 shadow-lg">
-        <h2 class="text-lg font-bold mb-4">部署一覧</h2>
+        <h2 class="text-lg font-bold mb-4">{{ $t("Unit List") }}</h2>
         <ul>
             <li
                 v-for="unit in units"

--- a/resources/js/Pages/Unit/ListForSidebar.vue
+++ b/resources/js/Pages/Unit/ListForSidebar.vue
@@ -77,12 +77,12 @@ export default {
 
 <template>
     <div class="sidebar bg-gray-100 w-56 h-screen p-4 shadow-lg">
-        <h2 class="text-xl font-bold mb-4">部署一覧</h2>
+        <h2 class="text-lg font-bold mb-4">部署一覧</h2>
         <ul>
             <li
                 v-for="unit in units"
                 :key="unit.id"
-                class="mb-2 p-2 rounded hover:bg-gray-200 cursor-pointer"
+                class="mb-2 p-2 rounded text-gray-500 hover:text-black hover:bg-gray-200 cursor-pointer"
                 @click="handleUnitClick(unit)"
             >
                 <span class="font-bold">{{ unit.name }}</span>

--- a/resources/js/Utils/deleteItem.js
+++ b/resources/js/Utils/deleteItem.js
@@ -1,40 +1,33 @@
 import { router } from "@inertiajs/vue3";
 import { getCsrfToken } from "@/Utils/csrf";
+import axios from "axios";
 
 /**
  * 汎用的な削除ロジック
  * @param {string} type 削除対象の種類 ('post', 'comment', 'user' など)
  * @param {number|string} id 削除対象のID
- * @param {Function} onSuccessCallback 成功時に実行するコールバック関数
+ * @param {Function} callback 成功時に実行するコールバック関数
  */
-export const deleteItem = (type, id, onSuccessCallback) => {
-    const confirmMessage =
-        type === "post"
-            ? "本当に投稿を削除しますか？"
-            : type === "comment"
-            ? "本当にコメントを削除しますか？"
-            : "本当に社員を削除しますか？";
-
-    if (confirm(confirmMessage)) {
-        const routeName =
-            type === "post"
-                ? "forum.destroy"
-                : type === "comment"
-                ? "comment.destroy"
-                : "users.destroy";
-
-        router.delete(route(routeName, id), {
-            headers: {
-                "X-CSRF-TOKEN": getCsrfToken(),
-            },
-            onSuccess: () => {
-                if (onSuccessCallback) {
-                    onSuccessCallback(id);
-                }
-            },
-            onError: (errors) => {
-                console.error("削除に失敗しました:", errors);
-            },
-        });
+export const deleteItem = (type, id, callback) => {
+    const isConfirmed = confirm("本当に削除しますか？");
+    
+    if (!isConfirmed) {
+        return;
     }
+
+    // 削除用のルートを設定
+    const route = type === 'post' 
+        ? `/forum/post/${id}`
+        : `/forum/comment/${id}`;
+
+    // DELETEメソッドでリクエストを送信
+    axios.delete(route)
+        .then(response => {
+            if (response.status === 200) {
+                callback(id);
+            }
+        })
+        .catch(error => {
+            console.error('削除エラー:', error);
+        });
 };

--- a/resources/js/Utils/deleteItem.js
+++ b/resources/js/Utils/deleteItem.js
@@ -1,6 +1,5 @@
-import { router } from "@inertiajs/vue3";
-import { getCsrfToken } from "@/Utils/csrf";
 import axios from "axios";
+import { router } from "@inertiajs/vue3";
 
 /**
  * 汎用的な削除ロジック
@@ -10,24 +9,28 @@ import axios from "axios";
  */
 export const deleteItem = (type, id, callback) => {
     const isConfirmed = confirm("本当に削除しますか？");
-    
+
     if (!isConfirmed) {
         return;
     }
 
+    // CSRFトークンを取得
+    const token = document
+        .querySelector('meta[name="csrf-token"]')
+        .getAttribute("content");
+
     // 削除用のルートを設定
-    const route = type === 'post' 
-        ? `/forum/post/${id}`
-        : `/forum/comment/${id}`;
+    const deleteUrl =
+        type === "post" ? route('forum.destroy', { id }) : route('comment.destroy', { id });
 
     // DELETEメソッドでリクエストを送信
-    axios.delete(route)
-        .then(response => {
-            if (response.status === 200) {
-                callback(id);
-            }
-        })
-        .catch(error => {
-            console.error('削除エラー:', error);
-        });
+    router.delete(deleteUrl, {
+        preserveScroll: true,
+        onSuccess: () => {
+            callback(id);
+        },
+        onError: (errors) => {
+            console.error("削除エラー:", errors);
+        }
+    });
 };


### PR DESCRIPTION
## 目的

掲示板アプリのコメント機能、投稿処理、削除処理、画像表示など、ユーザー体験に直結する要素を改善し、動作の安定化と使いやすさを向上させます。特に、投稿・削除後の動作改善やコメント表示ロジックの修正、画像スタイルの統一を通じて、直感的でスムーズな操作性を実現します。

## 達成条件

- 投稿後・削除後のエラーや意図しないスクロールが発生せず、スムーズに動作すること。
- コメント表示/非表示のロジックが明確で、期待通りに動作すること。
- 全コンポーネントで画像スタイルが統一され、アスペクト比が適切に維持されていること。

## 実装の概要

### 1. 投稿後および削除後の挙動改善
- **投稿後の挙動改善**:
  - 投稿後にスクロール位置を維持するよう`preserveScroll`オプションを追加。
  - 投稿後の履歴操作を簡略化し、不要なページリロードを防止。
- **削除後の挙動改善**:
  - 投稿削除後に`forum.index`ルートへリダイレクトすることで、削除用URLでのエラー発生を防止。
  - 削除後にページトップへのスクロールが発生しないよう修正。

### 2. コメント機能の改善
- **子コメントの初期表示を展開状態に変更**:
  - 初期値を`true`に設定し、子コメントが正しく展開された状態で表示されるよう修正。
- **コメント折りたたみ条件の変更**:
  - コメントが1週間以上前の場合のみ折りたたむロジックを導入しました。
  - 新しいコメントが視認しやすくなるよう調整すると同時に、古いコメントを簡潔にまとめて表示し、重要度の低い情報が目立ちすぎないようにしました。
  - これにより、ユーザーが最新の議論に集中しやすくなります。
- **コメントフォームのキャンセル機能追加**:
  - 当初はフォーム外をクリックすることでフォームを閉じる機能を実装していましたが、思わぬ場面でフォームが閉じられてしまうケースが多発し、ユーザー体験を損ねる結果となりました。
  - このため、フォーム外クリックによる閉鎖機能を廃止し、代わりにキャンセルボタンを追加しました。キャンセルボタンはフォームをリセットし、明示的に閉じる操作が可能です。
  - 表示/非表示の切り替えロジックも改善し、Vue.jsのリアクティブ性を確保。

### 3. 画像スタイルの統一
- **アスペクト比の維持**:
  - 画像が伸縮して見える問題を解消し、親要素にフィットしつつアスペクト比を保つ仕様に変更。
- **スタイルの一元化**:
  - `Forum.vue`に記述されていた`img`スタイルを`app.css`に移動し、全コンポーネントで一貫して適用。

### 4. UI/UXの改善
- トグルボタンと検索フォームの配置を調整し、画面全体のUIバランスを向上。
- 上部ページネーションの余白を調整し、レイアウトの安定性を確保。

### 5. コンフリクト解消
- **検索ボックスのクラス定義の修正**:
  - `master` と `feature/forum-update` でクラス定義が異なりコンフリクトが発生しました。
  - プロジェクト全体のデザイン一貫性を保つため、`master` のスタイルを採用しました。

## レビューしてほしいところ

- 投稿後および削除後の挙動が期待通り動作し、エラーや意図しないスクロールが発生しないか。
- コメント折りたたみ条件や初期表示ロジックがユーザーの期待通りに動作しているか。
- 画像スタイルの移動が他コンポーネントに影響を与えず、統一されたデザインが保たれているか。

## 不安に思っていること

- 投稿後および削除後の処理が、特定のブラウザやネットワーク環境で問題なく動作するか。
- コメント折りたたみロジックの変更が既存のユーザー操作に影響を与えていないか。
- 画像スタイルの変更が、他コンポーネントのレイアウトに予期せぬ影響を与えていないか。

## 保留していること

- 投稿削除後に関連データが即時反映されない場合の検証と修正。
  - 現時点では、投稿の削除や更新に伴うコメントや他の関連データが即時反映されないケースが確認されています。
  - また、ユーザーのプロフィール画像を更新しても、右サイドバーにその変更が即時反映されない問題が発生しており、これも同様に検証と修正を予定しています。
- コメント返信の折りたたみ表示ロジックの改善。
  - 今回は親コメントが投稿されてからの日数を基準に、返信コメントを折りたたむかどうかを判定しましたが、理想は投稿した直後の返信コメントのみ展開し、それ以外は折りたたまれて表示されるようにすることです。
  - これにより、最新の返信が目立ち、過去の返信はコンパクトに整理される仕様を目指しています。
- コメントフォームやトグルボタンのさらなるデザイン統一。
- ページネーションや検索結果表示部分のさらなるUX向上。