### PR TITLE
Viteビルド出力ディレクトリの設定を追加

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -17,4 +17,7 @@ export default defineConfig({
             },
         }),
     ],
+    build: {
+        outDir: "public/build",
+    },
 });


### PR DESCRIPTION
## 目的

本番環境でViteのビルドファイルが`public/build`配下に正しく生成・配置されず、アセットが読み込まれない問題を修正することを目的としています。

## 達成条件

- Viteのビルド時に`public/build`ディレクトリ内にアセットが出力されるようにする。
- 本番環境でビルド後にアプリケーションが正常に動作することを確認する。

## 実装の概要

- `vite.config.js`に`outDir`の設定を追加しました。
- ビルド結果が`public/build`に出力されるよう`build.outDir`を明示的に指定しました。
- ローカル環境でのビルド結果を確認し、期待通りの出力が得られることを確認済みです。

## レビューしてほしいところ

- `vite.config.js`の記述が適切かどうか。
- ビルド時の出力ディレクトリの指定が本番環境に影響を与えないか。
- 不要な設定が含まれていないか。

## 不安に思っていること

- 本番環境での挙動が完全に同一であるか、再度ビルドを行う際に問題が発生しないかが懸念点です。
- 特定の環境依存の問題が存在する可能性があるため、複数環境での確認が必要かもしれません。

## 保留していること

- 本番環境へのデプロイ後の最終的な検証はまだ行っていません。デプロイ後に動作確認を行う予定です。
