### PR TITLE
環境に応じたドメインとセッションの切り替え処理を実装

### DIFF
--- a/app/Http/Controllers/Auth/TenantRegisterController.php
+++ b/app/Http/Controllers/Auth/TenantRegisterController.php
@@ -32,8 +32,11 @@ class TenantRegisterController extends Controller
             ],
         ]);
 
+        // 環境に応じてベースドメインを設定
+        $baseDomain = app()->environment('production') ? 'communi-care.jp' : 'localhost';
+
         // ドメイン名を生成
-        $domain = strtolower(preg_replace('/[^\x20-\x7E]/', '', str_replace(' ', '-', $validatedData['tenant_domain_id']))) . '.localhost';
+        $domain = strtolower(preg_replace('/[^\x20-\x7E]/', '', str_replace(' ', '-', $validatedData['tenant_domain_id']))) . '.' . $baseDomain;
 
         // ドメインの重複チェック
         if (Domain::where('domain', $domain)->exists()) {
@@ -70,10 +73,11 @@ class TenantRegisterController extends Controller
         });
 
         // セッションのドメインを動的に設定
-        Config::set('session.domain', $domain);
+        $sessionDomain = app()->environment('production') ? '.communi-care.jp' : '.localhost';
+        Config::set('session.domain', $sessionDomain);
 
         // クッキーの設定
-        $cookie = Cookie::make('XSRF-TOKEN', csrf_token(), 120, '/', $domain, false, true, false, 'Lax');
+        $cookie = Cookie::make('XSRF-TOKEN', csrf_token(), 120, '/', $sessionDomain, false, true, false, 'Lax');
         Cookie::queue($cookie);
 
         // テナントIDをセッションに保存


### PR DESCRIPTION
## 目的

本番環境とローカル環境でのテナントドメインとセッションの管理を切り替えることで、環境ごとに正しくテナントが動作するようにするため。  
特に、本番環境では「*.communi-care.jp」のサブドメイン形式でテナントを登録・アクセス可能にし、ローカル環境では「*.localhost」での動作を維持することが目的です。

## 達成条件

- 本番環境で作成されたテナントが「tenant\_domain\_id.communi-care.jp」でアクセス可能になる
- ローカル環境で作成されたテナントが「tenant\_domain\_id.localhost」でアクセス可能になる
- セッションのドメインも環境ごとに切り替わり、クッキーが正しく設定される

## 実装の概要

以下の変更を加えました。

### 変更点

1. テナント登録時にドメインを動的に切り替え

   ```php
   $baseDomain = app()->environment('production') ? 'communi-care.jp' : 'localhost';
   $domain = strtolower(preg_replace('/[^\x20-\x7E]/', '', str_replace(' ', '-', $validatedData['tenant_domain_id']))) . '.' . $baseDomain;
   ```

2. セッションのドメインも環境に応じて切り替え

   ```php
   $sessionDomain = app()->environment('production') ? '.communi-care.jp' : '.localhost';
   Config::set('session.domain', $sessionDomain);
   ```

3. XSRF-TOKENのクッキーも環境に応じて設定

   ```php
   $cookie = Cookie::make('XSRF-TOKEN', csrf_token(), 120, '/', $sessionDomain, false, true, false, 'Lax');
   Cookie::queue($cookie);
   ```

## レビューしてほしいところ

- テナント登録処理におけるドメイン生成ロジックが適切かどうか
- セッションやクッキーのドメイン切り替えで漏れがないか

## 不安に思っていること

- 本番環境でのワイルドカードサブドメイン（\*.communi-care.jp）が正しく設定されるか
- 本番環境でのセッション管理が意図通りに動作するか

## 保留していること

- Xserverでのワイルドカードサブドメイン設定（「\*」での設定）が正しく反映されるか確認中
- 本番環境でのテナントドメインアクセスがDNSレコードの設定次第となるため、反映まで時間がかかる可能性あり