### PR TITLE
フラッシュメッセージ処理の改善および文言の統一

### DIFF
--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -81,6 +81,7 @@ class AuthenticatedSessionController extends Controller
         // セッションからドメイン情報を取得し、セッションが存在しない場合はリクエストから取得
         $domain = session('tenant_domain', $request->getHost());
 
-        return redirect('http://' . $domain . '/home');
+        return redirect('http://' . $domain . '/home')
+            ->with('message', 'ログアウトしました');
     }
 }

--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -58,8 +58,8 @@ class AuthenticatedSessionController extends Controller
 
         if (Auth::attempt($credentials)) {
             $request->session()->regenerate();
-            session()->flash('reload_page', true);
-            return inertia::location('dashboard');
+            session()->flash('success', 'ログインしました');
+            return Inertia::location(route('dashboard'));
         }
 
         return back()->withErrors([

--- a/app/Http/Controllers/Auth/GuestLoginController.php
+++ b/app/Http/Controllers/Auth/GuestLoginController.php
@@ -49,7 +49,7 @@ class GuestLoginController extends Controller
     $guestUser->update(['guest_session_id' => $newSessionId]);
 
     // ダッシュボードページに遷移
-    return redirect()->route('dashboard')->with('message', 'ゲストとしてログインしました！');
+    return redirect()->route('dashboard')->with('message', 'ゲストとしてログインしました');
 }
 
 

--- a/app/Http/Controllers/Auth/GuestLoginController.php
+++ b/app/Http/Controllers/Auth/GuestLoginController.php
@@ -49,7 +49,7 @@ class GuestLoginController extends Controller
     $guestUser->update(['guest_session_id' => $newSessionId]);
 
     // ダッシュボードページに遷移
-    return redirect()->route('dashboard')->with('message', 'ゲストとしてログインしました');
+    return redirect()->route('dashboard')->with('success', 'ゲストとしてログインしました');
 }
 
 

--- a/app/Http/Controllers/Auth/GuestLoginController.php
+++ b/app/Http/Controllers/Auth/GuestLoginController.php
@@ -78,7 +78,7 @@ class GuestLoginController extends Controller
     session()->regenerateToken();
 
     // ホーム画面にリダイレクト
-    return redirect('/home')->with('message', '操作内容がリセットされました。');
+    return redirect('/home')->with('message', 'ログアウトしました');
 }
 
 }

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -47,6 +47,7 @@ class HandleInertiaRequests extends Middleware
             'isGuest' => $request->user() && $request->user()->guest_session_id ? true : false,
             'guestSessionId' => $request->user() && $request->user()->guest_session_id ? $request->user()->guest_session_id : null,
             'flash' => [
+                'message' => $request->session()->get('message'),
                 'success' => $request->session()->get('success'),
                 'error' => $request->session()->get('error'),
                 'info' => $request->session()->get('info'),

--- a/resources/js/Pages/Dashboard.vue
+++ b/resources/js/Pages/Dashboard.vue
@@ -11,11 +11,10 @@ const isAdmin = props.isAdmin;
 const flash = props.flash;
 const isGuest = props.isGuest;
 
-const flashMessage = ref(flash.message || flash.success || flash.error || flash.info || null);
+const flashMessage = ref(flash.success || flash.error || null);
+
 const flashType = ref(
-    flash.success ? "success" :
-    flash.error ? "error" :
-    flash.message ? "info" : "info"
+    flash.success ? "success" : flash.error ? "error" : "info"
 );
 
 // 8秒後にフラッシュメッセージをフェードアウトさせる

--- a/resources/js/Pages/Dashboard.vue
+++ b/resources/js/Pages/Dashboard.vue
@@ -11,9 +11,11 @@ const isAdmin = props.isAdmin;
 const flash = props.flash;
 const isGuest = props.isGuest;
 
-const flashMessage = ref(flash.success || flash.error || flash.info || null);
+const flashMessage = ref(flash.message || flash.success || flash.error || flash.info || null);
 const flashType = ref(
-    flash.success ? "success" : flash.error ? "error" : "info"
+    flash.success ? "success" :
+    flash.error ? "error" :
+    flash.message ? "info" : "info"
 );
 
 // 8秒後にフラッシュメッセージをフェードアウトさせる

--- a/resources/js/Pages/TenantHome.vue
+++ b/resources/js/Pages/TenantHome.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { usePage } from "@inertiajs/vue3";
+import { ref } from "vue";
 import ApplicationLogo from "@/Components/ApplicationLogo.vue";
 import { Link } from "@inertiajs/vue3";
 import Footer from "@/Layouts/Footer.vue";
@@ -14,6 +15,19 @@ const tenant = page.props.tenant || {};
 let currentUrl; // 現在のページURLを格納する変数
 let guestTenantUrl; // 環境変数で指定されたゲストテナントのURL
 let isGuestHome = false; // 現在のページがゲストホームかどうかのフラグ
+
+// フラッシュメッセージの処理
+const { props } = usePage();
+const flash = props.flash;
+const flashMessage = ref(flash.message || null);
+const showFlashMessage = ref(!!flashMessage.value);
+
+// フラッシュメッセージを8秒後に非表示にする
+if (showFlashMessage.value) {
+    setTimeout(() => {
+        showFlashMessage.value = false;
+    }, 8000);
+}
 
 // try-catchでエラーハンドリング
 try {
@@ -32,6 +46,16 @@ try {
 </script>
 
 <template>
+    <!-- フラッシュメッセージ -->
+    <transition name="fade">
+        <div
+            v-if="flashMessage && showFlashMessage"
+            class="fixed bottom-10 left-1/2 transform -translate-x-1/2 z-50 w-full max-w-md mx-auto sm:rounded-lg shadow-lg text-center bg-blue-100 border-l-4 border-blue-500 text-blue-700 p-4"
+        >
+            <p class="font-bold">{{ flashMessage }}</p>
+        </div>
+    </transition>
+
     <div
         class="min-h-screen bg-gradient-to-b from-blue-50 to-white flex flex-col justify-center items-center text-center px-4"
     >
@@ -118,3 +142,15 @@ try {
     </div>
     <Footer />
 </template>
+
+<style>
+.fade-enter-active,
+.fade-leave-active {
+    transition: opacity 0.5s ease;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+    opacity: 0;
+}
+</style>


### PR DESCRIPTION
## 目的

- ログイン・ログアウトなどの操作に適切なフラッシュメッセージを設定し、ユーザー体験を向上させる。
- フラッシュメッセージの処理を改善し、コードの読みやすさと一貫性を向上させる。
- 文言の統一により、ユーザーにわかりやすい通知を提供する。

***

## 達成条件

- フラッシュメッセージの文言が一貫性を保ち、適切なタイミングで表示されること。
- 不要なフラッシュメッセージカテゴリを削除し、処理を簡素化すること。
- ログインおよびログアウト後に正しいメッセージが表示されること。
- フラッシュメッセージが8秒間表示され、フェードアニメーションを経て自動で非表示になること。

***

## 実装の概要

### **追加した内容**

1. `flash.message` プロパティを新たにサポートし、`tenanthome` などで優先的に参照する処理を追加。
2. セッションから `message` を取得する処理を追加。
3. ログアウト後に「ログアウトしました」というフラッシュメッセージを表示する機能を追加。

### **修正した内容**

1. フラッシュメッセージの文言を統一し、末尾の感嘆符を削除。
2. ゲストログイン時のフラッシュメッセージを `message` からより適切な `success` に変更。
3. ログイン成功時のリダイレクト処理をルート名を使用する形に修正。
4. ダッシュボードページでは、`flash.message` の参照を削除し、`success` と `error` のみ対応するよう簡素化。

### **削除した内容**

- **`flash.message` のダッシュボードでの利用**: ダッシュボードでは `success` と `error` のみで十分対応可能と判断したため、`flash.message` の参照を削除しました。ただし、`tenanthome` など他の部分では `flash.message` を採用しています。

***

## レビューしてほしいところ

1. フラッシュメッセージの処理ロジックが簡素で、一貫性があるか。
2. ログインおよびログアウト時に適切なメッセージが表示されるか。
3. フラッシュメッセージのフェードアニメーションが適切に動作しているか。

***

## 不安に思っていること

- ダッシュボードでは `flash.message` を削除しましたが、他の部分で `flash.message` を採用している場合との一貫性が十分かどうか。
- ログイン・ログアウト時のメッセージ表示がユーザー体験にどの程度寄与するか。

***

## 保留していること

- 現時点ではダッシュボードでは `flash.message` を使用していませんが、必要に応じて再導入する可能性があります。
- 他のページでの `flash.message` の利用状況を考慮し、さらなる統一性を検討する余地があります。
- 現時点では、各ビューに同じようなフラッシュメッセージのスクリプトを書いているため、将来的にフラッシュメッセージのスクリプトをコンポーネント化して使い回しできるようにしたいと考えています。
