### PR TITLE
プレースホルダーの初期選択状態を「hidden」から「selected」へ変更

### DIFF
--- a/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
+++ b/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
@@ -204,7 +204,7 @@ const handleOpenIconEdit = () => {
                     class="w-full border border-gray-300 p-2 rounded"
                 >
                     <!-- プレースホルダー（選択を促す） -->
-                    <option value="" disabled hidden>
+                    <option value="" disabled selected>
                         {{ $t("Select your unit") }}
                     </option>
 
@@ -217,6 +217,7 @@ const handleOpenIconEdit = () => {
                         {{ unit.name }}
                     </option>
                 </select>
+
                 <p class="text-sm text-gray-600 mt-2">
                     {{ $t("By setting your unit, you can access the forum.") }}
                 </p>


### PR DESCRIPTION
## 目的

プレースホルダーオプションの挙動を改善し、ユーザーが意図せずフォーム送信することを防ぐため、初期状態でプレースホルダーが選択済みとなるように変更します。これにより、ユーザーが適切にオプションを選択していることを視覚的に明示します。

## 達成条件

- プレースホルダーオプションが初期状態で選択されていること。
- 選択肢が未選択のままフォーム送信されないこと。

## 実装の概要

以下の修正を実施しました：

1. `<option>` タグの属性を `disabled hidden` から `disabled selected` に変更。

   - 変更前:  
     `<option value="" disabled hidden>`
   - 変更後:  
     `<option value="" disabled selected>`

この変更により、プレースホルダーがフォームロード時に表示され、選択状態が明示されます。

## レビューしてほしいところ

1. この変更が他のフォームの動作に影響を与えないか。
2. ユーザーが意図せずプレースホルダー状態のままフォーム送信するリスクが解消されているか。

## 不安に思っていること

- 他のブラウザ環境（特に古いバージョン）での挙動に問題が発生する可能性がないか。

## 保留していること

- プレースホルダー表示にカスタムスタイルを適用する案を検討しましたが、現時点ではユーザビリティ改善の優先度が低いため採用を見送りました。