### PR TITLE
返信部分の改行が反映されない不具合の修正

### DIFF
--- a/resources/js/Components/ChildComment.vue
+++ b/resources/js/Components/ChildComment.vue
@@ -55,7 +55,7 @@ const props = defineProps({
                 </div>
 
                 <!-- コメント本文 -->
-                <p class="mt-2">{{ comment.message }}</p>
+                <p class="mt-2 whitespace-pre-wrap">{{ comment.message }}</p>
 
                 <div class="flex justify-end space-x-2 mt-2">
                     <!-- 返信ボタン -->

--- a/resources/js/Components/ParentComment.vue
+++ b/resources/js/Components/ParentComment.vue
@@ -107,7 +107,7 @@ const getCommentCountRecursive = (comments) => {
                 </div>
 
                 <!-- コメント本文 -->
-                <p class="mt-3">{{ comment.message }}</p>
+                <p class="mt-3 whitespace-pre-wrap">{{ comment.message }}</p>
 
                 <!-- 子コメント -->
                 <div


### PR DESCRIPTION
## 目的
ユーザーが返信コメントを投稿した際に、改行が反映されず一行で表示されてしまう問題を解消するため。

## 達成条件
- 返信コメントにおいて、改行が反映されること。
- 子コメントおよび親コメントの表示で、改行が正しく処理されること。

## 実装の概要
`resources/js/Components/ChildComment.vue` および `resources/js/Components/ParentComment.vue` のコメント表示部分に `whitespace-pre-wrap` クラスを追加しました。  
これにより、ユーザーが入力した改行が画面上で適切に反映されるようになります。  

具体的な変更箇所は以下の通りです：
- 親コメントの表示部分
- 子コメントの表示部分

## レビューしてほしいところ
- 改行処理が適切に反映されているか確認してください。
- 既存のレイアウトに影響が出ていないか（文字の折り返しや余白など）確認をお願いします。

## 不安に思っていること
- 特定のブラウザ環境で、`whitespace-pre-wrap` の動作に差異が発生しないか若干の懸念があります。
- コメントの内容が長文の場合、見た目が崩れないか確認が必要かもしれません。

## 保留していること
特にありません。
