### PR TITLE
ゲストテナントURLのフォールバック条件を追加・修正

### DIFF
--- a/resources/js/Pages/TenantHome.vue
+++ b/resources/js/Pages/TenantHome.vue
@@ -13,7 +13,9 @@ const tenant = page.props.tenant || {};
 
 // 現在のURLが特定のパスかをチェック
 const guestTenantUrl =
-    import.meta.env.VITE_GUEST_TENANT_URL || "http://guestdemo.localhost";
+    import.meta.env.VITE_GUEST_TENANT_URL ||
+    "http://guestdemo.localhost" ||
+    "https://guestdemo.communi-care.jp";
 const isGuestHome = window.location.href === `${guestTenantUrl}/home`;
 </script>
 


### PR DESCRIPTION
## **目的**

ゲストホームURLの判定において、環境変数 `VITE_GUEST_TENANT_URL` が未設定の場合にデフォルトのURLが使用されるように条件を修正しました。これにより、本番環境やローカル環境における挙動の一貫性を確保します。

***

## **達成条件**

- 環境変数 `VITE_GUEST_TENANT_URL` が設定されている場合、その値が優先されること。
- 環境変数が未設定の場合、ローカル環境用のURL（`http://guestdemo.localhost`）が使用されること。
- 最後に、フォールバックURLとして本番環境用のURL（`https://guestdemo.communi-care.jp`）が使用されること。

***

## **実装の概要**

- 環境変数 `VITE_GUEST_TENANT_URL` の値を判定し、未設定時に複数のフォールバックURLを指定するロジックを追加しました。

- 判定ロジック：

  ```
  javascript
  コードをコピーする
  const guestTenantUrl =
      import.meta.env.VITE_GUEST_TENANT_URL ||
      "http://guestdemo.localhost" ||
      "https://guestdemo.communi-care.jp";
  const isGuestHome = window.location.href === `${guestTenantUrl}/home`;
  ```

- 本番環境やローカル環境で挙動が異なる場合に対応するため、複数のデフォルト値を条件として指定。

***

## **レビューしてほしいところ**

1. フォールバック条件の順序に問題がないか（意図通りに最優先のURLが適用されるか）。
2. 判定ロジックの可読性や保守性について、改善点があれば教えてください。
3. 環境変数の未設定時の動作が適切かどうか。

***

## **不安に思っていること**

- 複数のデフォルト値を設定することによって、意図しない挙動が発生する可能性があるかどうか。
- 環境変数が無効な値（空文字列や誤ったURL）を持つ場合の挙動が正しいかどうか。

***

## **保留していること**

- 現在のロジックでは `import.meta.env.VITE_GUEST_TENANT_URL` が空文字列で設定された場合も条件を通過しますが、この挙動については明確に許可するかどうか検討が必要です。
- 将来的に環境ごとに動的にURLを設定する仕組みを導入する場合、このロジックの簡略化を検討する余地があります。