### PR TITLE
Xserver用ドメイン（`communi-care.jp`）への変更対応

### DIFF
--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -39,7 +39,7 @@ class AuthenticatedSessionController extends Controller
         // 環境に応じてドメインからテナントIDを抽出
         $tenantDomainId = match(config('app.env')) {
             'local' => str_replace('.localhost', '', $domain),
-            'production' => str_replace('.communicare-app.jp', '', $domain),
+            'production' => str_replace('.communi-care.jp', '', $domain),
             default => $domain
         };
 

--- a/app/Http/Controllers/Auth/TenantRegisterController.php
+++ b/app/Http/Controllers/Auth/TenantRegisterController.php
@@ -40,7 +40,7 @@ class TenantRegisterController extends Controller
         ]);
 
         // ドメイン名の生成
-        $baseDomain = app()->environment('production') ? 'communicare-app.jp' : 'localhost';
+        $baseDomain = app()->environment('production') ? 'communi-care.jp' : 'localhost';
         $domain = strtolower($validatedData['tenant_domain_id']) . '.' . $baseDomain;
 
         try {
@@ -68,7 +68,7 @@ class TenantRegisterController extends Controller
 
         // セッションとクッキーの設定
         session(['tenant_id' => $tenant->id]);
-        $sessionDomain = app()->environment('production') ? '.communicare-app.jp' : '.localhost';
+        $sessionDomain = app()->environment('production') ? '.communi-care.jp' : '.localhost';
         Config::set('session.domain', $sessionDomain);
         Cookie::queue(Cookie::make('XSRF-TOKEN', csrf_token(), 120, '/', $sessionDomain, false, true, false, 'Lax'));
 

--- a/config/app.php
+++ b/config/app.php
@@ -123,5 +123,5 @@ return [
         'store' => env('APP_MAINTENANCE_STORE', 'database'),
     ],
 
-    'tenant_base_domain' => env('TENANT_BASE_DOMAIN', 'communicare-app.jp'),
+    'tenant_base_domain' => env('TENANT_BASE_DOMAIN', 'communi-care.jp'),
 ];

--- a/config/tenancy.php
+++ b/config/tenancy.php
@@ -19,7 +19,7 @@ return [
     'central_domains' => [
         '127.0.0.1',
         'localhost',
-        'communicare-app.jp',//本番のセントラルドメイン
+        'communi-care.jp',//本番のセントラルドメイン
     ],
 
     /**
@@ -199,7 +199,7 @@ return [
 
     'domain_suffix' => [
         'local' => '.localhost',
-        'production' => '.communicare-app.jp',
-        'staging' => '.staging.communicare-app.jp',
+        'production' => '.communi-care.jp',
+        'staging' => '.staging.communi-care.jp',
     ]
 ];


### PR DESCRIPTION
## **目的**

Xserver環境でのアプリ運用を実現するため、ドメイン設定を `communi-care.jp` に統一する。これにより、さくらインターネットで発生していたマルチドメイン制約の問題を解消します。

***

## **達成条件**

1. **目的を達成するための具体的条件**:

   - 本番環境で `communi-care.jp` ドメインを使用して、全機能が正常に動作すること。
   - ローカル環境やステージング環境も問題なく動作すること。

***

## **実装の概要**

- **修正箇所**:

  - ドメイン指定を行っている全ファイルを修正:

    - `app/Http/Controllers/Auth/AuthenticatedSessionController.php`
    - `app/Http/Controllers/Auth/TenantRegisterController.php`
    - `config/app.php`
    - `config/tenancy.php`

- **詳細な変更点**:

  - 環境に応じたドメイン切り替えロジックを修正。
  - セッションドメインの指定を Xserver のドメインに対応。
  - 本番環境ドメインを `communi-care.jp` に設定。
  - 不要になった `communicare-app.jp` に関する記述を削除。

***

## **レビューしてほしいところ**

1. **コードの正確性**:

   - 環境に応じたドメイン切り替えロジックが適切であるか。
   - ドメイン変更に伴う影響範囲が適切に考慮されているか。

2. **動作確認手順**:

   - 修正後のアプリケーションが本番環境・ローカル環境で問題なく動作することを保証するための確認手順が適切か。

***

## **不安に思っていること**

- 本番環境における Laravel のキャッシュやセッション設定が正しく動作するか。
- ドメイン変更による意図しない副作用（特にリダイレクトやミドルウェア部分）が発生しないか。

***

## **保留していること**

- 旧ドメイン（`communicare-app.jp`）でのテナント運用に関する互換性の確保。