### PR TITLE
本番環境でアセットURLに不要なプレフィックスが追加される問題を修正

### DIFF
--- a/config/tenancy.php
+++ b/config/tenancy.php
@@ -135,7 +135,7 @@ return [
          * disable asset() helper tenancy and explicitly use tenant_asset() calls in places
          * where you want to use tenant-specific assets (product images, avatars, etc).
          */
-        'asset_helper_tenancy' => true,
+        'asset_helper_tenancy' => false,
     ],
 
     /**
@@ -178,7 +178,7 @@ return [
      * enabled. But it may be useful to disable them if you use external
      * storage (e.g. S3 / Dropbox) or have a custom asset controller.
      */
-    'routes' => true,
+    'routes' => false,
 
     /**
      * Parameters used by the tenants:migrate command.

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,10 +2,7 @@ import { defineConfig } from "vite";
 import laravel from "laravel-vite-plugin";
 import vue from "@vitejs/plugin-vue";
 
-export default defineConfig(({ mode }) => {
-    const tenantDomain = process.env.TENANT_DOMAIN || ""; // .env にサブドメイン情報がある場合は使用
-    const centralDomain = process.env.APP_URL || ""; // セントラルドメインを使用
-
+export default defineConfig(() => {
     return {
         plugins: [
             laravel({
@@ -24,8 +21,6 @@ export default defineConfig(({ mode }) => {
         build: {
             outDir: "public/build",
         },
-        base: tenantDomain
-            ? `${tenantDomain}/build/`
-            : `${centralDomain}/build/`,
+        base: "/build/", // 相対パスを指定
     };
 });


### PR DESCRIPTION
## 目的

本番環境で発生していたアセットURLの問題（不要なプレフィックス `/tenancy/assets/` が追加される）を修正し、アセットが正しく読み込まれるようにすることを目的としています。

***

## 達成条件

1. 本番環境でのアセットURLが正しい形式（例: `/build/assets/...`）になる。
2. 不要なURLプレフィックス（例: `/tenancy/assets/`）が削除される。
3. ローカル環境でも `npm run build` 実行後に同様の挙動が確認できる。

***

## 実装の概要

### **1. `vite.config.js` の修正**

- `base` 設定を相対パス `/build/` に固定しました。
- 環境変数 `TENANT_DOMAIN` や `APP_URL` を使用していた動的なURL生成は不要と判断し、削除しました。

### **2. `config/tenancy.php` の修正**

- `'asset_helper_tenancy'` を `true` から `false` に変更しました。これにより、Laravelの `asset()` ヘルパーがテナント固有のプレフィックス（`/tenancy/assets/`）を追加しなくなります。
- `'routes'` を `true` から `false` に変更しました。これにより、テナントアセット専用のルートが無効化され、404エラーを防ぎます。

***

## レビューしてほしいところ

1. **`vite.config.js` の修正**:
   - `base: "/build/"` への固定で問題が解決するか。
2. **`config/tenancy.php` の変更**:
   - `'asset_helper_tenancy'` と `'routes'` の設定変更が他の部分に影響を与えないか。
3. ローカル環境と本番環境の動作確認手順が適切か。

***

## 不安に思っていること

- `config/tenancy.php` の設定変更がテナント固有のアセットURLを使用する既存の機能に影響を与えないか。
- 本番環境に反映後、想定外のURL生成やアセットの読み込み不具合が発生する可能性。

***

## 保留していること

- 本番環境での最終的な動作確認。
- テナントが複数存在する場合、それぞれのアセット読み込みが正しく行われるかの確認。