### PR TITLE
掲示板機能のUI/UX改善および部署選択の復元ロジック対応

### DIFF
--- a/resources/js/Components/ChildComment.vue
+++ b/resources/js/Components/ChildComment.vue
@@ -73,12 +73,12 @@ const props = defineProps({
                         <i class="bi bi-reply"></i>
                     </button>
 
-                    <!-- コメント削除ボタン -->
+                    <!-- 返信削除ボタン -->
                     <button
                         v-if="isCommentAuthor(comment)"
                         @click="onDeleteItem('comment', comment.id)"
                         class="px-4 py-2 rounded-md bg-red-100 text-red-700 transition hover:bg-red-300 hover:text-white cursor-pointer flex items-center"
-                        title="コメントの削除"
+                        title="返信の削除"
                     >
                         <i class="bi bi-trash"></i>
                     </button>

--- a/resources/js/Components/ParentComment.vue
+++ b/resources/js/Components/ParentComment.vue
@@ -156,7 +156,7 @@ const getCommentCountRecursive = (comments) => {
                         v-if="isCommentAuthor(comment)"
                         @click="onDeleteItem('comment', comment.id)"
                         class="px-4 py-2 rounded-md bg-red-100 text-red-700 transition hover:bg-red-300 hover:text-white cursor-pointer flex items-center"
-                        title="コメント削除"
+                        title="返信の削除"
                     >
                         <i class="bi bi-trash"></i>
                     </button>

--- a/resources/js/Components/QuotePostForm.vue
+++ b/resources/js/Components/QuotePostForm.vue
@@ -55,7 +55,7 @@ const submitQuotePost = () => {
             <textarea
                 v-model="newPostContent"
                 class="w-full border rounded p-2 mb-4"
-                placeholder="ここにコメントを入力してください"
+                placeholder="投稿文を入力してください"
                 rows="4"
             ></textarea>
 

--- a/resources/js/Components/QuotePostForm.vue
+++ b/resources/js/Components/QuotePostForm.vue
@@ -63,13 +63,13 @@ const submitQuotePost = () => {
             <div class="flex justify-end space-x-2">
                 <button
                     @click="cancel"
-                    class="px-3 py-1 rounded bg-gray-300 text-gray-800 link-hover"
+                    class="my-2 py-2 px-4 rounded-md bg-gray-300 text-gray-700 font-medium transition hover:bg-gray-500 hover:text-white focus:outline-none focus:shadow-outline"
                 >
                     <i class="bi bi-x-lg"></i>
                 </button>
                 <button
                     @click="submitQuotePost"
-                    class="px-3 py-1 rounded bg-blue-500 text-white link-hover"
+                    class="my-2 px-4 py-2 rounded-md bg-blue-100 text-blue-700 transition hover:bg-blue-300 hover:text-white cursor-pointer"
                 >
                     <i class="bi bi-send"></i>
                 </button>

--- a/resources/js/Components/SearchForm.vue
+++ b/resources/js/Components/SearchForm.vue
@@ -49,32 +49,30 @@ const compositionEnd = () => {
 </script>
 
 <template>
-    <div class="relative">
+    <div class="relative flex items-center">
+        <!-- 検索アイコン -->
+        <div class="absolute left-3 text-gray-400">
+            <i class="bi bi-search"></i>
+        </div>
+
         <!-- 検索ボックス -->
         <input
             v-model="search"
             type="text"
             placeholder="投稿を検索"
-            class="border p-2 w-full pr-12 rounded shadow-sm focus:ring-2 focus:border-blue-500"
+            class="w-full rounded-md border-gray-300 shadow-sm pl-10 pr-10 focus:border-blue-500"
             @keydown.enter="searchPosts"
             @compositionstart="compositionStart"
             @compositionend="compositionEnd"
         />
 
-        <!-- 検索アイコン -->
-        <div
-            class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none"
-        >
-            <i class="bi bi-search text-gray-400"></i>
-        </div>
-
         <!-- リセットアイコン（×ボタン） -->
         <div
             v-if="search"
-            class="absolute inset-y-0 right-0 pr-3 flex items-center cursor-pointer"
+            class="absolute right-3 cursor-pointer text-gray-400 hover:text-gray-600"
             @click="resetSearch"
         >
-            <i class="bi bi-x text-gray-400 hover:text-gray-600"></i>
+            <i class="bi bi-x"></i>
         </div>
     </div>
 </template>

--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -175,7 +175,7 @@ const isForumPage = ref(window.location.pathname === "/forum");
                         </div>
 
                         <!-- Hamburger -->
-                        <div class="flex items-center lg:hidden">
+                        <div class="flex items-center lg:hidden my-auto">
                             <button
                                 @click="
                                     showingNavigationDropdown =

--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -75,9 +75,7 @@ const isForumPage = ref(window.location.pathname === "/forum");
                             </div>
 
                             <!-- Navigation Links -->
-                            <div
-                                class="hidden space-x-8 sm:-my-px sm:ms-10 sm:flex"
-                            >
+                            <div class="hidden lg:flex space-x-8 -my-px ms-10">
                                 <NavLink
                                     href="/forum"
                                     @click.prevent="navigateToForum"
@@ -110,7 +108,7 @@ const isForumPage = ref(window.location.pathname === "/forum");
                             </div>
                         </div>
 
-                        <div class="hidden sm:flex sm:items-center sm:ms-6">
+                        <div class="hidden lg:flex lg:items-center lg:ms-6">
                             <!-- Settings Dropdown -->
                             <div class="ms-3 relative">
                                 <Dropdown align="right" width="48">
@@ -177,7 +175,7 @@ const isForumPage = ref(window.location.pathname === "/forum");
                         </div>
 
                         <!-- Hamburger -->
-                        <div class="-me-2 flex items-center sm:hidden">
+                        <div class="flex items-center lg:hidden">
                             <button
                                 @click="
                                     showingNavigationDropdown =
@@ -225,7 +223,7 @@ const isForumPage = ref(window.location.pathname === "/forum");
                         block: showingNavigationDropdown,
                         hidden: !showingNavigationDropdown,
                     }"
-                    class="sm:hidden"
+                    class="lg:hidden"
                 >
                     <div class="pt-2 pb-3 space-y-1">
                         <ResponsiveNavLink
@@ -304,3 +302,29 @@ const isForumPage = ref(window.location.pathname === "/forum");
         <Footer />
     </div>
 </template>
+
+<style scoped>
+@media (max-width: 861px) {
+    .lg\:flex {
+        display: none;
+    }
+
+    .lg\:hidden {
+        display: block;
+    }
+
+    .hidden.lg\:hidden {
+        display: none;
+    }
+}
+
+@media (min-width: 862px) {
+    .hidden.lg\:flex {
+        display: flex;
+    }
+
+    .lg\:hidden {
+        display: none;
+    }
+}
+</style>

--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -108,9 +108,9 @@ const isForumPage = ref(window.location.pathname === "/forum");
                             </div>
                         </div>
 
-                        <div class="hidden lg:flex lg:items-center lg:ms-6">
+                        <div class="hidden lg:flex lg:items-center">
                             <!-- Settings Dropdown -->
-                            <div class="ms-3 relative">
+                            <div class="relative">
                                 <Dropdown align="right" width="48">
                                     <template #trigger>
                                         <span class="inline-flex rounded-md">
@@ -326,5 +326,17 @@ const isForumPage = ref(window.location.pathname === "/forum");
     .lg\:hidden {
         display: none;
     }
+}
+
+.lg\:flex {
+    align-items: center;
+    height: 100%;
+}
+
+.relative {
+    display: flex;
+    align-items: center;
+    height: 100%;
+    padding: 0 0.75rem;
 }
 </style>

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -318,46 +318,8 @@ const handleForumSelected = (unitId) => {
                     class="bg-white rounded-md shadow-md mb-6 p-4"
                 >
                     <div>
-                        <p class="mb-2 text-xs text-gray-500">
-                            {{ formatDate(post.created_at) }}
-                            <span
-                                v-if="post.user"
-                                class="flex items-center space-x-2"
-                            >
-                                <!-- ユーザーアイコンの表示 -->
-                                <img
-                                    v-if="post.user.icon"
-                                    :src="
-                                        post.user.icon.startsWith('/storage/')
-                                            ? post.user.icon
-                                            : `/storage/${post.user.icon}`
-                                    "
-                                    alt="User Icon"
-                                    class="w-12 h-12 rounded-full border border-gray-300 shadow-sm cursor-pointer hover:scale-110 transition-transform duration-300 mb-1"
-                                    @click="openUserProfile(post)"
-                                />
-                                <img
-                                    v-else
-                                    src="https://via.placeholder.com/40"
-                                    alt="Default Icon"
-                                    class="w-12 h-12 rounded-full border border-gray-300 shadow-sm cursor-pointer hover:scale-110 transition-transform duration-300 mb-1"
-                                    @click="openUserProfile(post)"
-                                />
-
-                                <!-- 投稿者名の表示 -->
-                                <span
-                                    @click="openUserProfile(post)"
-                                    class="text-sm font-semibold text-gray-800 hover:bg-blue-100 p-1 rounded cursor-pointer"
-                                >
-                                    ＠{{ post.user.name }}
-                                </span>
-                            </span>
-                            <span v-else>＠Unknown</span>
-                        </p>
-                        <p class="mb-2 text-xl font-bold">{{ post.title }}</p>
-
-                        <!-- 引用投稿がある場合の表示 -->
-                        <div>
+                        <!-- 引用投稿がある場合の表示を最初に移動 -->
+                        <div class="mb-4">
                             <!-- 削除済みの場合 -->
                             <template v-if="post.quoted_post_deleted === 1">
                                 <p
@@ -370,7 +332,7 @@ const handleForumSelected = (unitId) => {
                             <!-- 削除されていない場合 -->
                             <template v-else-if="post.quoted_post">
                                 <div
-                                    class="quoted-post mb-2 p-2 border-l-4 border-gray-300 bg-gray-100"
+                                    class="quoted-post p-2 border-l-4 border-gray-300 bg-gray-100"
                                 >
                                     <div class="flex items-center space-x-2">
                                         <img
@@ -428,6 +390,44 @@ const handleForumSelected = (unitId) => {
                             </template>
                         </div>
 
+                        <!-- ユーザー情報と投稿内容 -->
+                        <p class="mb-2 text-xs text-gray-500">
+                            {{ formatDate(post.created_at) }}
+                            <span
+                                v-if="post.user"
+                                class="flex items-center space-x-2"
+                            >
+                                <!-- ユーザーアイコンの表示 -->
+                                <img
+                                    v-if="post.user.icon"
+                                    :src="
+                                        post.user.icon.startsWith('/storage/')
+                                            ? post.user.icon
+                                            : `/storage/${post.user.icon}`
+                                    "
+                                    alt="User Icon"
+                                    class="w-12 h-12 rounded-full border border-gray-300 shadow-sm cursor-pointer hover:scale-110 transition-transform duration-300 mb-1"
+                                    @click="openUserProfile(post)"
+                                />
+                                <img
+                                    v-else
+                                    src="https://via.placeholder.com/40"
+                                    alt="Default Icon"
+                                    class="w-12 h-12 rounded-full border border-gray-300 shadow-sm cursor-pointer hover:scale-110 transition-transform duration-300 mb-1"
+                                    @click="openUserProfile(post)"
+                                />
+
+                                <!-- 投稿者名の表示 -->
+                                <span
+                                    @click="openUserProfile(post)"
+                                    class="text-sm font-semibold text-gray-800 hover:bg-blue-100 p-1 rounded cursor-pointer"
+                                >
+                                    ＠{{ post.user.name }}
+                                </span>
+                            </span>
+                            <span v-else>＠Unknown</span>
+                        </p>
+                        <p class="mb-2 text-xl font-bold">{{ post.title }}</p>
                         <p class="mb-2 whitespace-pre-wrap">
                             {{ post.message }}
                         </p>

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -193,12 +193,12 @@ const handleCommentDeletion = (commentId) => {
         if (deleted) {
             // Vueに変更を通知
             posts.value.data[postIndex].comments = [...comments];
-            console.log(`コメント削除成功: ${commentId}`);
+            console.log(`返信削除成功: ${commentId}`);
         } else {
-            console.error(`コメント削除に失敗しました: ${commentId}`);
+            console.error(`返信削除に失敗しました: ${commentId}`);
         }
     } else {
-        console.error(`削除対象のコメントが見つかりませんでした: ${commentId}`);
+        console.error(`削除対象の返信が見つかりませんでした: ${commentId}`);
     }
 };
 

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -273,7 +273,7 @@ const handleForumSelected = (unitId) => {
                 <!-- サイドバーのトグルボタンと検索フォーム -->
                 <div class="flex items-center mb-4 relative">
                     <h1
-                        class="text-lg font-bold cursor-pointer toggle-button"
+                        class="text-lg font-bold cursor-pointer text-gray-500 hover:text-black p-2 toggle-button"
                         @click="toggleSidebar"
                     >
                         {{ $t("Unit List") }}

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -534,6 +534,8 @@ const handleForumSelected = (unitId) => {
             <RightSidebar
                 :unit-users="selectedUnitUsers"
                 :unit-name="selectedUnitName"
+                :users="users"
+                :active-unit-id="activeUnitId"
                 class="p-4 lg:mt-16 sm:block"
                 @user-selected="onUserSelected"
             />

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -54,14 +54,25 @@ const quotePost = (post) => {
 };
 
 onMounted(() => {
-    // マウント時にselectedForumIdを初期化
     initSelectedForumId(selectedForumId);
-    // マウント時に選択されたユニットのユーザーと名前を復元
     restoreSelectedUnit(selectedUnitUsers, selectedUnitName);
-    // 保存された部署IDを復元
-    const savedUnitId = localStorage.getItem("lastSelectedUnitId");
-    if (savedUnitId) {
-        activeUnitId.value = parseInt(savedUnitId);
+
+    // URLパラメータからactive_unit_idを取得
+    const urlParams = new URLSearchParams(window.location.search);
+    const urlUnitId = urlParams.get("active_unit_id");
+
+    if (urlUnitId) {
+        // URLパラメータがある場合はそれを優先
+        activeUnitId.value = parseInt(urlUnitId);
+        localStorage.setItem("lastSelectedUnitId", urlUnitId);
+    } else {
+        // URLパラメータがない場合は既存のロジックを使用
+        const savedUnitId = localStorage.getItem("lastSelectedUnitId");
+        if (savedUnitId) {
+            activeUnitId.value = parseInt(savedUnitId);
+        } else if (auth.user.unit_id) {
+            activeUnitId.value = auth.user.unit_id;
+        }
     }
 });
 

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -21,7 +21,6 @@ import { restoreSelectedUnit } from "@/Utils/sessionUtils";
 import { initSelectedForumId } from "@/Utils/initUtils";
 import { fetchPostsByForumId } from "@/Utils/fetchPosts";
 import { deleteItem } from "@/Utils/deleteItem";
-import axios from "axios";
 
 // props を構造分解して取得
 const {

--- a/resources/js/Pages/Unit/RightSidebar.vue
+++ b/resources/js/Pages/Unit/RightSidebar.vue
@@ -1,5 +1,6 @@
 <!-- RightSidebar.vue -->
 <script setup>
+import { computed } from "vue";
 
 const props = defineProps({
     unitUsers: {
@@ -10,9 +11,22 @@ const props = defineProps({
         type: String,
         default: "",
     },
+    users: {
+        type: Array,
+        default: () => [],
+    },
+    activeUnitId: {
+        type: Number,
+        default: null,
+    },
 });
-console.log("props.unitUsers", props.unitUsers);
-console.log("props.unitName", props.unitName);
+
+// 現在の部署のユーザーを動的に計算
+const currentUnitUsers = computed(() => {
+    if (!props.activeUnitId) return props.unitUsers;
+
+    return props.users.filter((user) => user.unit_id === props.activeUnitId);
+});
 </script>
 
 <template>
@@ -22,10 +36,13 @@ console.log("props.unitName", props.unitName);
         <h2 class="text-lg font-bold mb-4">
             {{ unitName + "職員" || "部署メンバー" }}
         </h2>
-        <ul v-if="unitUsers && unitUsers.length > 0">
+        <ul
+            v-if="currentUnitUsers.length > 0"
+            :key="currentUnitUsers.map((u) => u.id).join(',')"
+        >
             <li
-                v-for="user in unitUsers"
-                :key="user.id"
+                v-for="user in currentUnitUsers"
+                :key="user.id + user.icon"
                 class="mb-2 p-2 rounded hover:bg-gray-200 cursor-pointer flex items-center space-x-4 font-bold"
                 @click="$emit('user-selected', user)"
             >

--- a/resources/js/Utils/deleteItem.js
+++ b/resources/js/Utils/deleteItem.js
@@ -12,7 +12,7 @@ export const deleteItem = (type, id, onSuccessCallback) => {
         type === "post"
             ? "本当に投稿を削除しますか？"
             : type === "comment"
-            ? "本当にコメントを削除しますか？"
+            ? "本当に返信を削除しますか？"
             : "本当に職員を削除しますか？";
 
     if (confirm(confirmMessage)) {

--- a/resources/js/Utils/redirectToForum.js
+++ b/resources/js/Utils/redirectToForum.js
@@ -32,13 +32,17 @@ export const redirectToForum = async (
                     JSON.stringify(unitUsers)
                 );
                 sessionStorage.setItem("selectedUnitName", unit.name);
+                localStorage.setItem("lastSelectedUnitId", userUnitId);
             }
         } else {
             console.warn("User does not belong to a unit.");
         }
 
         if (forumId) {
-            router.get(route(routeName, { forum_id: forumId }), {
+            router.get(route(routeName, { 
+                forum_id: forumId,
+                active_unit_id: userUnitId 
+            }), {
                 preserveState: false,
             });
         } else {

--- a/routes/web.php
+++ b/routes/web.php
@@ -51,7 +51,7 @@ Route::middleware([App\Http\Middleware\InitializeTenancyCustom::class])->group(f
         Route::delete('/forum/post/{id}', [PostController::class, 'destroy'])->name('forum.destroy');
         Route::post('/like/toggle', [LikeController::class, 'toggleLike'])->name('like.toggle');
 
-        // コメント
+        // 返信
         Route::post('/forum/comment', [CommentController::class, 'store'])->name('comment.store');
         Route::delete('/forum/comment/{id}', [CommentController::class, 'destroy'])->name('comment.destroy');
 


### PR DESCRIPTION
## 目的

掲示板のUI/UXを改善し、部署選択状態やユーザーアイコンの反映機能を強化することで、操作性と視認性を向上させる。

---

## 達成条件

1. 検索ボックスのデザインおよび操作性が改善されていること。
2. コメント関連の文言が「返信」に統一されていること。
3. 部署選択状態がURLパラメータから正しく復元され、左サイドバーに反映されること。
4. 右サイドバーのユーザーアイコン更新がリアルタイムで反映されること。
5. 引用投稿の表示位置が投稿内容の前に移動し、視認性が向上していること。
6. ナビゲーションとハンバーガーメニューが適切に表示され、余白が最適化されていること。
7. 引用投稿フォームのボタンスタイルが他フォームと統一されていること。

---

## 実装の概要

### 1. **検索ボックスのデザイン調整**
   - 検索アイコンとリセットボタンの配置を改善し、スタイルを統一して視認性と操作性を向上させました。

### 2. **コメント関連の文言統一**
   - 削除ボタン、エラーメッセージ、確認メッセージなどの文言を「コメント」から「返信」に統一し、表現を明確化しました。

### 3. **部署選択の復元ロジック拡張**
   - URLパラメータ `active_unit_id` から部署選択状態を復元する機能を追加。
   - 左サイドバーのアクティブ部署表示が正しく反映されるよう改善しました。

### 4. **右サイドバーのユーザーアイコン即時反映**
   - `Forum.vue` からユーザーデータを `RightSidebar` に直接渡し、`computed` プロパティで動的にリストを更新するよう変更。
   - プロフィール画像の更新がリアルタイムで反映されるよう修正しました。

### 5. **引用投稿の表示位置改善**
   - 引用投稿の表示位置を投稿内容の前に移動し、情報の流れと視認性を改善しました。

### 6. **ナビゲーションおよびハンバーガーメニューのレイアウト調整**
   - `lg:items-center` と `.relative` のスタイルを調整し、不要な余白を削除。
   - ハンバーガーメニューに `my-auto` クラスを追加し、縦方向に中央揃えされるようにしました。

### 7. **引用投稿フォームのボタンスタイル統一**
   - キャンセルボタンと送信ボタンのスタイルを他フォームと統一し、デザインの一貫性を確保しました。

---

## レビューしてほしいところ

- URLパラメータを使用した部署選択復元が期待通り動作するか。
- 右サイドバーのユーザーアイコンがリアルタイムで更新されるか。
- 引用投稿の表示位置変更がユーザーにとって見やすいかどうか。
- ナビゲーションおよびハンバーガーメニューの表示が適切に調整されているか。

---

## 不安に思っていること

- URLパラメータを使用した部署復元ロジックが他機能へ影響を与えていないか。
- UI/UX改善の変更がユーザー体験の向上につながっているか。

---

## 保留していること

- ナビゲーションリンクの追加・整理（今後の要件次第で対応予定）。
- 部署選択の状態を永続化する機能の更なる改善。
- **レイアウトの関係上、掲示板ページにのみ `Head :title` を定義していないこと。**  
  今後、レイアウトを改善し、掲示板ページにも適切な `Head :title` を定義する予定。