### PR TITLE
本番環境のドメインをcommuni-care.jpからcommunicare-app.jpへ変更

### DIFF
--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -39,7 +39,7 @@ class AuthenticatedSessionController extends Controller
         // 環境に応じてドメインからテナントIDを抽出
         $tenantDomainId = match(config('app.env')) {
             'local' => str_replace('.localhost', '', $domain),
-            'production' => str_replace('.communi-care.jp', '', $domain),
+            'production' => str_replace('.communicare-app.jp', '', $domain),
             default => $domain
         };
 

--- a/app/Http/Controllers/Auth/TenantRegisterController.php
+++ b/app/Http/Controllers/Auth/TenantRegisterController.php
@@ -40,7 +40,7 @@ class TenantRegisterController extends Controller
         ]);
 
         // ドメイン名の生成
-        $baseDomain = app()->environment('production') ? 'communi-care.jp' : 'localhost';
+        $baseDomain = app()->environment('production') ? 'communicare-app.jp' : 'localhost';
         $domain = strtolower($validatedData['tenant_domain_id']) . '.' . $baseDomain;
 
         try {
@@ -68,7 +68,7 @@ class TenantRegisterController extends Controller
 
         // セッションとクッキーの設定
         session(['tenant_id' => $tenant->id]);
-        $sessionDomain = app()->environment('production') ? '.communi-care.jp' : '.localhost';
+        $sessionDomain = app()->environment('production') ? '.communicare-app.jp' : '.localhost';
         Config::set('session.domain', $sessionDomain);
         Cookie::queue(Cookie::make('XSRF-TOKEN', csrf_token(), 120, '/', $sessionDomain, false, true, false, 'Lax'));
 

--- a/config/app.php
+++ b/config/app.php
@@ -123,5 +123,5 @@ return [
         'store' => env('APP_MAINTENANCE_STORE', 'database'),
     ],
 
-    'tenant_base_domain' => env('TENANT_BASE_DOMAIN', 'communi-care.jp'),
+    'tenant_base_domain' => env('TENANT_BASE_DOMAIN', 'communicare-app.jp'),
 ];

--- a/config/tenancy.php
+++ b/config/tenancy.php
@@ -19,7 +19,7 @@ return [
     'central_domains' => [
         '127.0.0.1',
         'localhost',
-        'communi-care.jp',//本番のセントラルドメイン
+        'communicare-app.jp',//本番のセントラルドメイン
     ],
 
     /**
@@ -199,7 +199,7 @@ return [
 
     'domain_suffix' => [
         'local' => '.localhost',
-        'production' => '.communi-care.jp',
-        'staging' => '.staging.communi-care.jp',
+        'production' => '.communicare-app.jp',
+        'staging' => '.staging.communicare-app.jp',
     ]
 ];


### PR DESCRIPTION
## 目的

Xserverからさくらインターネットへの移行に伴い、本番環境のドメインが`communi-care.jp`から`communicare-app.jp`へ変更されました。  
これに合わせて、テナントのサブドメイン生成やセッション管理で使用するドメインを新しいものに置き換える必要があります。

***

## 達成条件

- テナント登録時に`〇〇.communicare-app.jp`形式でサブドメインが正しく生成されること。
- セッション管理で`communicare-app.jp`が適切に使用されること。
- `config/tenancy.php` や環境変数 `.env` に反映されているドメインが新しいものに置き換わっていること。
- 既存のテナントが問題なく動作し、セッションが切れずに維持されること。

***

## 実装の概要

- `config/tenancy.php` でテナントのベースドメインを`communi-care.jp`から`communicare-app.jp`に変更しました。
- テナント登録時にサブドメイン生成で使用される`$baseDomain`を`communicare-app.jp`へ修正しました。
- セッション管理に使用するドメインを`communi-care.jp`から`communicare-app.jp`に置き換えました。
- 環境変数`.env` の `TENANT_BASE_DOMAIN` も同様に変更しました。
- 一部、環境判定でドメインを抽出するロジックに`str_replace`を使用していたため、新ドメインで置き換えるよう修正しました。

***

## レビューしてほしいところ

- ドメイン置き換えが漏れなく行われているか。
- テナント登録処理において、サブドメイン生成ロジックが正しく動作するか。
- セッション管理におけるドメインの変更が意図した通りに反映されているか。
- `config/tenancy.php` などの設定ファイルに不備がないか。

***

## 不安に思っていること

- DNS設定の反映が遅延した場合、新ドメインでの動作確認に時間がかかる可能性があります。
- サブドメイン生成処理において、`localhost` での動作確認は問題ありませんが、本番環境での動作確認が必要です。
- セッション管理のドメイン切り替えに伴い、予期せぬセッション切れが発生するリスクがあります。

***

## 保留していること

- 現時点でサブドメインに対してはSSL証明書の適用は行っていません。必要に応じてワイルドカードSSLの設定を別途検討します。
- 一部のサブドメインが`communi-care.jp`に残る可能性があるため、移行期間中は両方のドメインでアクセスできるようDNS設定を維持します。
- staging環境のドメインも変更予定ですが、今回は本番環境のドメイン変更にフォーカスしています。
