### PR TITLE
SetSessionDomainミドルウェアの実行順序を修正し、セッション関連の問題を解決

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -18,12 +18,12 @@ return Application::configure(basePath: dirname(__DIR__))
     )
     ->withMiddleware(function (Middleware $middleware) {
         $middleware->web(prepend: [
+            SetSessionDomain::class,
             AuthenticateSession::class,
             HandleInertiaRequests::class,
             AddLinkHeadersForPreloadedAssets::class,
             InitializeTenancyCustom::class,
             SetTenantCookie::class,
-            SetSessionDomain::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {


### PR DESCRIPTION
## 目的

リダイレクトループの問題を解決するために、SetSessionDomainミドルウェアの実行順序を修正します。この変更により、セッションドメインが正しく設定され、AuthenticateSessionが適切に動作することを目的としています。

## 達成条件

- SetSessionDomainミドルウェアがAuthenticateSessionよりも先に実行されること。
- リダイレクトループが発生しないこと。
- セッションドメインの動的設定が正しく機能すること。

## 実装の概要

- SetSessionDomainミドルウェアの順序を、`web`ミドルウェアスタック内でAuthenticateSessionよりも前に変更しました。

  ```php
  ->withMiddleware(function (Middleware $middleware) {
      $middleware->web(prepend: [
          SetSessionDomain::class,
          AuthenticateSession::class,
          HandleInertiaRequests::class,
          AddLinkHeadersForPreloadedAssets::class,
          InitializeTenancyCustom::class,
          SetTenantCookie::class,
      ]);
  })
  ```

- AuthenticateSessionがセッション情報を使用する際に正しくセッションドメインが適用されるようになり、リダイレクトループの問題が解決しました。

## レビューしてほしいところ

- SetSessionDomainミドルウェアをAuthenticateSessionより前に配置することが適切かどうか。
- 他のミドルウェアとの間で依存関係が発生していないか。

## 不安に思っていること

- 特定の環境や複雑なセッションシナリオにおいて、今回の変更が予期せぬ影響を及ぼす可能性がないか。
- 今回の変更が他のミドルウェアスタックの動作に影響を与えないか。

## 保留していること

- 特定の環境（例: サブドメインを使用した複数テナント構成）における動作確認。
- 必要に応じて追加のログ出力やテストの作成。