### PR TITLE
ゲストユーザー削除処理を特定テナントに限定するよう修正

### DIFF
--- a/app/Console/Commands/CleanupGuestUsers.php
+++ b/app/Console/Commands/CleanupGuestUsers.php
@@ -28,50 +28,34 @@ class CleanupGuestUsers extends Command
      */
     public function handle()
     {
-        $tenantDomainId = env('TENANT_DOMAIN_ID');
-        $this->info("設定されているTENANT_DOMAIN_ID: " . ($tenantDomainId ?? 'null'));
-
-        if (!$tenantDomainId) {
-            $this->error('TENANT_DOMAIN_ID が設定されていません。');
-            return;
-        }
-
-        // テナントの検索処理をデバッグ
-        $tenant = Tenant::whereJsonContains('data->tenant_domain_id', $tenantDomainId)->first();
-        $this->info("検索クエリ結果: " . ($tenant ? "テナントが見つかりました" : "テナントが見つかりません"));
-        
-        if ($tenant) {
-            $this->info("テナントデータ: " . json_encode($tenant->data));
-        }
+        // guestdemo テナントだけを取得
+        $tenant = Tenant::where('tenant_domain_id', 'guestdemo')->first();
 
         if (!$tenant) {
-            $this->error("指定されたテナントが見つかりません: {$tenantDomainId}");
+            $this->error("テナント 'guestdemo' が見つかりません。");
             return;
         }
 
+        $this->info("テナント処理開始: " . $tenant->business_name);
+
         try {
-            // テナントの初期化
+            // テナントを初期化
             Tenancy::initialize($tenant);
             $this->info("データベース接続: " . \DB::connection()->getDatabaseName());
 
-            // 削除対象のユーザー数を事前に確認
-            $targetUsers = User::whereNotNull('guest_session_id')
-                ->where('created_at', '<', now()->subHours(1))
-                ->get();
-            
-            $this->info("削除対象ユーザー数: " . $targetUsers->count());
-            $this->info("対象ユーザー情報: " . json_encode($targetUsers->toArray()));
-
+            // ゲストユーザー削除処理
             $deletedCount = User::whereNotNull('guest_session_id')
                 ->where('created_at', '<', now()->subHours(1))
                 ->delete();
 
-            $this->info("削除完了。削除数: {$deletedCount}");
+            $this->info("テナント [{$tenant->business_name}] のゲストユーザーを削除しました: {$deletedCount} 件");
         } catch (\Exception $e) {
-            $this->error("エラーが発生しました: " . $e->getMessage());
+            $this->error("処理中にエラーが発生しました: " . $e->getMessage());
             $this->error("スタックトレース: " . $e->getTraceAsString());
         } finally {
             Tenancy::end();
         }
+
+        $this->info('テナント guestdemo の処理が完了しました。');
     }
 }


### PR DESCRIPTION
## 目的

- シングルデータベース方式に移行したことに伴い、環境変数 `TENANT_DOMAIN_ID` に依存せず、特定のテナントを直接検索してゲストユーザーの削除処理を行う形に変更します。
- 本番環境とローカル環境で同様に動作し、環境差異によるエラーを防ぐためです。
- 不要なエラーや削除漏れを防ぎ、メンテナンスのしやすさを向上させます。

***

## 達成条件

- 特定のテナント (guestdemo) のみを対象として、1時間以上経過したゲストユーザーを削除する処理が問題なく動作すること。
- 処理が実行された際に、ログが正しく出力され、エラーが発生した場合は適切にハンドリングされること。
- 本番環境でも`guestdemo`が存在すれば動作し、特別な設定を必要としないこと。

***

## 実装の概要

- `TENANT_DOMAIN_ID` という環境変数を使用してテナントを特定していた処理を削除し、`Tenant::where('tenant_domain_id', 'guestdemo')->first()` に置き換えました。
- エラー処理として、テナントが見つからない場合は処理を終了し、ログに「テナント 'guestdemo' が見つかりません。」と出力するようにしました。
- 削除対象のユーザーが存在した場合、削除件数をログに記録します。
- 例外が発生した場合はエラーメッセージとスタックトレースをログに出力するようにしています。
- テナントの初期化と終了 (`Tenancy::initialize` / `Tenancy::end`) は変更せず、処理フローを維持しています。

***

## レビューしてほしいところ

- `guestdemo` テナントを直接指定する方式に変更したことで、今後の拡張性や他テナントへの展開がしやすいか。
- エラーハンドリングやログ出力が適切で、運用時に問題なく動作するか確認していただきたいです。
- コードの可読性や処理フローがわかりやすいか、レビューをお願いします。

***

## 不安に思っていること

- 現在は `guestdemo` という特定のテナントだけを処理対象にしていますが、将来的に複数のテナントを対象にする必要が出てきた場合の拡張方法について懸念があります。
- `guestdemo` テナントが存在しない環境ではエラーが発生するため、本番環境での確認が必要です。
- もし他のテナントでの処理が必要になる場合は、ループ処理などを導入する必要があるかもしれません。

***

## 保留していること

- 現在は `guestdemo` テナントのみを対象としていますが、すべてのテナントを順番に処理する機能については実装を見送っています。
- 全テナントを処理する方式は拡張が容易ですが、現時点では必要性が低いため、将来的な課題として保留しています。
- cronジョブを使った自動化についても検討しましたが、手動での運用を優先する方針のため、今回は見送りました。