### PR TITLE
サブドメイン対応ルーティングの追加とテナントドメインの環境変数化、および不要なテーブル・カラムの削除

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -123,4 +123,5 @@ return [
         'store' => env('APP_MAINTENANCE_STORE', 'database'),
     ],
 
+    'tenant_base_domain' => env('TENANT_BASE_DOMAIN', 'communi-care.jp'),
 ];

--- a/database/migrations/2024_07_18_060229_add_columns_to_users_table.php
+++ b/database/migrations/2024_07_18_060229_add_columns_to_users_table.php
@@ -15,14 +15,11 @@ class AddColumnsToUsersTable extends Migration
     {
         Schema::table('users', function (Blueprint $table) {
             $table->unsignedBigInteger('username_id')->nullable(false);
-            $table->unsignedBigInteger('unit_id')->nullable();
             $table->unsignedBigInteger('tenant_id')->nullable();
             $table->string('icon')->nullable();
             $table->string('tel', 20)->nullable();
 
             // 外部キー制約を追加
-            // usernames テーブルが存在しないため、ここでは外部キー制約を設定しません
-            $table->foreign('unit_id')->references('id')->on('units')->onDelete('cascade');
             $table->foreign('tenant_id')->references('id')->on('tenants')->onDelete('cascade');
         });
     }
@@ -36,11 +33,10 @@ class AddColumnsToUsersTable extends Migration
     {
         Schema::table('users', function (Blueprint $table) {
             // 外部キー制約を削除
-            $table->dropForeign(['unit_id']);
             $table->dropForeign(['tenant_id']);
 
             // カラムを削除
-            $table->dropColumn(['username_id', 'unit_id', 'tenant_id', 'icon', 'tel']);
+            $table->dropColumn(['username_id', 'tenant_id', 'icon', 'tel']);
         });
     }
 }

--- a/database/migrations/2024_12_26_181911_modify_users_table_remove_unit_id_foreign.php
+++ b/database/migrations/2024_12_26_181911_modify_users_table_remove_unit_id_foreign.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            if (Schema::hasColumn('users', 'unit_id')) {
+                // 外部キーが存在する場合は削除
+                $table->dropForeign(['unit_id']);
+                $table->dropColumn('unit_id');
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->unsignedBigInteger('unit_id')->nullable();
+
+            // 必要であれば再度外部キーを追加
+            // $table->foreign('unit_id')->references('id')->on('units')->onDelete('cascade');
+        });
+    }
+};

--- a/database/migrations/2024_12_26_182236_drop_units_table.php
+++ b/database/migrations/2024_12_26_182236_drop_units_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // セントラル環境で units テーブルを削除
+        Schema::dropIfExists('units');
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // 必要であれば再作成
+        Schema::create('units', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+};

--- a/routes/web.php
+++ b/routes/web.php
@@ -27,54 +27,56 @@ Route::middleware([])->group(function () {
     })->name('welcome');
 });
 
-// テナント識別を行うルート
-Route::middleware([App\Http\Middleware\InitializeTenancyCustom::class])->group(function () {
-    Route::get('/home', [TenantHomeController::class, 'index'])
-    ->name('tenant-home');
+Route::domain('{tenant}.' . config('app.tenant_base_domain'))->group(function () {
+    // テナント識別を行うルート
+    Route::middleware([App\Http\Middleware\InitializeTenancyCustom::class])->group(function () {
+        Route::get('/home', [TenantHomeController::class, 'index'])
+        ->name('tenant-home');
 
-    Route::middleware(['auth'])->group(function () {
-        Route::get('/dashboard', [DashboardController::class, 'index'])->name('dashboard');
+        Route::middleware(['auth'])->group(function () {
+            Route::get('/dashboard', [DashboardController::class, 'index'])->name('dashboard');
 
-        Route::post('/profile/update-icon', [ProfileController::class, 'updateIcon'])->name('profile.updateIcon');
-        Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
-        Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
-        Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
+            Route::post('/profile/update-icon', [ProfileController::class, 'updateIcon'])->name('profile.updateIcon');
+            Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
+            Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
+            Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
 
-        // ユーザーの所属ユニットのforum_idを取得（エンドポイント）
-        Route::get('/user-forum-id', [UserController::class, 'getUserForumId']);
+            // ユーザーの所属ユニットのforum_idを取得（エンドポイント）
+            Route::get('/user-forum-id', [UserController::class, 'getUserForumId']);
 
-        // フォーラム
-        Route::get('/forum', [ForumController::class, 'index'])->name('forum.index');
+            // フォーラム
+            Route::get('/forum', [ForumController::class, 'index'])->name('forum.index');
 
-        // 投稿
-        Route::post('/forum/post', [PostController::class, 'store'])->name('forum.store');
-        Route::delete('/forum/post/{id}', [PostController::class, 'destroy'])->name('forum.destroy');
-        Route::post('/like/toggle', [LikeController::class, 'toggleLike'])->name('like.toggle');
+            // 投稿
+            Route::post('/forum/post', [PostController::class, 'store'])->name('forum.store');
+            Route::delete('/forum/post/{id}', [PostController::class, 'destroy'])->name('forum.destroy');
+            Route::post('/like/toggle', [LikeController::class, 'toggleLike'])->name('like.toggle');
 
-        // 返信
-        Route::post('/forum/comment', [CommentController::class, 'store'])->name('comment.store');
-        Route::delete('/forum/comment/{id}', [CommentController::class, 'destroy'])->name('comment.destroy');
+            // 返信
+            Route::post('/forum/comment', [CommentController::class, 'store'])->name('comment.store');
+            Route::delete('/forum/comment/{id}', [CommentController::class, 'destroy'])->name('comment.destroy');
 
-        Route::resource('users', UserController::class);
-        Route::get('/users/{user}/edit-profile', [UserController::class, 'editProfile'])->name('users.editProfile');
-        Route::get('/users/{user}/edit-icon', [UserController::class, 'editIcon'])->name('users.editIcon');
-        Route::post('/users/{user}/update-icon', [UserController::class, 'updateIcon'])->name('users.updateIcon');
+            Route::resource('users', UserController::class);
+            Route::get('/users/{user}/edit-profile', [UserController::class, 'editProfile'])->name('users.editProfile');
+            Route::get('/users/{user}/edit-icon', [UserController::class, 'editIcon'])->name('users.editIcon');
+            Route::post('/users/{user}/update-icon', [UserController::class, 'updateIcon'])->name('users.updateIcon');
 
-        // Route::middleware(['role:admin'])->group(function () {
-        //     Route::get('/admin', [AdminController::class, 'index'])->name('admin.dashboard');
-        // });
-        // Route::get('/units/list-for-sidebar', [UnitController::class, 'listForSidebar'])->name('units.listForSidebar');
+            // Route::middleware(['role:admin'])->group(function () {
+            //     Route::get('/admin', [AdminController::class, 'index'])->name('admin.dashboard');
+            // });
+            // Route::get('/units/list-for-sidebar', [UnitController::class, 'listForSidebar'])->name('units.listForSidebar');
 
-        // ユニット
-        Route::resource('units', UnitController::class);
+            // ユニット
+            Route::resource('units', UnitController::class);
 
-        // 利用者
-        Route::resource('residents', ResidentController::class);
+            // 利用者
+            Route::resource('residents', ResidentController::class);
 
-        // 管理者権限の譲渡
-        Route::post('/admin/transfer-admin', [AdminUserController::class, 'transferAdmin'])->name('admin.transferAdmin');
+            // 管理者権限の譲渡
+            Route::post('/admin/transfer-admin', [AdminUserController::class, 'transferAdmin'])->name('admin.transferAdmin');
+        });
+        Route::post('/logout', [AuthenticatedSessionController::class, 'destroy'])->name('logout');
     });
-    Route::post('/logout', [AuthenticatedSessionController::class, 'destroy'])->name('logout');
 });
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
## 目的
- テナントごとのサブドメインアクセスを可能にし、本番環境での運用を柔軟にするため  
- セントラル環境で使用しない`units`テーブルや`users`テーブルの`unit_id`カラムを削除し、データベースの整合性を保つため  

## 達成条件
- サブドメインでテナントごとのアクセスができるルーティングを実装  
- 本番環境の`.env`に`TENANT_BASE_DOMAIN`を追加し、ドメインの切り替えが容易になる  
- `users`テーブルから`unit_id`とその外部キー制約を削除  
- セントラルデータベースから`units`テーブルを削除  

## 実装の概要
### 1. サブドメイン対応ルーティングの追加
- `routes/web.php`に`Route::domain`を使用したサブルーティングを追加  
- `.env`に`TENANT_BASE_DOMAIN`を追加し、テナントドメインを環境変数化  

### 2. usersテーブルの修正
- `users`テーブルから`unit_id`カラムと外部キー制約を削除  
- 該当マイグレーションファイルを修正し、`unit_id`が存在する場合は外部キーを削除する処理を追加  

### 3. セントラル環境のunitsテーブル削除
- セントラルデータベースで不要な`units`テーブルを削除  
- 必要に応じて再作成できるよう、逆マイグレーションも用意  

## レビューしてほしいところ
- サブドメインルーティングの実装が期待通り動作するか  
- 本番環境での`.env`設定に問題がないか  
- `users`テーブルのマイグレーションが本番環境でもエラーなく実行されるか  

## 不安に思っていること
- 本番環境で`git pull`した際に、すでに存在している`unit_id`がマイグレーションの実行を妨げる可能性  
- マイグレーションのリフレッシュを行わない場合の`users`テーブルの整合性  

## 保留していること
- テナントごとのテーブルマイグレーション（`php artisan tenants:migrate`）は別途検証後に実施  
- 本番環境での`TENANT_BASE_DOMAIN`の適用テストはDNS設定完了後に行う予定  