### PR TITLE
SetSessionDomainミドルウェアの復元と改善

### DIFF
--- a/app/Http/Middleware/SetSessionDomain.php
+++ b/app/Http/Middleware/SetSessionDomain.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Support\Facades\Config;
+
+class SetSessionDomain
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        // 現在のホストを取得
+        $currentHost = $request->getHost();
+
+        // ドメインを動的に設定（例: サブドメインの設定を抽出）
+        $dynamicDomain = $this->resolveDomain($currentHost);
+
+        // セッションドメインを動的に設定
+        Config::set('session.domain', $dynamicDomain);
+
+        return $next($request);
+    }
+
+    /**
+     * ドメインを解析して適切なセッションドメインを返す
+     *
+     * @param string $host
+     * @return string|null
+     */
+    protected function resolveDomain(string $host): ?string
+    {
+        if (strpos($host, 'guestdemo.communi-care.jp') !== false) {
+            return 'guestdemo.communi-care.jp';
+        }
+
+        // デフォルト値を返す
+        return config('session.domain', null);
+    }
+}

--- a/app/Http/Middleware/SetSessionDomain.php
+++ b/app/Http/Middleware/SetSessionDomain.php
@@ -4,6 +4,7 @@ namespace App\Http\Middleware;
 
 use Closure;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Log;
 
 class SetSessionDomain
 {
@@ -16,14 +17,17 @@ class SetSessionDomain
      */
     public function handle($request, Closure $next)
     {
-        // 現在のホストを取得
+        // 現在のリクエストのホスト名を取得
         $currentHost = $request->getHost();
 
-        // ドメインを動的に設定（例: サブドメインの設定を抽出）
+        // リクエストホストに基づいて適切なセッションドメインを解決
         $dynamicDomain = $this->resolveDomain($currentHost);
 
-        // セッションドメインを動的に設定
+        // セッションドメインを設定
         Config::set('session.domain', $dynamicDomain);
+
+        // セッションドメインの設定をログ出力
+        Log::info('SetSessionDomain: ' . $dynamicDomain);
 
         return $next($request);
     }
@@ -36,11 +40,12 @@ class SetSessionDomain
      */
     protected function resolveDomain(string $host): ?string
     {
-        if (strpos($host, 'guestdemo.communi-care.jp') !== false) {
-            return 'guestdemo.communi-care.jp';
+        // communi-care.jp ドメインおよびサブドメインを許可
+        if (preg_match('/^.+\.communi-care\.jp$/', $host)) {
+            return $host;
         }
 
-        // デフォルト値を返す
+        // デフォルトのセッションドメインを返す
         return config('session.domain', null);
     }
 }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -8,6 +8,7 @@ use App\Http\Middleware\HandleInertiaRequests;
 use Illuminate\Http\Middleware\AddLinkHeadersForPreloadedAssets;
 use App\Http\Middleware\InitializeTenancyCustom;
 use App\Http\Middleware\SetTenantCookie;
+use App\Http\Middleware\SetSessionDomain;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -17,6 +18,7 @@ return Application::configure(basePath: dirname(__DIR__))
     )
     ->withMiddleware(function (Middleware $middleware) {
         $middleware->web(prepend: [
+            SetSessionDomain::class,
             AuthenticateSession::class,
             HandleInertiaRequests::class,
             AddLinkHeadersForPreloadedAssets::class,


### PR DESCRIPTION
## 目的

本番環境におけるリダイレクトループエラーの再発を解消するため、サブドメインごとにセッションを正しく管理できるよう、SetSessionDomainミドルウェアを復元・改善しました。また、SESSION\_DOMAINの設定については現時点で空文字を維持しつつ、本ミドルウェアの運用を試験的に開始します。

***

## 達成条件

- SetSessionDomainミドルウェアが動的にセッションドメインを設定すること。
- すべてのサブドメインで適切にセッションが管理され、リダイレクトループエラーが発生しないこと。
- ログ出力により、セッションドメインの設定状況が確認できること。
- 空文字のSESSION\_DOMAIN設定においても正しく動作すること。

***

## 実装の概要

1. **SetSessionDomainミドルウェアを復元**  
   本番環境で再発したリダイレクトループエラーの解消を目的に、以前削除したSetSessionDomainミドルウェアを復元しました。サブドメインごとに異なるセッションドメインを設定するため、このミドルウェアが必要です。

2. **SetSessionDomainミドルウェアの改善**  
   正規表現を用いてすべてのサブドメインに対応可能な動的ドメイン解決を試みました。これにより、どのサブドメインに対しても適切にセッションドメインが設定されることを期待しています。

3. **ログ出力の追加**  
   セッションドメインの設定状況をログに出力する機能を追加しました。これにより、設定内容を容易に確認できます。

4. **bootstrap/app.phpへの再追加**  
   SetSessionDomainミドルウェアをミドルウェアスタックに追加し、アプリケーション全体で機能するよう設定しました。

5. **SESSION\_DOMAINの空文字設定の維持**  
   現時点ではSESSION\_DOMAINを空文字のままとし、ミドルウェアによる動的なセッション管理設定の効果を検証します。

***

## レビューしてほしいところ

- 正規表現を用いた動的ドメイン解決が適切であるか。
- SESSION\_DOMAINを空文字で維持した際の動作に問題がないか。
- ログ出力内容が本番環境のトラブルシューティングにおいて有用か。

***

## 不安に思っていること

- 空文字のSESSION\_DOMAIN設定でリダイレクトループエラーが完全に解消されるかどうか。
- 特殊なサブドメイン構成に対して正規表現が十分な汎用性を持つか。

***

## 保留していること

- 必要に応じてSESSION\_DOMAINの設定値を再検討する可能性があります（例: `.communi-care.jp`への変更）。
- ログ出力の詳細化（必要に応じて改善予定）。