### PR TITLE
フラッシュメッセージ表示・トランジションの改善とTailwind CSSへの移行

### DIFF
--- a/resources/js/Pages/Dashboard.vue
+++ b/resources/js/Pages/Dashboard.vue
@@ -77,7 +77,7 @@ console.log("User data:", props.auth.user);
                     'bg-blue-100 border-l-4 border-blue-500 text-blue-700 p-4':
                         flashType === 'info',
                 }"
-                class="fixed bottom-10 left-1/2 transform -translate-x-1/2 z-50 w-full max-w-md mx-auto sm:rounded-lg shadow-lg"
+                class="fixed bottom-10 left-1/2 transform -translate-x-1/2 z-50 w-full max-w-md mx-auto sm:rounded-lg shadow-lg text-center"
             >
                 <p class="font-bold">{{ flashMessage }}</p>
             </div>

--- a/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
+++ b/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
@@ -83,7 +83,7 @@ const handleOpenIconEdit = () => {
         >
             <div
                 v-if="form.recentlySuccessful"
-                class="bg-green-100 text-green-700 p-3 mt-4 mb-6 rounded"
+                class="bg-green-100 border-l-4 border-green-500 text-green-700 p-4 m-2 rounded shadow-lg"
             >
                 <p class="font-medium text-center">
                     {{ $t("Saved.") }}

--- a/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
+++ b/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
@@ -57,12 +57,20 @@ const submitForm = async () => {
     isSuccess.value = true;
     setTimeout(() => {
         isSuccess.value = false;
-    }, 8000); // 8秒後にメッセージを非表示
+    }, 8000);
 };
 
 // アイコン編集を開く関数
 const handleOpenIconEdit = () => {
     emit("openIconEdit");
+};
+
+// アイコン更新成功時のメッセージ表示
+const handleSuccessMessage = (message) => {
+    isSuccess.value = true;
+    setTimeout(() => {
+        isSuccess.value = false;
+    }, 8000);
 };
 </script>
 
@@ -78,14 +86,6 @@ const handleOpenIconEdit = () => {
             </p>
         </header>
 
-        <!-- プロフィール画像更新成功メッセージ表示 -->
-        <div
-            v-if="successMessage"
-            class="bg-green-100 text-green-700 p-3 mt-4 mb-6 rounded"
-        >
-            {{ successMessage }}
-        </div>
-
         <!-- プロフィール情報更新成功メッセージ表示 -->
         <Transition
             enter-active-class="transition ease-in-out duration-300"
@@ -96,11 +96,11 @@ const handleOpenIconEdit = () => {
             leave-to-class="opacity-0 transform translate-y-2"
         >
             <div
-                v-if="isSuccess"
+                v-if="isSuccess || successMessage"
                 class="bg-green-100 border-l-4 border-green-500 text-green-700 p-4 m-2 rounded fixed bottom-10 left-1/2 transform -translate-x-1/2 z-50 w-full max-w-md mx-auto sm:rounded-lg shadow-lg"
             >
-                <p class="font-bold">
-                    {{ $t("Saved.") }}
+                <p class="font-bold text-center">
+                    {{ successMessage || $t("Saved.") }}
                 </p>
             </div>
         </Transition>

--- a/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
+++ b/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
@@ -88,16 +88,18 @@ const handleOpenIconEdit = () => {
 
         <!-- プロフィール情報更新成功メッセージ表示 -->
         <Transition
-            enter-active-class="transition ease-in-out"
-            enter-from-class="opacity-0"
-            leave-active-class="transition ease-in-out"
-            leave-to-class="opacity-0"
+            enter-active-class="transition ease-in-out duration-300"
+            enter-from-class="opacity-0 transform translate-y-2"
+            enter-to-class="opacity-100 transform translate-y-0"
+            leave-active-class="transition ease-in-out duration-300"
+            leave-from-class="opacity-100 transform translate-y-0"
+            leave-to-class="opacity-0 transform translate-y-2"
         >
             <div
                 v-if="isSuccess"
-                class="bg-green-100 border-l-4 border-green-500 text-green-700 p-4 m-2 rounded shadow-lg"
+                class="bg-green-100 border-l-4 border-green-500 text-green-700 p-4 m-2 rounded fixed bottom-10 left-1/2 transform -translate-x-1/2 z-50 w-full max-w-md mx-auto sm:rounded-lg shadow-lg"
             >
-                <p class="font-medium text-center">
+                <p class="font-bold">
                     {{ $t("Saved.") }}
                 </p>
             </div>

--- a/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
+++ b/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
@@ -4,7 +4,7 @@ import InputLabel from "@/Components/InputLabel.vue";
 import PrimaryButton from "@/Components/PrimaryButton.vue";
 import TextInput from "@/Components/TextInput.vue";
 import { useForm } from "@inertiajs/vue3";
-import { computed } from "vue";
+import { computed, ref } from "vue";
 
 const props = defineProps({
     user: {
@@ -40,13 +40,25 @@ const units = props.units;
 const form = useForm({
     name: user.name,
     username_id: user.username_id,
-    tel: user.tel || "", // telに初期値を設定
-    email: user.email || "", // emailに初期値を設定
-    unit_id: user.unit_id ? String(user.unit_id) : "", // unit_idに初期値を設定
+    tel: user.tel || "",
+    email: user.email || "",
+    unit_id: user.unit_id ? String(user.unit_id) : "",
     _token: document
         .querySelector('meta[name="csrf-token"]')
         .getAttribute("content"),
 });
+
+// カスタムの成功メッセージ状態
+const isSuccess = ref(false);
+
+// フォーム送信の処理を修正
+const submitForm = async () => {
+    await form.patch(route("profile.update"));
+    isSuccess.value = true;
+    setTimeout(() => {
+        isSuccess.value = false;
+    }, 8000); // 8秒後にメッセージを非表示
+};
 
 // アイコン編集を開く関数
 const handleOpenIconEdit = () => {
@@ -82,7 +94,7 @@ const handleOpenIconEdit = () => {
             leave-to-class="opacity-0"
         >
             <div
-                v-if="form.recentlySuccessful"
+                v-if="isSuccess"
                 class="bg-green-100 border-l-4 border-green-500 text-green-700 p-4 m-2 rounded shadow-lg"
             >
                 <p class="font-medium text-center">
@@ -91,10 +103,7 @@ const handleOpenIconEdit = () => {
             </div>
         </Transition>
 
-        <form
-            @submit.prevent="form.patch(route('profile.update'))"
-            class="mt-6 space-y-6"
-        >
+        <form @submit.prevent="submitForm" class="mt-6 space-y-6">
             <!-- プロフィール画像表示と編集ボタン -->
             <div class="relative w-24 h-24 group">
                 <button

--- a/resources/js/Pages/Residents/Index.vue
+++ b/resources/js/Pages/Residents/Index.vue
@@ -221,7 +221,7 @@ const isAdmin = computed(() => {
                 }"
                 class="fixed bottom-10 left-1/2 transform -translate-x-1/2 w-full max-w-md mx-auto sm:rounded-lg shadow-lg z-50"
             >
-                <p class="font-bold">{{ localFlashMessage }}</p>
+                <p class="font-bold text-center">{{ localFlashMessage }}</p>
             </div>
         </transition>
 

--- a/resources/js/Pages/Residents/Index.vue
+++ b/resources/js/Pages/Residents/Index.vue
@@ -207,8 +207,15 @@ const isAdmin = computed(() => {
             </h2>
         </template>
 
-        <!-- フラッシュメッセージの条件を修正 -->
-        <transition name="fade">
+        <!-- フラッシュメッセージのスタイル -->
+        <transition
+            enter-active-class="transition ease-in-out duration-300"
+            enter-from-class="opacity-0 transform translate-y-2"
+            enter-to-class="opacity-100 transform translate-y-0"
+            leave-active-class="transition ease-in-out duration-300"
+            leave-from-class="opacity-100 transform translate-y-0"
+            leave-to-class="opacity-0 transform translate-y-2"
+        >
             <div
                 v-if="localFlashMessage && showFlashMessage"
                 :class="{
@@ -236,7 +243,10 @@ const isAdmin = computed(() => {
                                 class="flex flex-col space-y-4 sm:flex-row sm:space-y-0 sm:justify-between sm:items-start"
                             >
                                 <!-- 管理者のみに表示するボタン群 -->
-                                <div v-if="isAdmin" class="flex items-center space-x-4 order-1 sm:order-2">
+                                <div
+                                    v-if="isAdmin"
+                                    class="flex items-center space-x-4 order-1 sm:order-2"
+                                >
                                     <!-- 新規登録ボタン -->
                                     <Link
                                         :href="route('residents.create')"
@@ -247,9 +257,16 @@ const isAdmin = computed(() => {
 
                                     <!-- 削除モードトグルボタン -->
                                     <button
-                                        @click="showDeleteButtons = !showDeleteButtons"
+                                        @click="
+                                            showDeleteButtons =
+                                                !showDeleteButtons
+                                        "
                                         class="w-32 px-4 py-2 rounded-md transition delete-mode-button bg-red-100 text-red-700 hover:bg-red-300 hover:text-white text-center"
-                                        :class="showDeleteButtons ? 'bg-red-300 !text-white' : 'bg-red-200 text-red-600'"
+                                        :class="
+                                            showDeleteButtons
+                                                ? 'bg-red-300 !text-white'
+                                                : 'bg-red-200 text-red-600'
+                                        "
                                     >
                                         削除モード
                                     </button>
@@ -383,15 +400,3 @@ const isAdmin = computed(() => {
         </div>
     </AuthenticatedLayout>
 </template>
-
-<style>
-.fade-enter-active,
-.fade-leave-active {
-    transition: opacity 0.5s;
-}
-
-.fade-enter,
-.fade-leave-to {
-    opacity: 0;
-}
-</style>

--- a/resources/js/Pages/Unit/Register.vue
+++ b/resources/js/Pages/Unit/Register.vue
@@ -73,7 +73,7 @@ watchEffect(() => {
                     v-if="flashMessage"
                     class="fixed bottom-10 left-1/2 transform -translate-x-1/2 w-full max-w-md bg-green-100 border-l-4 border-green-500 text-green-700 p-4 rounded shadow-lg z-50"
                 >
-                    <p class="font-bold">{{ flashMessage }}</p>
+                    <p class="font-bold text-center">{{ flashMessage }}</p>
                 </div>
             </transition>
 

--- a/resources/js/Pages/Users/index.vue
+++ b/resources/js/Pages/Users/index.vue
@@ -199,7 +199,13 @@ const totalFilteredUsers = computed(() => {
             </h2>
         </template>
         <!-- フラッシュメッセージ -->
-        <transition name="fade">
+        <transition
+            enter-active-class="transition-opacity duration-500 ease-in-out"
+            leave-active-class="transition-opacity duration-500 ease-in-out"
+            enter-from-class="opacity-0"
+            enter-to-class="opacity-100"
+            leave-to-class="opacity-0"
+        >
             <div
                 v-if="flashMessage"
                 class="fixed bottom-10 left-1/2 transform -translate-x-1/2 w-full max-w-md bg-green-100 border-l-4 border-green-500 text-green-700 p-4 rounded shadow-lg z-50"
@@ -455,14 +461,3 @@ const totalFilteredUsers = computed(() => {
         </div>
     </AuthenticatedLayout>
 </template>
-
-<style>
-.fade-enter-active,
-.fade-leave-active {
-    transition: opacity 0.5s;
-}
-.fade-enter,
-.fade-leave-to {
-    opacity: 0;
-}
-</style>

--- a/resources/js/Pages/Users/index.vue
+++ b/resources/js/Pages/Users/index.vue
@@ -200,11 +200,12 @@ const totalFilteredUsers = computed(() => {
         </template>
         <!-- フラッシュメッセージ -->
         <transition
-            enter-active-class="transition-opacity duration-500 ease-in-out"
-            leave-active-class="transition-opacity duration-500 ease-in-out"
-            enter-from-class="opacity-0"
-            enter-to-class="opacity-100"
-            leave-to-class="opacity-0"
+            enter-active-class="transition ease-in-out duration-300"
+            enter-from-class="opacity-0 transform translate-y-2"
+            enter-to-class="opacity-100 transform translate-y-0"
+            leave-active-class="transition ease-in-out duration-300"
+            leave-from-class="opacity-100 transform translate-y-0"
+            leave-to-class="opacity-0 transform translate-y-2"
         >
             <div
                 v-if="flashMessage"

--- a/resources/js/Pages/Users/index.vue
+++ b/resources/js/Pages/Users/index.vue
@@ -204,7 +204,7 @@ const totalFilteredUsers = computed(() => {
                 v-if="flashMessage"
                 class="fixed bottom-10 left-1/2 transform -translate-x-1/2 w-full max-w-md bg-green-100 border-l-4 border-green-500 text-green-700 p-4 rounded shadow-lg z-50"
             >
-                <p class="font-bold">{{ flashMessage }}</p>
+                <p class="font-bold text-center">{{ flashMessage }}</p>
             </div>
         </transition>
 


### PR DESCRIPTION
# 目的
フラッシュメッセージの表示方法とトランジションを改善し、**プロフィール画面と一覧画面（ユーザー一覧・利用者一覧）のレイアウト・アニメーションを統一**します。メッセージの表示位置やトランジションを合わせることで、ユーザー体験の一貫性を高めることを目的としています。

# 達成条件
- **プロフィール画面のフラッシュメッセージを画面下部中央に表示**し、ユーザー一覧・利用者一覧ページと表示位置を統一。  
- **ユーザー一覧・利用者一覧ページのフラッシュメッセージに`ease-in-out`のトランジションを適用**し、プロフィール画面とアニメーションを統一。  
- フォーム送信後の成功状態を管理する`isSuccess`を導入し、**8秒後に自動で非表示**にする。  
- ダッシュボード、ユニット登録、ユーザー一覧、利用者一覧など主要なページのフラッシュメッセージを**中央寄せ**に変更し、表示位置を統一。  
- 職員一覧・利用者一覧ページのフラッシュメッセージに**Tailwind CSSのトランジション（`transition-opacity`と`ease-in-out`）**を適用し、**CSSを削除してコードを簡素化**。

# 実装の概要
1. **プロフィール画面のフラッシュメッセージ改善**  
    - フラッシュメッセージを**画面下部中央**に表示することで、ユーザー一覧・利用者一覧ページと表示位置を統一。  
2. **プロフィール更新後のメッセージ表示処理の改善**  
    - `isSuccess`フラグを導入し、成功時にフラッシュメッセージを表示。  
    - メッセージは8秒後に自動で消える`setTimeout`を実装。  
3. **各一覧画面のフラッシュメッセージ表示位置とアニメーションの統一**  
    - **ユーザー一覧・利用者一覧ページのCSSトランジションを削除し、Tailwind CSSの`ease-in-out`を適用**。  
    - プロフィール画面のトランジションと統一することで、**全画面で一貫したアニメーション**を実現。  
4. **一覧画面のフラッシュメッセージのTailwind CSS移行**  
    - CSSトランジションを削除し、Tailwind CSSの`transition-opacity`を適用。  
    - **フェードイン・アウトと上下移動のアニメーション**を追加し、動きの統一感を向上。

# レビューしてほしいところ
- 各画面でフラッシュメッセージが適切に表示・非表示されるか。  
- 画面遷移やアイコン更新時にメッセージが期待通りに動作するか。  
- `isSuccess`の状態管理に問題がないか。  
- Tailwind CSSの移行によるスタイルの崩れや不具合がないか。

# 不安に思っていること
- 一部の画面で`isSuccess`が未導入な箇所があり、処理フローの統一に不安がある。  
- フラッシュメッセージの**表示時間（8秒）**が長すぎる可能性がある。  
- Tailwind CSSの`transform`がすべてのブラウザで想定通り動作するか。

# 保留していること
- モバイルビューでのフラッシュメッセージ表示位置の調整。  
- **閉じるボタン（Xボタン）**の追加を検討中。  
- 表示時間の調整や短縮を今後検討予定。
