### PR TITLE
本番・ステージング環境のドメイン抽出処理およびサフィックスの修正

### DIFF
--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -39,7 +39,7 @@ class AuthenticatedSessionController extends Controller
         // 環境に応じてドメインからテナントIDを抽出
         $tenantDomainId = match(config('app.env')) {
             'local' => str_replace('.localhost', '', $domain),
-            'production' => str_replace('.communicare-app.jp', '', $domain),
+            'production' => str_replace('.communi-care.jp', '', $domain),
             default => $domain
         };
 

--- a/config/tenancy.php
+++ b/config/tenancy.php
@@ -199,7 +199,7 @@ return [
 
     'domain_suffix' => [
         'local' => '.localhost',
-        'production' => '.communicare-app.jp',
-        'staging' => '.staging.communicare-app.jp',
+        'production' => '.communi-care.jp',
+        'staging' => '.staging.communi-care.jp',
     ]
 ];


### PR DESCRIPTION
## 目的

シングルデータベース方式に移行したことで、テナントごとのサブドメイン登録が不要となりました。これに伴い、新規取得した `communicare-app.jp` ドメインではなく、既存のXserver環境で使用していた `communi-care.jp` ドメインを利用してデプロイすることにしました。  
この変更により、ドメイン管理の手間を削減し、既存環境を活用して運用の効率化を図ることを目的としています。

## 達成条件

- 本番環境およびステージング環境で、正しくテナントIDがドメインから抽出されること
- ローカル環境に影響を与えずに動作すること
- ドメイン変更によるサービスの停止や不具合が発生しないこと

## 実装の概要

- 環境に応じてドメインからテナントIDを抽出する処理を修正

  - `production` のドメイン抽出を `communicare-app.jp` から `communi-care.jp` に変更
  - `staging` のドメインサフィックスも同様に修正

- `config` 配下の `domain_suffix` の定義を更新し、本番環境とステージング環境に対応

## レビューしてほしいところ

- 本番およびステージング環境のドメインサフィックス修正に漏れがないか
- ドメイン抽出処理が意図したとおりに動作するか
- ローカル環境や他の環境に意図しない影響が出ないか

## 不安に思っていること

- ドメイン切り替えに伴い、既存の `communi-care.jp` へのデプロイで予期せぬ環境変化が発生しないか
- シングルデータベース方式でのドメイン運用が正しく機能するか
- テナントID抽出処理が環境によって誤動作しないか

## 保留していること

- ドメイン変更に伴う他のサービスの影響範囲の調査が保留中
- ドメイン以外の環境変数や設定ファイルでの影響がないか、追加で調査を行う予定