### PR TITLE
ナビゲーション・プロフィールモーダル・ユニット管理の改善およびエラー修正

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -58,6 +58,7 @@ class UserController extends Controller
          $user->load('unit'); // ユニット情報をロードする
          return Inertia::render('Users/Show', [
              'user' => $user,
+             'units' => Unit::all(),
          ]);
      }
 

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -189,5 +189,6 @@
     "Resident Name": "利用者名",
     "Register Resident": "利用者登録",
     "Manage unit.": "部署を管理します",
-    "Staff": "職員ページ"
+    "Staff": "職員ページ",
+    "Register or delete departments.": "部署の登録や削除を行います"
 }

--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -274,23 +274,14 @@ const isForumPage = ref(window.location.pathname === "/forum");
                         >
                             {{ $t("Profile") }}
                         </ResponsiveNavLink>
-                        <form
-                            :action="route('logout')"
-                            method="post"
-                            class="inline"
-                        >
-                            <input
-                                type="hidden"
-                                name="_token"
-                                :value="csrfToken"
-                            />
-                            <button
-                                type="submit"
-                                class="block w-full text-left px-4 py-2 text-sm leading-5 text-gray-700 hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus:bg-gray-100 transition duration-150 ease-in-out"
+                        <form method="POST" @submit.prevent="logout">
+                            <ResponsiveNavLink
+                                as="button"
+                                href="#"
                                 @click="confirmGuestLogout"
                             >
                                 {{ $t("Log Out") }}
-                            </button>
+                            </ResponsiveNavLink>
                         </form>
                     </div>
                 </div>

--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -79,7 +79,7 @@ const isForumPage = ref(window.location.pathname === "/forum");
                                     href="#"
                                     @click.prevent="navigateToForum"
                                     :active="isForumPage"
-                                    class="cursor-pointer"
+                                    class="cursor-pointer whitespace-nowrap"
                                 >
                                     {{ $t("Forum") }}
                                 </NavLink>
@@ -87,6 +87,7 @@ const isForumPage = ref(window.location.pathname === "/forum");
                                 <NavLink
                                     :href="route('users.index')"
                                     :active="route().current('users.index')"
+                                    class="whitespace-nowrap"
                                 >
                                     {{ $t("Staff") }}
                                 </NavLink>
@@ -94,6 +95,7 @@ const isForumPage = ref(window.location.pathname === "/forum");
                                 <NavLink
                                     :href="route('residents.index')"
                                     :active="route().current('residents.index')"
+                                    class="whitespace-nowrap"
                                 >
                                     {{ $t("Residents") }}
                                 </NavLink>
@@ -101,6 +103,7 @@ const isForumPage = ref(window.location.pathname === "/forum");
                                 <NavLink
                                     :href="route('dashboard')"
                                     :active="route().current('dashboard')"
+                                    class="whitespace-nowrap"
                                 >
                                     {{ $t("Dashboard") }}
                                 </NavLink>

--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -111,7 +111,7 @@ const isForumPage = ref(window.location.pathname === "/forum");
                             <!-- テナント名を表示 -->
                             <div
                                 v-if="page.props.tenant?.business_name"
-                                class="text-gray-500 mr-4 px-3 py-1 bg-gray-100 rounded-md text-sm font-medium"
+                                class="hidden xl:block text-gray-500 mr-4 px-3 py-1 bg-gray-100 rounded-md text-sm font-medium"
                             >
                                 {{ page.props.tenant.business_name }}
                             </div>
@@ -344,5 +344,11 @@ const isForumPage = ref(window.location.pathname === "/forum");
     align-items: center;
     height: 100%;
     padding: 0 0.75rem;
+}
+
+@media (min-width: 1120px) {
+    .xl\:block {
+        display: block;
+    }
 }
 </style>

--- a/resources/js/Pages/Admin/Dashboard.vue
+++ b/resources/js/Pages/Admin/Dashboard.vue
@@ -17,7 +17,7 @@ import { Link, Head } from "@inertiajs/vue3";
                         {{ $t("Unit Management") }}
                     </h3>
                     <p class="mt-2 max-w-4xl text-sm text-gray-500">
-                        {{ $t("Manage unit.") }}
+                        {{ $t("Register or delete departments.") }}
                     </p>
                     <div class="mt-4">
                         <Link

--- a/resources/js/Pages/Dashboard.vue
+++ b/resources/js/Pages/Dashboard.vue
@@ -4,7 +4,7 @@ import { Head, usePage } from "@inertiajs/vue3";
 import { ref, onMounted } from "vue";
 import AdminDashboard from "@/Pages/Admin/Dashboard.vue";
 import { redirectToForum } from "@/Utils/redirectToForum";
-import { Link } from "@inertiajs/vue3";
+import Show from "@/Pages/Users/Show.vue";
 
 const { props } = usePage();
 const isAdmin = props.isAdmin;
@@ -31,6 +31,21 @@ const navigateToForum = () => {
 };
 
 console.log("User data:", props.auth.user);
+
+// モーダル制御用の状態
+const isUserProfileVisible = ref(false);
+const selectedUser = ref(null);
+
+// モーダルを開く関数
+const openUserProfile = (user) => {
+    selectedUser.value = user;
+    isUserProfileVisible.value = true;
+};
+
+// モーダルを閉じる関数
+const closeUserProfile = () => {
+    isUserProfileVisible.value = false;
+};
 </script>
 
 <template>
@@ -69,9 +84,9 @@ console.log("User data:", props.auth.user);
                             </div>
 
                             <!-- 右側：ユーザーアイコンと名前 -->
-                            <Link
-                                :href="`/users/${props.auth.user.id}`"
-                                class="flex items-center space-x-4 group hover:bg-gray-50 rounded-lg p-2"
+                            <div
+                                @click="openUserProfile(props.auth.user)"
+                                class="flex items-center space-x-4 group hover:bg-gray-50 rounded-lg p-2 cursor-pointer"
                             >
                                 <img
                                     :src="
@@ -89,7 +104,7 @@ console.log("User data:", props.auth.user);
                                         {{ props.auth.user.name }}
                                     </span>
                                 </div>
-                            </Link>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -117,6 +132,17 @@ console.log("User data:", props.auth.user);
         <!-- 管理者ページ -->
         <div v-if="isAdmin">
             <AdminDashboard />
+        </div>
+
+        <!-- モーダルコンポーネント -->
+        <div
+            v-if="isUserProfileVisible"
+            class="fixed inset-0 bg-black/50 flex justify-center items-center z-50"
+            @click="closeUserProfile"
+        >
+            <div @click.stop>
+                <Show v-if="selectedUser" :user="selectedUser" :units="units" />
+            </div>
         </div>
     </AuthenticatedLayout>
 </template>

--- a/resources/js/Pages/Dashboard.vue
+++ b/resources/js/Pages/Dashboard.vue
@@ -54,12 +54,13 @@ console.log("User data:", props.auth.user);
                             {{ $t("Logged in as guest user") }}
                         </div>
                         <!-- 掲示板へのリンクボタン -->
-                        <button
-                            @click="navigateToForum"
-                            class="text-blue-500 link-hover"
+                        <ResponsiveNavLink
+                            href="#"
+                            @click.prevent="navigateToForum"
+                            class="cursor-pointer text-blue-500"
                         >
                             {{ $t("Go to Forum") }}
-                        </button>
+                        </ResponsiveNavLink>
                     </div>
                 </div>
             </div>

--- a/resources/js/Pages/Dashboard.vue
+++ b/resources/js/Pages/Dashboard.vue
@@ -4,6 +4,7 @@ import { Head, usePage } from "@inertiajs/vue3";
 import { ref, onMounted } from "vue";
 import AdminDashboard from "@/Pages/Admin/Dashboard.vue";
 import { redirectToForum } from "@/Utils/redirectToForum";
+import { Link } from "@inertiajs/vue3";
 
 const { props } = usePage();
 const isAdmin = props.isAdmin;
@@ -46,23 +47,50 @@ console.log("User data:", props.auth.user);
         <div class="pb-12 px-4 sm:px-8 lg:px-16">
             <div class="max-w-6xl mx-auto">
                 <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
-                    <div
-                        class="p-6 text-gray-900 flex flex-col sm:flex-row items-center space-y-4 sm:space-y-0 sm:space-x-4"
-                    >
-                        <div v-if="!isGuest">
-                            {{ $t("You're logged in") }}
-                        </div>
-                        <div v-else>
-                            {{ $t("Logged in as guest user") }}
-                        </div>
-                        <!-- 掲示板へのリンクボタン -->
-                        <button
-                            href="#"
-                            @click.prevent="navigateToForum"
-                            class="text-blue-500 link-hover whitespace-nowrap"
+                    <div class="p-6 text-gray-900">
+                        <div
+                            class="flex flex-col sm:flex-row justify-between items-center space-y-4 sm:space-y-0"
                         >
-                            {{ $t("Go to Forum") }}
-                        </button>
+                            <!-- 左側：ログインメッセージと掲示板リンク -->
+                            <div class="flex items-center space-x-4">
+                                <div v-if="!isGuest">
+                                    {{ $t("You're logged in") }}
+                                </div>
+                                <div v-else>
+                                    {{ $t("Logged in as guest user") }}
+                                </div>
+                                <button
+                                    href="#"
+                                    @click.prevent="navigateToForum"
+                                    class="text-blue-500 link-hover whitespace-nowrap"
+                                >
+                                    {{ $t("Go to Forum") }}
+                                </button>
+                            </div>
+
+                            <!-- 右側：ユーザーアイコンと名前 -->
+                            <Link
+                                :href="`/users/${props.auth.user.id}`"
+                                class="flex items-center space-x-4 group hover:bg-gray-50 rounded-lg p-2"
+                            >
+                                <img
+                                    :src="
+                                        props.auth.user.icon
+                                            ? `/storage/${props.auth.user.icon}`
+                                            : '/images/default_user_icon.png'
+                                    "
+                                    alt="Profile Icon"
+                                    class="w-12 h-12 rounded-full"
+                                />
+                                <div class="flex items-center">
+                                    <span
+                                        class="font-bold text-lg text-gray-500 group-hover:text-black transition-colors"
+                                    >
+                                        {{ props.auth.user.name }}
+                                    </span>
+                                </div>
+                            </Link>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/resources/js/Pages/Dashboard.vue
+++ b/resources/js/Pages/Dashboard.vue
@@ -54,13 +54,13 @@ console.log("User data:", props.auth.user);
                             {{ $t("Logged in as guest user") }}
                         </div>
                         <!-- 掲示板へのリンクボタン -->
-                        <ResponsiveNavLink
+                        <button
                             href="#"
                             @click.prevent="navigateToForum"
-                            class="cursor-pointer text-blue-500"
+                            class="text-blue-500 link-hover"
                         >
                             {{ $t("Go to Forum") }}
-                        </ResponsiveNavLink>
+                        </button>
                     </div>
                 </div>
             </div>

--- a/resources/js/Pages/Dashboard.vue
+++ b/resources/js/Pages/Dashboard.vue
@@ -46,7 +46,9 @@ console.log("User data:", props.auth.user);
         <div class="pb-12 px-4 sm:px-8 lg:px-16">
             <div class="max-w-6xl mx-auto">
                 <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
-                    <div class="p-6 text-gray-900 flex items-center space-x-4">
+                    <div
+                        class="p-6 text-gray-900 flex flex-col sm:flex-row items-center space-y-4 sm:space-y-0 sm:space-x-4"
+                    >
                         <div v-if="!isGuest">
                             {{ $t("You're logged in") }}
                         </div>
@@ -57,7 +59,7 @@ console.log("User data:", props.auth.user);
                         <button
                             href="#"
                             @click.prevent="navigateToForum"
-                            class="text-blue-500 link-hover"
+                            class="text-blue-500 link-hover whitespace-nowrap"
                         >
                             {{ $t("Go to Forum") }}
                         </button>

--- a/resources/js/Pages/Profile/Partials/IconEditForm.vue
+++ b/resources/js/Pages/Profile/Partials/IconEditForm.vue
@@ -153,14 +153,14 @@ const submit = () => {
                 <div class="flex justify-between">
                     <button
                         type="submit"
-                        class="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600"
+                        class="w-32 px-4 py-2 bg-blue-100 text-blue-700 rounded-md transition hover:bg-blue-300 hover:text-white text-center"
                     >
                         更新
                     </button>
                     <button
                         type="button"
                         @click="$emit('close')"
-                        class="bg-gray-300 text-gray-700 px-4 py-2 rounded hover:bg-gray-400"
+                        class="w-32 px-4 py-2 bg-gray-300 text-gray-700 rounded-md transition hover:bg-gray-500 hover:text-white text-center"
                     >
                         キャンセル
                     </button>

--- a/resources/js/Pages/Unit/Register.vue
+++ b/resources/js/Pages/Unit/Register.vue
@@ -127,7 +127,7 @@ watchEffect(() => {
                         <span class="text-gray-800">{{ unit.name }}</span>
                         <button
                             @click="deleteUnit(unit.id)"
-                            class="w-full sm:w-auto px-4 py-2 bg-red-100 text-red-700 rounded-md transition hover:bg-red-300 hover:text-white text-center"
+                            class="px-4 py-2 bg-red-100 text-red-700 rounded-md transition hover:bg-red-300 hover:text-white text-center"
                         >
                             <i class="bi bi-trash"></i>
                         </button>


### PR DESCRIPTION
## 目的

ナビゲーションリンクやプロフィール表示の改善、ダッシュボードのレイアウト調整を通じて、ユーザー体験を向上させることを目的としています。  
また、ユニット削除ボタンの幅調整や表示エラーの修正を行い、UIの整合性と柔軟性を高めます。

## 達成条件

- テナント名が画面幅1120px以上で表示されること
- ナビゲーションリンクの折り返しが発生しないこと
- ユーザープロフィールがモーダル表示されること
- ユニット削除ボタンがレスポンシブに対応していること
- Showコンポーネントでの「units」プロパティ不足エラーが解消されていること

## 実装の概要

- **テナント名の表示制限**：画面幅1120px以上でのみテナント名を表示するようにし、ナビゲーションリンクとのバランスを維持しました。
- **ナビゲーションリンクの修正**：`whitespace-nowrap`を適用し、ナビゲーションリンクの折り返しを防ぎ、視認性を向上させました。
- **ログアウトボタンの統一**：`ResponsiveNavLink`コンポーネントを利用し、ログアウトボタンのデザインと挙動を他のリンクと統一しました。
- **ユーザープロフィールのモーダル表示**：ユーザープロフィールページへの遷移をモーダル表示に変更し、クリック時にユーザー情報が即座に表示されるようにしました。
- **ユニット削除ボタンの幅固定解除**：ユニット削除ボタンの幅がモバイルとデスクトップで固定されていたため、画面サイズに応じて柔軟に表示されるように修正しました。
- **Showコンポーネントのエラー修正**：「Missing required prop: 'units'」エラーを解消するため、`Unit::all()`で全ユニット情報を取得し、`Inertia::render`に`units`プロパティを追加しました。

## レビューしてほしいところ

- ユーザープロフィールのモーダル表示が意図したとおりに動作しているか
- `Show`コンポーネントでの`units`の渡し方が適切か
- ナビゲーションリンクやログアウトボタンのレイアウトが崩れていないか
- ユニット削除ボタンの幅調整がデバイスごとに適切に機能しているか

## 不安に思っていること

- ユーザープロフィールのモーダル表示が複数回開閉した際に、不要なパフォーマンスの低下や不具合が発生しないか懸念しています。
- レスポンシブ対応において、一部の端末で表示崩れが発生しないか確認が必要と考えています。

## 保留していること

- **管理者用の部署管理ページを、職員ページや利用者ページと同じレイアウトやスタイルで作り直すことを検討しています。**  
  この際、以下の要素を見直し、操作性と視認性を向上させることを目指しています。

  - **削除モードボタンの導入**：部署を複数選択して一括削除できるモードを追加し、操作の効率化を図ります。
  - **部署新規登録フォームの分離**：部署登録を別ページやポップアップで行うことで、部署一覧ページの視認性を維持しつつ、操作ミスを防ぎます。
  - **レスポンシブ対応の強化**：モバイル端末からの操作性を高めるため、各セクションのレイアウトやボタン配置を見直します。
