### PR TITLE
不要なdefinePropsとdefineEmitsのインポート削除

### DIFF
--- a/resources/js/Components/CommentForm.vue
+++ b/resources/js/Components/CommentForm.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, defineProps, defineEmits, onMounted } from "vue";
+import { ref, onMounted } from "vue";
 import { router } from "@inertiajs/vue3";
 import { getCsrfToken } from "@/Utils/csrf";
 

--- a/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
+++ b/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
@@ -4,7 +4,7 @@ import InputLabel from "@/Components/InputLabel.vue";
 import PrimaryButton from "@/Components/PrimaryButton.vue";
 import TextInput from "@/Components/TextInput.vue";
 import { useForm } from "@inertiajs/vue3";
-import { defineEmits, computed } from "vue";
+import { computed } from "vue";
 
 const props = defineProps({
     user: {


### PR DESCRIPTION
## 目的

Vue 3.3以降で`defineProps`と`defineEmits`がコンパイラマクロとして自動的に処理されるようになったため、不要なインポートを削除し、コードの簡潔さと最新仕様への準拠を実現します。

***

## 達成条件

1. `defineProps`と`defineEmits`のインポートをすべて削除する。
2. アプリケーションが正常に動作することを確認する。

***

## 実装の概要

- **変更内容**  
  `defineProps`および`defineEmits`をインポートしていた箇所を削除。  
  例：

  ```
  diff
  コードをコピーする
  - import { ref, defineProps, defineEmits, onMounted } from "vue";
  + import { ref, onMounted } from "vue";
  ```

- **理由**  
  Vue 3.3以降で`defineProps`と`defineEmits`がコンパイラマクロとして動作するため、インポートが不要になりました。

***

## レビューしてほしいところ

1. インポート削除によるアプリケーションの動作に影響がないか。
2. 他にインポートが残っている箇所がないか。

***

## 不安に思っていること

- 削除した箇所に影響する潜在的な問題がないか。

***

## 保留していること

- 今回は`defineProps`と`defineEmits`の削除に集中しており、他のコードリファクタリングは別のプルリクエストで対応予定。