### PR TITLE
モバイル向けレスポンシブ対応および入居者詳細画面・編集画面のレイアウト改善

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -2,10 +2,16 @@
 @tailwind components;
 @tailwind utilities;
 
-
 img {
     max-width: 100%; /* 親要素の幅に合わせる */
     height: auto; /* アスペクト比を保ちながら高さを自動調整 */
     object-fit: cover; /* アスペクト比を維持しながら、親要素に収める */
     border-radius: 8px; /* デザインとして角を丸める（オプション） */
+}
+
+/* レスポンシブ対応 */
+@media (max-width: 861px) {
+    .grid {
+        grid-template-columns: 1fr; /* 1列のグリッドにする */
+    }
 }

--- a/resources/js/Pages/Residents/Edit.vue
+++ b/resources/js/Pages/Residents/Edit.vue
@@ -38,180 +38,212 @@ const submit = () => {
     <AuthenticatedLayout>
         <div class="pt-6 pb-12 mt-16">
             <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-                <h2 class="text-xl font-bold text-gray-800 mb-6">
-                    {{ resident.name }}さんの情報編集
-                </h2>
+                <div class="bg-gray-100 overflow-hidden rounded-lg">
+                    <div class="p-6">
+                        <div class="flex items-center gap-8 mb-6">
+                            <h2 class="text-xl font-bold text-gray-800">
+                                {{ resident.name }}さんの情報編集
+                            </h2>
+                        </div>
 
-                <form @submit.prevent="submit">
-                    <div class="bg-gray-100 p-6 space-y-6 rounded-lg">
-                        <!-- 2x2 グリッドレイアウト -->
-                        <div class="grid grid-cols-2 gap-6">
-                            <!-- 利用者名 -->
-                            <div>
-                                <h3 class="text-lg font-medium text-gray-900">
-                                    利用者名
-                                </h3>
-                                <div class="mt-2">
-                                    <input
-                                        type="text"
-                                        v-model="form.name"
-                                        class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-                                    />
-                                    <div
-                                        v-if="form.errors.name"
-                                        class="text-red-500 text-sm mt-1"
-                                    >
-                                        {{ form.errors.name }}
-                                    </div>
-                                </div>
-                            </div>
-
-                            <!-- 所属ユニット -->
-                            <div>
-                                <h3 class="text-lg font-medium text-gray-900">
-                                    所属ユニット
-                                </h3>
-                                <div class="mt-2">
-                                    <select
-                                        v-model="form.unit_id"
-                                        class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-                                    >
-                                        <option
-                                            v-for="unit in units"
-                                            :key="unit.id"
-                                            :value="unit.id"
+                        <form @submit.prevent="submit">
+                            <div class="space-y-6">
+                                <!-- 2x2 グリッドレイアウト -->
+                                <div class="grid grid-cols-2 gap-6">
+                                    <!-- 利用者名 -->
+                                    <div>
+                                        <h3
+                                            class="text-lg font-medium text-gray-900"
                                         >
-                                            {{ unit.name }}
-                                        </option>
-                                    </select>
-                                    <div
-                                        v-if="form.errors.unit_id"
-                                        class="text-red-500 text-sm mt-1"
-                                    >
-                                        {{ form.errors.unit_id }}
+                                            利用者名
+                                        </h3>
+                                        <div class="mt-2">
+                                            <input
+                                                type="text"
+                                                v-model="form.name"
+                                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+                                            />
+                                            <div
+                                                v-if="form.errors.name"
+                                                class="text-red-500 text-sm mt-1"
+                                            >
+                                                {{ form.errors.name }}
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    <!-- 所属ユニット -->
+                                    <div>
+                                        <h3
+                                            class="text-lg font-medium text-gray-900"
+                                        >
+                                            所属ユニット
+                                        </h3>
+                                        <div class="mt-2">
+                                            <select
+                                                v-model="form.unit_id"
+                                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+                                            >
+                                                <option
+                                                    v-for="unit in units"
+                                                    :key="unit.id"
+                                                    :value="unit.id"
+                                                >
+                                                    {{ unit.name }}
+                                                </option>
+                                            </select>
+                                            <div
+                                                v-if="form.errors.unit_id"
+                                                class="text-red-500 text-sm mt-1"
+                                            >
+                                                {{ form.errors.unit_id }}
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    <!-- 食事の支援 -->
+                                    <div>
+                                        <h3
+                                            class="text-lg font-medium text-gray-900"
+                                        >
+                                            食事の支援
+                                        </h3>
+                                        <div class="mt-2">
+                                            <textarea
+                                                v-model="form.meal_support"
+                                                rows="8"
+                                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+                                            ></textarea>
+                                            <div
+                                                v-if="form.errors.meal_support"
+                                                class="text-red-500 text-sm mt-1"
+                                            >
+                                                {{ form.errors.meal_support }}
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    <!-- 排泄介助について -->
+                                    <div>
+                                        <h3
+                                            class="text-lg font-medium text-gray-900"
+                                        >
+                                            排泄介助について
+                                        </h3>
+                                        <div class="mt-2">
+                                            <textarea
+                                                v-model="form.toilet_support"
+                                                rows="8"
+                                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+                                            ></textarea>
+                                            <div
+                                                v-if="
+                                                    form.errors.toilet_support
+                                                "
+                                                class="text-red-500 text-sm mt-1"
+                                            >
+                                                {{ form.errors.toilet_support }}
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    <!-- 入浴介助について -->
+                                    <div>
+                                        <h3
+                                            class="text-lg font-medium text-gray-900"
+                                        >
+                                            入浴介助について
+                                        </h3>
+                                        <div class="mt-2">
+                                            <textarea
+                                                v-model="form.bathing_support"
+                                                rows="8"
+                                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+                                            ></textarea>
+                                            <div
+                                                v-if="
+                                                    form.errors.bathing_support
+                                                "
+                                                class="text-red-500 text-sm mt-1"
+                                            >
+                                                {{
+                                                    form.errors.bathing_support
+                                                }}
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    <!-- 移動や歩行に関する情報 -->
+                                    <div>
+                                        <h3
+                                            class="text-lg font-medium text-gray-900"
+                                        >
+                                            移動や歩行に関する情報
+                                        </h3>
+                                        <div class="mt-2">
+                                            <textarea
+                                                v-model="form.mobility_support"
+                                                rows="8"
+                                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+                                            ></textarea>
+                                            <div
+                                                v-if="
+                                                    form.errors.mobility_support
+                                                "
+                                                class="text-red-500 text-sm mt-1"
+                                            >
+                                                {{
+                                                    form.errors.mobility_support
+                                                }}
+                                            </div>
+                                        </div>
                                     </div>
                                 </div>
-                            </div>
 
-                            <!-- 食事の支援 -->
-                            <div>
-                                <h3 class="text-lg font-medium text-gray-900">
-                                    食事の支援
-                                </h3>
-                                <div class="mt-2">
-                                    <textarea
-                                        v-model="form.meal_support"
-                                        rows="8"
-                                        class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-                                    ></textarea>
-                                    <div
-                                        v-if="form.errors.meal_support"
-                                        class="text-red-500 text-sm mt-1"
+                                <!-- その他の備考 -->
+                                <div class="mt-6">
+                                    <h3
+                                        class="text-lg font-medium text-gray-900"
                                     >
-                                        {{ form.errors.meal_support }}
+                                        その他の備考
+                                    </h3>
+                                    <div class="mt-2">
+                                        <textarea
+                                            v-model="form.memo"
+                                            rows="3"
+                                            class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+                                        ></textarea>
+                                        <div
+                                            v-if="form.errors.memo"
+                                            class="text-red-500 text-sm mt-1"
+                                        >
+                                            {{ form.errors.memo }}
+                                        </div>
                                     </div>
                                 </div>
-                            </div>
 
-                            <!-- 排泄介助について -->
-                            <div>
-                                <h3 class="text-lg font-medium text-gray-900">
-                                    排泄介助について
-                                </h3>
-                                <div class="mt-2">
-                                    <textarea
-                                        v-model="form.toilet_support"
-                                        rows="8"
-                                        class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-                                    ></textarea>
-                                    <div
-                                        v-if="form.errors.toilet_support"
-                                        class="text-red-500 text-sm mt-1"
+                                <!-- アクションボタン -->
+                                <div class="mt-6 flex space-x-4">
+                                    <button
+                                        type="submit"
+                                        class="bg-blue-100 text-blue-700 font-medium py-2 px-4 rounded-md transition hover:bg-blue-300 hover:text-white focus:outline-none focus:shadow-outline"
+                                        :disabled="form.processing"
                                     >
-                                        {{ form.errors.toilet_support }}
-                                    </div>
-                                </div>
-                            </div>
-
-                            <!-- 入浴介助について -->
-                            <div>
-                                <h3 class="text-lg font-medium text-gray-900">
-                                    入浴介助について
-                                </h3>
-                                <div class="mt-2">
-                                    <textarea
-                                        v-model="form.bathing_support"
-                                        rows="8"
-                                        class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-                                    ></textarea>
-                                    <div
-                                        v-if="form.errors.bathing_support"
-                                        class="text-red-500 text-sm mt-1"
+                                        保存する
+                                    </button>
+                                    <Link
+                                        :href="
+                                            route('residents.show', resident.id)
+                                        "
+                                        class="bg-gray-300 text-gray-700 font-medium py-2 px-4 rounded-md transition hover:bg-gray-500 hover:text-white focus:outline-none focus:shadow-outline"
                                     >
-                                        {{ form.errors.bathing_support }}
-                                    </div>
+                                        キャンセル
+                                    </Link>
                                 </div>
                             </div>
-
-                            <!-- 移動や歩行に関する情報 -->
-                            <div>
-                                <h3 class="text-lg font-medium text-gray-900">
-                                    移動や歩行に関する情報
-                                </h3>
-                                <div class="mt-2">
-                                    <textarea
-                                        v-model="form.mobility_support"
-                                        rows="8"
-                                        class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-                                    ></textarea>
-                                    <div
-                                        v-if="form.errors.mobility_support"
-                                        class="text-red-500 text-sm mt-1"
-                                    >
-                                        {{ form.errors.mobility_support }}
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-
-                        <!-- その他の備考 -->
-                        <div class="mt-6">
-                            <h3 class="text-lg font-medium text-gray-900">
-                                その他の備考
-                            </h3>
-                            <div class="mt-2">
-                                <textarea
-                                    v-model="form.memo"
-                                    rows="3"
-                                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-                                ></textarea>
-                                <div
-                                    v-if="form.errors.memo"
-                                    class="text-red-500 text-sm mt-1"
-                                >
-                                    {{ form.errors.memo }}
-                                </div>
-                            </div>
-                        </div>
-
-                        <!-- アクションボタン -->
-                        <div class="mt-6 flex space-x-4">
-                            <button
-                                type="submit"
-                                class="bg-blue-100 text-blue-700 font-medium py-2 px-4 rounded-md transition hover:bg-blue-300 hover:text-white focus:outline-none focus:shadow-outline"
-                                :disabled="form.processing"
-                            >
-                                保存する
-                            </button>
-                            <Link
-                                :href="route('residents.show', resident.id)"
-                                class="bg-gray-300 text-gray-700 font-medium py-2 px-4 rounded-md transition hover:bg-gray-500 hover:text-white focus:outline-none focus:shadow-outline"
-                            >
-                                キャンセル
-                            </Link>
-                        </div>
+                        </form>
                     </div>
-                </form>
+                </div>
             </div>
         </div>
     </AuthenticatedLayout>

--- a/resources/js/Pages/Residents/Show.vue
+++ b/resources/js/Pages/Residents/Show.vue
@@ -52,103 +52,115 @@ const flashType = computed(() => (flash.value.success ? "success" : "error"));
 
         <div class="pt-6 pb-12 mt-16">
             <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-                <div class="flex items-center gap-8 mb-6">
-                    <h2 class="text-xl font-bold text-gray-800">
-                        {{ resident.unit.name }}
-                    </h2>
-                    <h2 class="text-xl font-bold text-gray-800">
-                        {{ resident.name }}さんの情報
-                    </h2>
-                </div>
+                <div class="bg-gray-100 overflow-hidden rounded-lg">
+                    <div class="p-6">
+                        <div class="flex items-center gap-8 mb-6">
+                            <h2 class="text-xl font-bold text-gray-800">
+                                {{ resident.unit.name }}
+                            </h2>
+                            <h2 class="text-xl font-bold text-gray-800">
+                                {{ resident.name }}さんの情報
+                            </h2>
+                        </div>
 
-                <div class="bg-gray-100 p-6 space-y-6 rounded-lg">
-                    <!-- 2x2 グリッドレイアウト -->
-                    <div class="grid grid-cols-2 gap-6">
-                        <!-- 食事の支援 -->
-                        <div>
-                            <h3 class="text-lg font-medium text-gray-900">
-                                食事の支援
-                            </h3>
-                            <div class="mt-2">
-                                <div
-                                    class="p-3 bg-white rounded-md border border-gray-300 min-h-[12rem] whitespace-pre-wrap"
-                                >
-                                    {{ resident.meal_support }}
+                        <div class="space-y-6">
+                            <!-- 2x2 グリッドレイアウト -->
+                            <div class="grid grid-cols-2 gap-6">
+                                <!-- 食事の支援 -->
+                                <div>
+                                    <h3
+                                        class="text-lg font-medium text-gray-900"
+                                    >
+                                        食事の支援
+                                    </h3>
+                                    <div class="mt-2">
+                                        <div
+                                            class="p-3 bg-white rounded-md border border-gray-300 min-h-[12rem] whitespace-pre-wrap"
+                                        >
+                                            {{ resident.meal_support }}
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <!-- 排泄介助について -->
+                                <div>
+                                    <h3
+                                        class="text-lg font-medium text-gray-900"
+                                    >
+                                        排泄介助について
+                                    </h3>
+                                    <div class="mt-2">
+                                        <div
+                                            class="p-3 bg-white rounded-md border border-gray-300 min-h-[12rem] whitespace-pre-wrap"
+                                        >
+                                            {{ resident.toilet_support }}
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <!-- 入浴介助について -->
+                                <div>
+                                    <h3
+                                        class="text-lg font-medium text-gray-900"
+                                    >
+                                        入浴介助について
+                                    </h3>
+                                    <div class="mt-2">
+                                        <div
+                                            class="p-3 bg-white rounded-md border border-gray-300 min-h-[12rem] whitespace-pre-wrap"
+                                        >
+                                            {{ resident.bathing_support }}
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <!-- 移動や歩行に関する情報 -->
+                                <div>
+                                    <h3
+                                        class="text-lg font-medium text-gray-900"
+                                    >
+                                        移動や歩行に関する情報
+                                    </h3>
+                                    <div class="mt-2">
+                                        <div
+                                            class="p-3 bg-white rounded-md border border-gray-300 min-h-[12rem] whitespace-pre-wrap"
+                                        >
+                                            {{ resident.mobility_support }}
+                                        </div>
+                                    </div>
                                 </div>
                             </div>
-                        </div>
 
-                        <!-- 排泄介助について -->
-                        <div>
-                            <h3 class="text-lg font-medium text-gray-900">
-                                排泄介助について
-                            </h3>
-                            <div class="mt-2">
-                                <div
-                                    class="p-3 bg-white rounded-md border border-gray-300 min-h-[12rem] whitespace-pre-wrap"
-                                >
-                                    {{ resident.toilet_support }}
+                            <!-- その他の備考 -->
+                            <div class="mt-6">
+                                <h3 class="text-lg font-medium text-gray-900">
+                                    その他の備考
+                                </h3>
+                                <div class="mt-2">
+                                    <div
+                                        class="p-3 bg-white rounded-md border border-gray-300 min-h-[12rem] whitespace-pre-wrap"
+                                    >
+                                        {{ resident.memo }}
+                                    </div>
                                 </div>
                             </div>
-                        </div>
 
-                        <!-- 入浴介助について -->
-                        <div>
-                            <h3 class="text-lg font-medium text-gray-900">
-                                入浴介助について
-                            </h3>
-                            <div class="mt-2">
-                                <div
-                                    class="p-3 bg-white rounded-md border border-gray-300 min-h-[12rem] whitespace-pre-wrap"
+                            <!-- アクションボタン -->
+                            <div class="mt-6 flex space-x-4">
+                                <Link
+                                    :href="route('residents.edit', resident.id)"
+                                    class="bg-blue-100 text-blue-700 font-medium py-2 px-4 rounded-md transition hover:bg-blue-300 hover:text-white focus:outline-none focus:shadow-outline"
                                 >
-                                    {{ resident.bathing_support }}
-                                </div>
-                            </div>
-                        </div>
-
-                        <!-- 移動や歩行に関する情報 -->
-                        <div>
-                            <h3 class="text-lg font-medium text-gray-900">
-                                移動や歩行に関する情報
-                            </h3>
-                            <div class="mt-2">
-                                <div
-                                    class="p-3 bg-white rounded-md border border-gray-300 min-h-[12rem] whitespace-pre-wrap"
+                                    編集する
+                                </Link>
+                                <Link
+                                    :href="route('residents.index')"
+                                    class="bg-gray-300 text-gray-700 font-medium py-2 px-4 rounded-md transition hover:bg-gray-500 hover:text-white focus:outline-none focus:shadow-outline"
                                 >
-                                    {{ resident.mobility_support }}
-                                </div>
+                                    一覧に戻る
+                                </Link>
                             </div>
                         </div>
-                    </div>
-
-                    <!-- その他の備考 -->
-                    <div class="mt-6">
-                        <h3 class="text-lg font-medium text-gray-900">
-                            その他の備考
-                        </h3>
-                        <div class="mt-2">
-                            <div
-                                class="p-3 bg-white rounded-md border border-gray-300 min-h-[12rem] whitespace-pre-wrap"
-                            >
-                                {{ resident.memo }}
-                            </div>
-                        </div>
-                    </div>
-
-                    <!-- アクションボタン -->
-                    <div class="mt-6 flex space-x-4">
-                        <Link
-                            :href="route('residents.edit', resident.id)"
-                            class="bg-blue-100 text-blue-700 font-medium py-2 px-4 rounded-md transition hover:bg-blue-300 hover:text-white focus:outline-none focus:shadow-outline"
-                        >
-                            編集する
-                        </Link>
-                        <Link
-                            :href="route('residents.index')"
-                            class="bg-gray-300 text-gray-700 font-medium py-2 px-4 rounded-md transition hover:bg-gray-500 hover:text-white focus:outline-none focus:shadow-outline"
-                        >
-                            一覧に戻る
-                        </Link>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
**目的**  
モバイルデバイスでのユーザー体験を向上させるため、以下の改善を行いました：

1. モバイル向けグリッドレイアウトのレスポンシブ対応
2. 入居者詳細画面および編集画面のレイアウト全体の視覚的一貫性とメンテナンス性向上

***

**達成条件**

- モバイル（861px以下）でグリッドレイアウトが縦並びに変更されること
- 入居者詳細画面および編集画面のレイアウトが親コンテナで統一的に制御されていること
- `Head` コンポーネントやタイトル部分とのレイアウトのズレが解消されていること

***

**実装の概要**

### 変更内容

1. **モバイル向けレスポンシブ対応**

   - 861px以下でグリッドレイアウトが1列構造になるようスタイルを追加:

     ```css
     @media (max-width: 861px) {
         .grid {
             grid-template-columns: 1fr; /* 1列のグリッドにする */
         }
     }
     ```

2. **入居者詳細画面および編集画面のレイアウト改善**

   - 親コンテナでの一括管理を採用し、`ml-6` や `pl-2` のような個別指定を削除
   - `<Head>` コンポーネントのタイトル表示（例: `<Head :title="`${resident.name}さんの詳細情報`" />`）とページ内のタイトル部分（例: `{{ resident.name }}さんの情報`）を同じ親コンテナ内に統合し、レイアウトのズレを解消
   - これにより、詳細画面と編集画面で統一感のある見た目を実現

***

**レビューしてほしいところ**

1. レスポンシブ対応が正しく動作しているか（特にモバイル環境での動作確認）
2. `Head` コンポーネントのタイトル表示とページレイアウトが一貫しているか
3. レイアウト変更による不具合や意図しない表示崩れがないか
4. コードの可読性やメンテナンス性についてのフィードバック

***

**不安に思っていること**

- 一部のブラウザや端末でスタイルが正しく適用されない可能性がある点

***

**保留していること**

1. 入居者画面全体のデザインをさらに統一的にするための追加スタイルは、別タスクで対応予定

2. テストデータの精査

3. **iPhone版Chromeでの戻るボタンの挙動問題**

   - iPhone版Chromeにおいて、ブラウザの戻るボタンを押すとリロード前のページに戻ってしまう問題があります。
   - 本アプリケーションはSPA（Single Page Application）として動作しており、通常の操作履歴に従った戻るボタンの挙動を期待していますが、iPhone版Chromeでは物理的なページ履歴に従って動作している可能性があります。
   - この挙動はiPhone版Chrome固有の仕様によるものと考えられ、Safariや他のブラウザでは発生していません。
   - 現状、この問題に対する対応は保留とし、必要に応じて将来的に再度検討します。