### PR TITLE
Inertia::renderによる不適切なURL表示をリダイレクトで修正

### DIFF
--- a/app/Http/Controllers/Auth/GuestLoginController.php
+++ b/app/Http/Controllers/Auth/GuestLoginController.php
@@ -49,12 +49,7 @@ class GuestLoginController extends Controller
     $guestUser->update(['guest_session_id' => $newSessionId]);
 
     // ダッシュボードページに遷移
-    return Inertia::render('Dashboard', [
-        'auth' => [
-            'user' => Auth::user(),
-        ],
-        'isGuest' => Auth::user() && Auth::user()->guest_session_id ? true : false,
-    ])->with('message', 'ゲストとしてログインしました！');
+    return redirect()->route('dashboard')->with('message', 'ゲストとしてログインしました！');
 }
 
 


### PR DESCRIPTION
## 目的

ダッシュボードにアクセスしているにもかかわらず、URLが`/guest/user/login`と表示される問題を修正し、正しいURL(`/dashboard`)が表示されるようにすること。

## 達成条件

- ダッシュボードにアクセスした際にURLが`/dashboard`と表示されること。
- 必要のないデータの重複渡しを削除し、コードの保守性を向上させること。

## 実装の概要

1. ダッシュボード遷移時の処理を`Inertia::render`から`redirect`に変更し、`Route::get('/dashboard', [DashboardController::class, 'index'])->name('dashboard')`を通るよう修正しました。
2. 不適切なURLが表示される原因である`Inertia::render`を採用していた箇所を変更しました。
3. 既に`HandleInertiaRequests`で提供されており、重複して渡されていたデータの指定を削除しました。

## レビューしてほしいところ

- リダイレクトの変更によって正しく`Route::dashboard`が動作しているか。
- データ渡しを削除した影響で、他の箇所に不具合が発生しないか。
- 他に改善できる箇所がないか。

## 不安に思っていること

- リダイレクト処理への変更が、他の関連機能やルートに予期せぬ影響を与えていないか。
- 削除したデータ指定が、特定のユースケースで必要になる可能性がないか。

## 保留していること

- 特にありません。