### PR TITLE
テナントトップページのURLを `/home` から `/` に統一

### DIFF
--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -81,7 +81,7 @@ class AuthenticatedSessionController extends Controller
         // セッションからドメイン情報を取得し、セッションが存在しない場合はリクエストから取得
         $domain = session('tenant_domain', $request->getHost());
 
-        return redirect('http://' . $domain . '/home')
+        return redirect('http://' . $domain . '/')
             ->with('message', 'ログアウトしました');
     }
 }

--- a/app/Http/Controllers/Auth/GuestLoginController.php
+++ b/app/Http/Controllers/Auth/GuestLoginController.php
@@ -78,7 +78,7 @@ class GuestLoginController extends Controller
     session()->regenerateToken();
 
     // ホーム画面にリダイレクト
-    return redirect('/home')->with('message', 'ログアウトしました');
+    return redirect('/')->with('message', 'ログアウトしました');
 }
 
 }

--- a/app/Http/Controllers/Auth/GuestTenantController.php
+++ b/app/Http/Controllers/Auth/GuestTenantController.php
@@ -38,7 +38,7 @@ class GuestTenantController extends Controller
 
         // 環境に応じてHTTP/HTTPSを切り替えてリダイレクト
         $protocol = config('app.env') === 'local' ? 'http' : 'https';
-        return Inertia::location($protocol . '://' . $guestDomain . '/home');
+        return Inertia::location($protocol . '://' . $guestDomain . '/');
     }
 }
 

--- a/app/Http/Controllers/Auth/TenantRegisterController.php
+++ b/app/Http/Controllers/Auth/TenantRegisterController.php
@@ -73,7 +73,7 @@ class TenantRegisterController extends Controller
         Cookie::queue(Cookie::make('XSRF-TOKEN', csrf_token(), 120, '/', $sessionDomain, false, true, false, 'Lax'));
 
         // テナントのホームページにリダイレクト
-        return Inertia::location('http://' . $domain . '/home');
+        return Inertia::location('http://' . $domain . '/');
     }
 
 }

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -112,7 +112,7 @@ class ProfileController extends Controller
         $request->session()->regenerateToken();
         Log::info('セッションが再生成されました');
 
-        return Redirect::to('http://' . $domain . '/home'); // 必要に応じて 'http://' を 'https://' に変更
+        return Redirect::to('http://' . $domain . '/'); // 必要に応じて 'http://' を 'https://' に変更
     }
 
 }

--- a/app/Http/Controllers/Unused/TenantLoginController.php
+++ b/app/Http/Controllers/Unused/TenantLoginController.php
@@ -60,6 +60,6 @@ class TenantLoginController extends Controller
     $request->session()->regenerate();
 
     // テナント初期化後にInertiaでリダイレクト
-    return Inertia::location('http://' . $domain->domain . '/home');
+    return Inertia::location('http://' . $domain->domain . '/');
 }
 }

--- a/resources/js/Layouts/GuestLayout.vue
+++ b/resources/js/Layouts/GuestLayout.vue
@@ -14,7 +14,7 @@ const currentPage = usePage().component;
         <!-- ロゴ部分 -->
         <div class="w-full flex justify-center">
             <Link
-                href="/home"
+                href="/"
                 :class="{ 'pointer-events-none': currentPage === 'Welcome' }"
             >
                 <ApplicationLogo class="w-full text-blue-900 text-center" />

--- a/resources/js/Pages/TenantHome.vue
+++ b/resources/js/Pages/TenantHome.vue
@@ -38,7 +38,7 @@ try {
 
     isGuestHome =
         currentUrl.hostname === guestTenantUrl.hostname &&
-        currentUrl.pathname === "/home"; // ゲストホームかどうかを判定
+        currentUrl.pathname === "/"; // ゲストホームかどうかを判定
 } catch (error) {
     // エラーが発生した場合の処理を記述
     console.error("URLの処理中にエラーが発生しました:", error);

--- a/routes/tenant.php
+++ b/routes/tenant.php
@@ -3,6 +3,7 @@
 use Illuminate\Support\Facades\Route;
 use Stancl\Tenancy\Middleware\InitializeTenancyByDomain;
 use Stancl\Tenancy\Middleware\PreventAccessFromCentralDomains;
+use App\Http\Controllers\TenantHomeController;
 
 // ルートに適用するミドルウェアを指定します。 'web' ミドルウェアとStancl\Tenancyの二つのミドルウェアを適用します。
 Route::middleware([
@@ -10,10 +11,6 @@ Route::middleware([
     InitializeTenancyByDomain::class, // ドメインによってテナントを初期化するミドルウェア
     PreventAccessFromCentralDomains::class, // 中央ドメインからのアクセスを防ぐミドルウェア
 ])->group(function () { // ミドルウェアを適用したルートグループを定義します
-    // ルートグループ内のルートを定義します
-    Route::get('/', function () { // HTTP GETリクエストに応答するルートを定義します（ルートパスは '/'）
-        // テナントIDを含むメッセージを返します
-        return 'This is your multi-tenant application. The id of the current tenant is ' . tenant('id');
-        // 'tenant' ヘルパー関数を使用して現在のテナントIDを取得し、それを返す文字列に追加します
-    });
+    // テナントのトップページへのルート
+    Route::get('/', [TenantHomeController::class, 'index'])->name('tenant-home');
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,7 +13,6 @@ use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\UnitController;
 use App\Http\Controllers\ForumController;
 use App\Http\Controllers\LikeController;
-use App\Http\Controllers\TenantHomeController;
 use App\Http\Controllers\ResidentController;
 
 // テナント識別をスキップするルート
@@ -30,8 +29,6 @@ Route::middleware([])->group(function () {
 // Route::domain('{tenant}.' . config('app.tenant_base_domain'))->group(function () {
     // テナント識別を行うルート
     Route::middleware([App\Http\Middleware\InitializeTenancyCustom::class])->group(function () {
-        Route::get('/home', [TenantHomeController::class, 'index'])
-        ->name('tenant-home');
 
         Route::middleware(['auth'])->group(function () {
             Route::get('/dashboard', [DashboardController::class, 'index'])->name('dashboard');


### PR DESCRIPTION
## 目的

テナントトップページのURLをシンプルにすることで、ユーザー体験を向上させ、URL構造を簡潔化することを目的としています。

***

## 達成条件

1. テナントトップページのURLを `/home` から `/` に統一する。
2. URL変更に伴う影響箇所（ルート定義、コントローラー、リダイレクト先、フロントエンドロジック）を修正し、アプリケーション全体の動作を保証する。

***

## 実装の概要

以下の変更を実施しました：

1. **テナントトップページのURLを `/home` から `/` に変更**

   - `routes/tenant.php` におけるルート定義を修正しました。

2. **web.phpからテナントトップページへのルートを削除**

   - 重複するルートが `routes/tenant.php` に移行されたため、`web.php` から該当ルートを削除しました。

3. **ロゴリンクのURLを修正**

   - ログイン画面やゲスト画面で使用されるロゴのリンク先を `/home` から `/` に変更しました。

4. **リダイレクト先の変更**

   - ログアウト後、アカウント削除後、テナント作成後（現在未使用）、ゲストログアウト後のリダイレクト先を `/home` から `/` に統一しました。

5. **未使用コントローラーの修正**

   - 現在未使用の `TenantLoginController` 内のリダイレクト先URLを修正しました。なお、このコントローラーは `Unused` ディレクトリに配置されています。

***

## レビューしてほしいところ

1. URL変更に伴う影響箇所（ルート、コントローラー、フロントエンド）の修正が漏れなく対応されているか。
2. 本番環境や異なる環境（ローカル/ステージング）において問題が発生しないか。
3. `Unused` ディレクトリ内の未使用コントローラーを修正することが適切かどうか。

***

## 不安に思っていること

1. URL変更に伴うテストケースがすべて網羅されているか不安があります。追加テストが必要かどうかご確認ください。
2. ログアウト後やアカウント削除後のリダイレクトにおいて、ユーザー体験が十分に考慮されているか。

***

## 保留していること

1. 環境に応じたプロトコル（HTTP/HTTPS）の切り替え実装。現在は一部箇所でHTTPがハードコードされています。
2. 未使用コントローラーの取り扱い。今後使用予定がない場合、完全に削除するかどうかの判断が必要です。
3. テナント作成コントローラーの扱い
   - テナント作成コントローラー（TenantRegisterController.php）について、現在、別ブランチにて `Unused` ディレクトリに配置することを検討しています。移行後の削除や整理については、別途対応予定です。