### PR TITLE
ゲストデモ環境で管理者がログインできる条件を追加

### DIFF
--- a/resources/js/Pages/Auth/Login.vue
+++ b/resources/js/Pages/Auth/Login.vue
@@ -14,6 +14,10 @@ const guestDomain =
     import.meta.env.VITE_GUEST_TENANT_URL || "http://guestdemo.localhost";
 const isGuestUrl = ref(currentUrl.includes(`${guestDomain}/login`));
 
+const isAdminMode = ref(
+    new URLSearchParams(window.location.search).has("admin")
+);
+
 // フォームデータにusername_idを使用
 const form = useForm({
     username_id: "",
@@ -35,15 +39,15 @@ const submit = () => {
     <GuestLayout>
         <Head :title="$t('Login')" />
 
-        <!-- 説明テキスト -->
+        <!-- ゲストデモテナントでかつ admin パラメータがない場合はフォーム非表示 -->
         <div
-            v-if="isGuestUrl"
+            v-if="isGuestUrl && !isAdminMode"
             class="p-6 bg-yellow-100 text-yellow-800 rounded"
         >
             セッションが切れました。アプリケーションロゴをクリックして、新たなゲストユーザーとしてログインし直してください。
         </div>
 
-        <!-- 通常ログインフォーム -->
+        <!-- admin パラメータがあれば通常のログインフォームを表示 -->
         <form v-else @submit.prevent="submit">
             <div>
                 <InputLabel for="username_id" :value="$t('Username_ID')" />


### PR DESCRIPTION
## **目的**

ゲストデモテナントでは、通常ログインフォームを非表示にしているが、管理者がログインできる手段を確保する必要がある。そのため、`?admin=true` というクエリパラメータを付与した場合のみ、ログインフォームを表示するようにする。

***

## **達成条件**

- ゲストデモ環境 (`VITE_GUEST_TENANT_URL`) の場合、通常はログインフォームを非表示にする
- `?admin=true` のパラメータが付いている場合のみ、管理者がログインフォームを利用できるようにする
- 既存のログインビュー (`Login.vue`) を流用し、新しいページを作成しない

***

## **実装の概要**

- `Login.vue` の `<script setup>` に、`?admin=true` のクエリパラメータを取得する処理を追加

  ```
  javascript
  コピーする編集する
  const isAdminMode = ref(
      new URLSearchParams(window.location.search).has("admin")
  );
  ```

- ログインフォームの表示条件を変更し、ゲストデモ環境 (`isGuestUrl`) で `isAdminMode` が `true` の場合のみフォームを表示

- これにより、管理者は `https://guestdemo.localhost/login?admin=true` にアクセスすることでログイン可能

***

## **レビューしてほしいところ**

- `isAdminMode` の取得方法 (`new URLSearchParams(window.location.search).has("admin")`) は適切か
- `Login.vue` の条件分岐が分かりやすいか
- 既存のログインビューを流用することで、メンテナンス性が向上しているか

***

## **不安に思っていること**

- `?admin=true` というURLパラメータを使う方式が適切か（他の方法の方が良いか？）
- URLが知られた場合にフォームが表示される点のリスクについて（`robots.txt` での対応を後から検討）
- 将来的に `admin` のパラメータを使った別のアクセス制御を行う可能性があるか

***

## **保留していること**

- **検索エンジンにログインページをインデックスさせない対応（`robots.txt` の設定）**
  - 今回はビューの変更のみとし、後から `robots.txt` の設定を検討する

- **シークレットキー (`?admin=シークレットキー`) を使ったアクセス制御の導入**

  - URLが知られた場合にフォームが表示されるリスクを下げるための手段として検討したが、  
    **管理者のID・パスワードが分からなければログインできないため、今回は採用を見送った**
  - 将来的にアクセス制御を強化する必要があれば、導入を検討