### PR TITLE
サブドメインごとにセッションを分離する処理を追加

### DIFF
--- a/app/Http/Middleware/SetSessionDomain.php
+++ b/app/Http/Middleware/SetSessionDomain.php
@@ -45,6 +45,11 @@ class SetSessionDomain
             return $host;
         }
 
+        // localhost の場合も、サブドメインごとにセッションを分離
+        if (preg_match('/^.+\.localhost$/', $host)) {
+            return $host; // サブドメインをそのまま返す
+        }
+
         // デフォルトのセッションドメインを返す
         return config('session.domain', null);
     }


### PR DESCRIPTION
## 目的

ローカル開発環境において、`localhost` 上で動作するサブドメインごとのセッションを分離することにより、セッションクッキーの重複によるリダイレクトループエラーを回避するため。また、これにより、開発環境でも本番環境と同じセッション分離の挙動をテストできるようにします。

## 達成条件

- `localhost` 上でサブドメインが異なる場合に、別々のセッションが保持されること。
- セッションが適切に分離され、リダイレクトループエラーが発生しないこと。
- 本番環境と同じ挙動をローカル開発環境でもテストできること。

## 実装の概要

- **開発環境への対応追加**

  - 先日のコミット ([a92ad1a](https://github.com/your-repo/commit/a92ad1a4cfe4f48a7d92ae5c5f59c6c88a19a396)) で実装された `app/Http/Middleware/SetSessionDomain.php` は、本番環境におけるセッション管理を目的としていましたが、ローカル開発環境（`localhost`）でのテストができない状態でした。
  - 今回、`localhost` 上でもサブドメインごとにセッションを分離する処理を追加し、開発環境でも本番環境と同等のテストが行えるよう修正しました。

- **具体的な変更点**

  - サブドメインごとにセッションを分離するため、`localhost` の場合に特化した正規表現チェックを追加しました。

    - 正規表現：`/^.+\.localhost$/`
    - この条件を満たす場合、ホスト名をそのまま返すようにしました。

  - 上記に該当しない場合は、従来通り `config('session.domain', null)` の値を返す処理にフォールバックします。

## レビューしてほしいところ

1. 実装した正規表現の妥当性について
   - サブドメインの分離が正しく行われるか、他に漏れがないか確認をお願いします。
2. 実装の流れや処理が適切かどうか
   - 特に、`preg_match` を利用した条件分岐部分で無駄な処理がないか。
3. ローカル開発環境での挙動が、本番環境の仕様と矛盾しないかどうか。

## 不安に思っていること

- 現在の実装が、IP アドレスや `localhost` に該当しないホスト名に対して影響を与えないか。
- 他の開発環境やホスト構成（例：Docker）で問題が発生する可能性がないか。

## 保留していること

- 正規表現の強化案の検討
  - 現状では英数字とハイフンのサブドメインを想定していますが、特殊なケースへの対応が必要な場合は別途対応を検討。
- 他のホスト（例：`127.0.0.1` や `::1`）への適用範囲拡大は今回見送りました。
  - 理由：現在の要件では `localhost` のみが対象であり、開発環境の仕様に基づいて判断。