### PR TITLE
マイグレーションファイルが無視される不具合の修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,5 @@ yarn-error.log
 /.idea
 /.vscode
 my.cnf
+!database/migrations/*.php
 


### PR DESCRIPTION
## 目的

`.gitignore`の設定により、`database/migrations`配下のマイグレーションファイルが無視され、本番環境でマイグレーションが適用されない問題が発生していました。  
この問題を修正し、マイグレーションファイルが正しく追跡・反映されるようにすることが目的です。

***

## 達成条件

- `database/migrations` 配下の `.php` ファイルが`git`で正しく追跡されること
- 本番環境で`git pull`を実行した際に、最新のマイグレーションファイルが反映されること

***

## 実装の概要

- `.gitignore`に以下の行を追加しました。

  ```plaintext
  !database/migrations/*.php
  ```

  これにより、`database/migrations`ディレクトリ内のマイグレーションファイルが無視されず、`git`で追跡されるようになります。

- 追加を検討した`!database/migrations/tenant/*.php`については、  
  `tenant`ディレクトリが存在しない、または利用予定がないため**採用を見送りました**。  
  今後必要になった場合は、その時点で改めて対応を検討します。

***

## レビューしてほしいところ

- `.gitignore`の設定が適切かどうか
- 他のディレクトリやファイルで同様の問題が発生していないか

***

## 不安に思っていること

- マイグレーションファイルが追跡されないケースが他のディレクトリにも存在する可能性があります。
- 本番環境で`git pull`後にマイグレーションが正しく実行されるかどうか。

***

## 保留していること

- `tenant`ディレクトリ配下のマイグレーションファイルに対する除外設定（現状では不要と判断）
- 本番環境でマイグレーションを手動で反映するか、自動化するかの検討