### PR TITLE
重複していたログアウトルートの削除

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -75,7 +75,6 @@ Route::domain('{tenant}.' . config('app.tenant_base_domain'))->group(function ()
             // 管理者権限の譲渡
             Route::post('/admin/transfer-admin', [AdminUserController::class, 'transferAdmin'])->name('admin.transferAdmin');
         });
-        Route::post('/logout', [AuthenticatedSessionController::class, 'destroy'])->name('logout');
     });
 });
 


### PR DESCRIPTION
## 目的

本番環境で `php artisan route:cache` を実行した際に、`logout` ルートが重複しておりエラーが発生しました。  
このプルリクエストでは、`routes/web.php` で定義されていたログアウトルートを削除し、`routes/auth.php` にあるルートを利用することで、ルートの重複を解消します。

***

## 達成条件

- `php artisan route:cache` 実行時にエラーが発生しないこと
- ログアウト処理が引き続き正しく動作すること

***

## 実装の概要

- `routes/web.php` に記述されていた下記ルートを削除しました。

  ```  php
  Route::post('/logout', [AuthenticatedSessionController::class, 'destroy'])->name('logout');
  ```

  理由：`routes/auth.php` に同一のルートがすでに存在しており、二重に定義されていたためです。

- 本番環境で `php artisan route:cache` を実行し、エラーが解消されることを確認しました。

***

## レビューしてほしいところ

- ログアウトルートの削除に伴う副作用がないか
- 他に同様の重複がないか

***

## 不安に思っていること

- 一部の環境でルートキャッシュが残っていた場合の挙動が不安です。必要に応じてキャッシュクリアを促す注意書きを追加するか検討中です。

***

## 保留していること

- 今回はログアウトルートの削除に限定しましたが、他のルートの重複がないか確認は完了していません。必要であれば別途対応します。
