### PR TITLE
セントラルドメインの追加による本番環境のエラー解消

### DIFF
--- a/config/tenancy.php
+++ b/config/tenancy.php
@@ -19,6 +19,7 @@ return [
     'central_domains' => [
         '127.0.0.1',
         'localhost',
+        'communi-care.jp',//本番のセントラルドメイン
     ],
 
     /**


### PR DESCRIPTION
## 目的
本番環境で「communi-care.jp」をセントラルドメインとして認識させることで、`TenantCouldNotBeIdentifiedOnDomainException` エラーを解消し、セントラルアプリケーションが正しく動作するようにする。

## 達成条件
- `config/tenancy.php` に本番環境のセントラルドメイン「communi-care.jp」を追加する。  
- 本番環境にデプロイし、403エラーや500エラーが解消されることを確認する。  
- テナントドメインとは異なり、セントラルドメインが特別なルーティングや処理の対象外となることを確認する。  

## 実装の概要
- `config/tenancy.php` の `central_domains` 配列に `communi-care.jp` を追加。  
- 本番環境でのデプロイ後、キャッシュのクリアとマイグレーションの確認を行った。  
- **テナントドメインとセントラルドメインを区別しつつ、セントラルドメインをバイパスするルーティングはすでに実装済み**。  
- エラーログ (`laravel.log`) で `TenantCouldNotBeIdentifiedOnDomainException` が記録されていたが、この修正によりエラーの再発が防止される。

## レビューしてほしいところ
- `config/tenancy.php` へのセントラルドメイン追加が適切か。  
- 他の環境（ステージングやローカル環境）での影響がないかの確認。  
- 今回の対応でセントラルドメインとテナントドメインの処理が明確に分離できているか。

## 不安に思っていること
- セントラルドメインを直接指定する方法で、将来的にドメインが変更になった場合の対応負荷が懸念される。  
- テナント作成のフローでセントラルドメインが誤って影響を受けないか。

## 保留していること
- 本番環境での完全な動作確認。  
- **テナントドメインの登録処理は別ブランチで対応予定**。  
- テナント作成フローの細かなエラーハンドリングについては、別ブランチで対応予定。  
