### PR TITLE
ユーザー管理画面のUI統一・レイアウト最適化

### DIFF
--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -284,7 +284,7 @@ const handleForumSelected = (unitId) => {
             @cancel="dialog.cancel"
         />
 
-        <div class="flex mt-16">
+        <div class="flex mt-16 gap-4">
             <!-- オーバーレイ (サイドバー表示時のみ) -->
             <div
                 v-if="sidebarVisible"
@@ -306,7 +306,7 @@ const handleForumSelected = (unitId) => {
             />
 
             <!-- メインコンテンツエリア -->
-            <div class="flex-1 max-w-4xl mx-auto p-4">
+            <div class="flex-1 p-4">
                 <!-- サイドバーのトグルボタンと検索フォーム -->
                 <div class="flex items-center mb-4 relative">
                     <h1
@@ -660,6 +660,7 @@ const handleForumSelected = (unitId) => {
 @media (min-width: 1366px) {
     .flex-1 {
         margin-left: 280px; /* サイドバー幅より広い余白を設定 */
+        margin-right: 280px; /* サイドバー幅より広い余白を設定 */
     }
 }
 

--- a/resources/js/Pages/Residents/Components/SearchForm.vue
+++ b/resources/js/Pages/Residents/Components/SearchForm.vue
@@ -72,7 +72,7 @@ const resetSearch = () => {
                     class="absolute inset-y-0 right-0 pr-3 flex items-center cursor-pointer"
                     @click="resetSearch"
                 >
-                    <i class="bi bi-x text-gray-400 hover:text-gray-600"></i>
+                    <i class="bi bi-x-lg text-gray-400 hover:text-gray-600"></i>
                 </div>
             </div>
             <!-- 検索結果件数表示 -->

--- a/resources/js/Pages/Users/Components/UserSearchForm.vue
+++ b/resources/js/Pages/Users/Components/UserSearchForm.vue
@@ -35,7 +35,7 @@ const resetSearch = () => {
 
 <template>
     <div
-        class="flex flex-col sm:flex-row items-start space-y-4 sm:space-y-0 sm:justify-between sm:items-start mt-4 sm:mt-0"
+        class="flex flex-col sm:flex-row items-start space-y-4 sm:space-y-0 sm:justify-between"
     >
         <!-- 部署選択プルダウン -->
         <div class="w-full sm:w-auto">
@@ -52,7 +52,7 @@ const resetSearch = () => {
         </div>
 
         <!-- 検索フィールドと結果表示 -->
-        <div class="w-full sm:w-auto space-y-2 ml-4">
+        <div class="w-full sm:w-auto space-y-2">
             <div class="relative">
                 <input
                     type="text"

--- a/resources/js/Pages/Users/Components/UserSearchForm.vue
+++ b/resources/js/Pages/Users/Components/UserSearchForm.vue
@@ -69,7 +69,7 @@ const resetSearch = () => {
                     class="absolute inset-y-0 right-0 pr-3 flex items-center cursor-pointer"
                     @click="resetSearch"
                 >
-                    <i class="bi bi-x text-gray-400 hover:text-gray-600"></i>
+                    <i class="bi bi-x-lg text-gray-400 hover:text-gray-600"></i>
                 </div>
             </div>
             <!-- 検索結果件数表示 -->

--- a/resources/js/Pages/Users/Components/UserSearchForm.vue
+++ b/resources/js/Pages/Users/Components/UserSearchForm.vue
@@ -34,7 +34,9 @@ const resetSearch = () => {
 </script>
 
 <template>
-    <div class="flex flex-col sm:flex-row items-start space-y-4 sm:space-y-0 mt-4 sm:mt-0 space-x-4">
+    <div
+        class="flex flex-col sm:flex-row items-start space-y-4 sm:space-y-0 sm:justify-between sm:items-start mt-4 sm:mt-0"
+    >
         <!-- 部署選択プルダウン -->
         <div class="w-full sm:w-auto">
             <select
@@ -50,7 +52,7 @@ const resetSearch = () => {
         </div>
 
         <!-- 検索フィールドと結果表示 -->
-        <div class="w-full sm:w-auto space-y-2">
+        <div class="w-full sm:w-auto space-y-2 ml-4">
             <div class="relative">
                 <input
                     type="text"
@@ -60,7 +62,9 @@ const resetSearch = () => {
                     class="w-full rounded-md border-gray-300 shadow-sm pl-10 pr-10 focus:border-blue-500"
                 />
                 <!-- 検索アイコン -->
-                <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                <div
+                    class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none"
+                >
                     <i class="bi bi-search text-gray-400"></i>
                 </div>
                 <!-- リセットアイコン -->
@@ -73,7 +77,7 @@ const resetSearch = () => {
                 </div>
             </div>
             <!-- 検索結果件数表示 -->
-            <div v-if="searchQuery" class="text-sm text-gray-600 absolute mt-1">
+            <div v-if="searchQuery" class="text-sm text-gray-600">
                 検索結果: {{ totalResults }}件
             </div>
         </div>

--- a/resources/js/Pages/Users/Components/UserSearchForm.vue
+++ b/resources/js/Pages/Users/Components/UserSearchForm.vue
@@ -35,7 +35,7 @@ const resetSearch = () => {
 
 <template>
     <div
-        class="flex flex-col sm:flex-row items-start space-y-4 sm:space-y-0 sm:justify-between"
+        class="flex flex-col sm:flex-row items-start space-y-4 sm:space-y-0 sm:space-x-4 "
     >
         <!-- 部署選択プルダウン -->
         <div class="w-full sm:w-auto">

--- a/resources/js/Pages/Users/Components/UserSearchForm.vue
+++ b/resources/js/Pages/Users/Components/UserSearchForm.vue
@@ -34,7 +34,7 @@ const resetSearch = () => {
 </script>
 
 <template>
-    <div class="flex flex-col sm:flex-row items-start space-y-4 sm:space-y-0 sm:space-x-4">
+    <div class="flex flex-col sm:flex-row items-start space-y-4 sm:space-y-0 mt-4 sm:mt-0 space-x-4">
         <!-- 部署選択プルダウン -->
         <div class="w-full sm:w-auto">
             <select

--- a/resources/js/Pages/Users/Components/UserSearchForm.vue
+++ b/resources/js/Pages/Users/Components/UserSearchForm.vue
@@ -34,7 +34,7 @@ const resetSearch = () => {
 </script>
 
 <template>
-    <div class="flex flex-col sm:flex-row items-start space-y-4 sm:space-y-0 sm:space-x-4">
+    <div class="flex flex-col sm:flex-row items-start space-y-4 sm:space-y-0 sm:space-x-4 mb-4">
         <!-- 部署選択プルダウン -->
         <div class="w-full sm:w-auto">
             <select

--- a/resources/js/Pages/Users/Components/UserSearchForm.vue
+++ b/resources/js/Pages/Users/Components/UserSearchForm.vue
@@ -34,7 +34,7 @@ const resetSearch = () => {
 </script>
 
 <template>
-    <div class="flex flex-col sm:flex-row items-start space-y-4 sm:space-y-0 sm:space-x-4 mb-4">
+    <div class="flex flex-col sm:flex-row items-start space-y-4 sm:space-y-0 sm:space-x-4">
         <!-- 部署選択プルダウン -->
         <div class="w-full sm:w-auto">
             <select

--- a/resources/js/Pages/Users/Index.vue
+++ b/resources/js/Pages/Users/Index.vue
@@ -264,24 +264,14 @@ const totalFilteredUsers = computed(() => {
                     <div class="p-6 bg-white border-b border-gray-200">
                         <!-- コントロール部分のコンテナ -->
                         <div class="mb-6">
-                            <!-- デスクトップでは横並び、モバイルでは縦並び -->
+                            <!-- 親コンテナ -->
                             <div
-                                class="flex flex-col space-y-4 sm:flex-row sm:space-y-0 sm:space-x-4 sm:items-center"
+                                class="flex flex-col space-y-4 sm:flex-row sm:space-y-0 sm:justify-between sm:items-start"
                             >
-                                <!-- 検索フォームとプルダウン -->
-                                <UserSearchForm
-                                    :units="units"
-                                    :selected-unit-id="selectedUnit"
-                                    :total-results="totalFilteredUsers"
-                                    @update:selected-unit="updateSelectedUnit"
-                                    @update:search-query="updateSearchQuery"
-                                    class="order-2 sm:order-1"
-                                />
-
                                 <!-- 管理者専用ボタン群 -->
                                 <div
                                     v-if="isAdmin"
-                                    class="flex space-x-2 order-1 sm:order-2"
+                                    class="flex items-center space-x-4 order-1 sm:order-2"
                                 >
                                     <Link
                                         :href="route('register')"
@@ -291,7 +281,7 @@ const totalFilteredUsers = computed(() => {
                                     </Link>
                                     <button
                                         @click="toggleDeleteMode"
-                                        class="w-32 px-4 py-2 rounded-md transition bg-red-100 text-red-700 hover:bg-red-300 hover:text-white"
+                                        class="w-32 px-4 py-2 rounded-md transition delete-mode-button bg-red-100 text-red-700 hover:bg-red-300 hover:text-white text-center"
                                         :class="
                                             showDeleteButtons
                                                 ? 'bg-red-300 !text-white'
@@ -302,7 +292,7 @@ const totalFilteredUsers = computed(() => {
                                     </button>
                                     <button
                                         @click="toggleAdminMode"
-                                        class="w-32 px-4 py-2 rounded-md transition bg-purple-100 text-purple-700 hover:bg-purple-300 hover:text-white"
+                                        class="w-32 px-4 py-2 rounded-md transition bg-purple-100 text-purple-700 hover:bg-purple-300 hover:text-white text-center"
                                         :class="
                                             isAdminMode
                                                 ? 'bg-purple-300 !text-white'
@@ -312,29 +302,39 @@ const totalFilteredUsers = computed(() => {
                                         管理者権限
                                     </button>
                                 </div>
+
+                                <!-- 検索フォームとプルダウン -->
+                                <UserSearchForm
+                                    :units="units"
+                                    :selected-unit-id="selectedUnit"
+                                    :total-results="totalFilteredUsers"
+                                    @update:selected-unit="updateSelectedUnit"
+                                    @update:search-query="updateSearchQuery"
+                                    class="order-2 sm:order-1"
+                                />
                             </div>
-                        </div>
 
-                        <!-- 削除モード説明（管理者かつ削除モードの時のみ表示） -->
-                        <div
-                            v-if="isAdmin && showDeleteButtons"
-                            class="mt-4 p-4 bg-red-100 rounded-lg"
-                        >
-                            <p class="text-red-700">
-                                削除したい職員をクリックすると削除できます。
-                                この操作は取り消しできませんのでご注意ください。
-                            </p>
-                        </div>
+                            <!-- 削除モード説明（管理者かつ削除モードの時のみ表示） -->
+                            <div
+                                v-if="isAdmin && showDeleteButtons"
+                                class="mt-4 p-4 bg-red-100 rounded-lg"
+                            >
+                                <p class="text-red-700">
+                                    削除したい職員をクリックすると削除できます。
+                                    この操作は取り消しできませんのでご注意ください。
+                                </p>
+                            </div>
 
-                        <!-- 管理者権限譲渡モード説明 -->
-                        <div
-                            v-if="isAdminMode"
-                            class="mt-4 p-4 bg-purple-100 rounded-lg"
-                        >
-                            <p class="text-purple-700">
-                                管理者権限を他の職員に渡すことができます。
-                                この操作を行うと、現在の管理者権限が解除されます。
-                            </p>
+                            <!-- 管理者権限譲渡モード説明 -->
+                            <div
+                                v-if="isAdminMode"
+                                class="mt-4 p-4 bg-purple-100 rounded-lg"
+                            >
+                                <p class="text-purple-700">
+                                    管理者権限を他の職員に渡すことができます。
+                                    この操作を行うと、現在の管理者権限が解除されます。
+                                </p>
+                            </div>
                         </div>
 
                         <!-- ユーザー一覧 -->

--- a/resources/js/Pages/Users/Index.vue
+++ b/resources/js/Pages/Users/Index.vue
@@ -117,13 +117,6 @@ const isAdmin = computed(() => {
     return currentAdminId === props.auth.user.id;
 });
 
-// 管理者とその他ユーザーの分類
-const sortedUsers = computed(() => {
-    const currentAdmin = users.value.find((user) => user.id === currentAdminId);
-    const otherUsers = users.value.filter((user) => user.id !== currentAdminId);
-    return { currentAdmin, otherUsers };
-});
-
 // showDeleteButtonsの更新時にisAdminModeをfalseに
 const toggleDeleteMode = () => {
     showDeleteButtons.value = !showDeleteButtons.value;

--- a/resources/js/Pages/Users/Index.vue
+++ b/resources/js/Pages/Users/Index.vue
@@ -242,65 +242,68 @@ const totalFilteredUsers = computed(() => {
             <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
                 <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
                     <div class="p-6 bg-white border-b border-gray-200">
-                        <!-- コントロール部分 -->
-                        <div
-                            class="flex flex-col space-y-4 sm:flex-row sm:space-y-0 sm:justify-between sm:items-start mb-6"
-                        >
-                            <!-- 検索フォームコンポーネント -->
-                            <UserSearchForm
-                                :units="units"
-                                :selected-unit-id="selectedUnit"
-                                :total-results="totalFilteredUsers"
-                                @update:selected-unit="updateSelectedUnit"
-                                @update:search-query="updateSearchQuery"
-                                class="order-2 sm:order-1"
-                            />
-
-                            <!-- 管理者のみに表示するボタン群 -->
+                        <!-- コントロール部分のコンテナ -->
+                        <div class="mb-6">
+                            <!-- ボタンと検索フォームの横並び部分 -->
                             <div
-                                v-if="isAdmin"
-                                class="flex items-center space-x-4 order-1 sm:order-2"
+                                class="flex flex-col space-y-4 sm:flex-row sm:space-y-0 sm:justify-between sm:items-start"
                             >
-                                <Link
-                                    :href="route('register')"
-                                    class="w-32 px-4 py-2 rounded-md transition bg-blue-100 text-blue-700 hover:bg-blue-300 hover:text-white text-center"
+                                <!-- 管理者のみに表示するボタン群 -->
+                                <div
+                                    v-if="isAdmin"
+                                    class="flex items-center space-x-4 order-1 sm:order-2"
                                 >
-                                    新規登録
-                                </Link>
-                                <button
-                                    @click="toggleDeleteMode"
-                                    class="w-32 px-4 py-2 rounded-md transition bg-red-100 text-red-700 hover:bg-red-300 hover:text-white"
-                                    :class="
-                                        showDeleteButtons
-                                            ? 'bg-red-300 !text-white'
-                                            : 'bg-red-200 text-red-600'
-                                    "
-                                >
-                                    削除モード
-                                </button>
-                                <button
-                                    @click="toggleAdminMode"
-                                    class="w-32 px-4 py-2 rounded-md transition bg-purple-100 text-purple-700 hover:bg-purple-300 hover:text-white"
-                                    :class="
-                                        isAdminMode
-                                            ? 'bg-purple-300 !text-white'
-                                            : 'bg-purple-200 text-purple-600'
-                                    "
-                                >
-                                    管理者権限
-                                </button>
-                            </div>
-                        </div>
+                                    <Link
+                                        :href="route('register')"
+                                        class="w-32 px-4 py-2 bg-blue-100 text-blue-700 rounded-md transition hover:bg-blue-300 hover:text-white text-center"
+                                    >
+                                        新規登録
+                                    </Link>
+                                    <button
+                                        @click="toggleDeleteMode"
+                                        class="w-32 px-4 py-2 rounded-md transition bg-red-100 text-red-700 hover:bg-red-300 hover:text-white"
+                                        :class="
+                                            showDeleteButtons
+                                                ? 'bg-red-300 !text-white'
+                                                : 'bg-red-200 text-red-600'
+                                        "
+                                    >
+                                        削除モード
+                                    </button>
+                                    <button
+                                        @click="toggleAdminMode"
+                                        class="w-32 px-4 py-2 rounded-md transition bg-purple-100 text-purple-700 hover:bg-purple-300 hover:text-white"
+                                        :class="
+                                            isAdminMode
+                                                ? 'bg-purple-300 !text-white'
+                                                : 'bg-purple-200 text-purple-600'
+                                        "
+                                    >
+                                        管理者権限
+                                    </button>
+                                </div>
 
-                        <!-- モード説明 -->
-                        <div
-                            v-if="showDeleteButtons"
-                            class="mb-4 p-4 bg-red-100 rounded-lg"
-                        >
-                            <p class="text-red-700">
-                                削除したい職員をクリックすると削除できます。
-                                この操作は取り消しできませんのでご注意ください。
-                            </p>
+                                <!-- 検索フォーム -->
+                                <UserSearchForm
+                                    :units="units"
+                                    :selected-unit-id="selectedUnit"
+                                    :total-results="totalFilteredUsers"
+                                    @update:selected-unit="updateSelectedUnit"
+                                    @update:search-query="updateSearchQuery"
+                                    class="order-2 sm:order-1"
+                                />
+                            </div>
+
+                            <!-- 削除モード説明（管理者かつ削除モードの時のみ表示） -->
+                            <div
+                                v-if="isAdmin && showDeleteButtons"
+                                class="mt-4 p-4 bg-red-100 rounded-lg"
+                            >
+                                <p class="text-red-700">
+                                    削除したい職員をクリックすると削除できます。
+                                    この操作は取り消しできませんのでご注意ください。
+                                </p>
+                            </div>
                         </div>
 
                         <!-- 既存の管理者モード説明 -->
@@ -352,7 +355,7 @@ const totalFilteredUsers = computed(() => {
                         </div>
 
                         <!-- ユーザー一覧 -->
-                        <div class="bg-white shadow rounded-lg p-4">
+                        <div class="bg-white shadow rounded-lg p-4 mt-12">
                             <!-- 部署ごとのユーザー一覧 -->
                             <div
                                 v-for="(unitUsers, unitName) in groupedUsers"

--- a/resources/js/Pages/Users/Index.vue
+++ b/resources/js/Pages/Users/Index.vue
@@ -306,10 +306,10 @@ const totalFilteredUsers = computed(() => {
                             </p>
                         </div>
 
-                        <!-- 既存の管理者モード説明 -->
+                        <!-- 管理者権限譲渡モード説明 -->
                         <div
                             v-if="isAdminMode"
-                            class="mb-4 p-4 bg-purple-100 rounded-lg"
+                            class="mt-4 p-4 bg-purple-100 rounded-lg"
                         >
                             <p class="text-purple-700">
                                 管理者権限を他の職員に渡すことができます。

--- a/resources/js/Pages/Users/Index.vue
+++ b/resources/js/Pages/Users/Index.vue
@@ -246,10 +246,20 @@ const totalFilteredUsers = computed(() => {
                         <div
                             class="flex flex-col space-y-4 sm:flex-row sm:space-y-0 sm:justify-between sm:items-start mb-6"
                         >
+                            <!-- 検索フォームコンポーネント -->
+                            <UserSearchForm
+                                :units="units"
+                                :selected-unit-id="selectedUnit"
+                                :total-results="totalFilteredUsers"
+                                @update:selected-unit="updateSelectedUnit"
+                                @update:search-query="updateSearchQuery"
+                                class="order-2 sm:order-1"
+                            />
+
                             <!-- 管理者のみに表示するボタン群 -->
                             <div
                                 v-if="isAdmin"
-                                class="flex items-center space-x-4"
+                                class="flex items-center space-x-4 order-1 sm:order-2"
                             >
                                 <Link
                                     :href="route('register')"
@@ -280,15 +290,6 @@ const totalFilteredUsers = computed(() => {
                                     管理者権限
                                 </button>
                             </div>
-
-                            <!-- 検索フォームコンポーネント -->
-                            <UserSearchForm
-                                :units="units"
-                                :selected-unit-id="selectedUnit"
-                                :total-results="totalFilteredUsers"
-                                @update:selected-unit="updateSelectedUnit"
-                                @update:search-query="updateSearchQuery"
-                            />
                         </div>
 
                         <!-- モード説明 -->

--- a/resources/js/Pages/Users/Index.vue
+++ b/resources/js/Pages/Users/Index.vue
@@ -248,41 +248,6 @@ const totalFilteredUsers = computed(() => {
                             <div
                                 class="flex flex-col space-y-4 sm:flex-row sm:space-y-0 sm:justify-between sm:items-start"
                             >
-                                <!-- 管理者のみに表示するボタン群 -->
-                                <div
-                                    v-if="isAdmin"
-                                    class="flex items-center space-x-4 order-1 sm:order-2"
-                                >
-                                    <Link
-                                        :href="route('register')"
-                                        class="w-32 px-4 py-2 bg-blue-100 text-blue-700 rounded-md transition hover:bg-blue-300 hover:text-white text-center"
-                                    >
-                                        新規登録
-                                    </Link>
-                                    <button
-                                        @click="toggleDeleteMode"
-                                        class="w-32 px-4 py-2 rounded-md transition bg-red-100 text-red-700 hover:bg-red-300 hover:text-white"
-                                        :class="
-                                            showDeleteButtons
-                                                ? 'bg-red-300 !text-white'
-                                                : 'bg-red-200 text-red-600'
-                                        "
-                                    >
-                                        削除モード
-                                    </button>
-                                    <button
-                                        @click="toggleAdminMode"
-                                        class="w-32 px-4 py-2 rounded-md transition bg-purple-100 text-purple-700 hover:bg-purple-300 hover:text-white"
-                                        :class="
-                                            isAdminMode
-                                                ? 'bg-purple-300 !text-white'
-                                                : 'bg-purple-200 text-purple-600'
-                                        "
-                                    >
-                                        管理者権限
-                                    </button>
-                                </div>
-
                                 <!-- 検索フォーム -->
                                 <UserSearchForm
                                     :units="units"
@@ -293,17 +258,52 @@ const totalFilteredUsers = computed(() => {
                                     class="order-2 sm:order-1"
                                 />
                             </div>
+                        </div>
 
-                            <!-- 削除モード説明（管理者かつ削除モードの時のみ表示） -->
-                            <div
-                                v-if="isAdmin && showDeleteButtons"
-                                class="mt-4 p-4 bg-red-100 rounded-lg"
+                        <!-- 管理者のみに表示するボタン群 -->
+                        <div
+                            v-if="isAdmin"
+                            class="flex items-center space-x-4 order-1 sm:order-2"
+                        >
+                            <Link
+                                :href="route('register')"
+                                class="w-32 px-4 py-2 bg-blue-100 text-blue-700 rounded-md transition hover:bg-blue-300 hover:text-white text-center"
                             >
-                                <p class="text-red-700">
-                                    削除したい職員をクリックすると削除できます。
-                                    この操作は取り消しできませんのでご注意ください。
-                                </p>
-                            </div>
+                                新規登録
+                            </Link>
+                            <button
+                                @click="toggleDeleteMode"
+                                class="w-32 px-4 py-2 rounded-md transition bg-red-100 text-red-700 hover:bg-red-300 hover:text-white"
+                                :class="
+                                    showDeleteButtons
+                                        ? 'bg-red-300 !text-white'
+                                        : 'bg-red-200 text-red-600'
+                                "
+                            >
+                                削除モード
+                            </button>
+                            <button
+                                @click="toggleAdminMode"
+                                class="w-32 px-4 py-2 rounded-md transition bg-purple-100 text-purple-700 hover:bg-purple-300 hover:text-white"
+                                :class="
+                                    isAdminMode
+                                        ? 'bg-purple-300 !text-white'
+                                        : 'bg-purple-200 text-purple-600'
+                                "
+                            >
+                                管理者権限
+                            </button>
+                        </div>
+
+                        <!-- 削除モード説明（管理者かつ削除モードの時のみ表示） -->
+                        <div
+                            v-if="isAdmin && showDeleteButtons"
+                            class="mt-4 p-4 bg-red-100 rounded-lg"
+                        >
+                            <p class="text-red-700">
+                                削除したい職員をクリックすると削除できます。
+                                この操作は取り消しできませんのでご注意ください。
+                            </p>
                         </div>
 
                         <!-- 既存の管理者モード説明 -->
@@ -315,43 +315,6 @@ const totalFilteredUsers = computed(() => {
                                 管理者権限を他の職員に渡すことができます。
                                 この操作を行うと、現在の管理者権限が解除されます。
                             </p>
-                        </div>
-
-                        <!-- 現在の管理者 -->
-                        <div v-if="sortedUsers.currentAdmin" class="my-8">
-                            <div
-                                class="bg-white w-11/12 mx-auto sm:w-full overflow-hidden shadow rounded-lg p-3 flex items-center justify-between border-l-4 border-blue-500 group cursor-pointer hover:bg-gray-50 transition-all"
-                                @click="
-                                    openUserProfile(sortedUsers.currentAdmin)
-                                "
-                            >
-                                <div class="flex items-center space-x-4">
-                                    <img
-                                        :src="
-                                            sortedUsers.currentAdmin.icon
-                                                ? `/storage/${sortedUsers.currentAdmin.icon}`
-                                                : '/images/default_user_icon.png'
-                                        "
-                                        alt="Profile Icon"
-                                        class="w-12 h-12 sm:w-16 sm:h-16 rounded-full"
-                                    />
-                                    <div class="flex items-center space-x-2">
-                                        <p
-                                            class="font-bold text-lg text-gray-500 group-hover:text-black transition-colors"
-                                        >
-                                            {{ sortedUsers.currentAdmin.name }}
-                                        </p>
-                                        <i
-                                            class="bi bi-award-fill text-yellow-500 text-xl mr-2"
-                                        ></i>
-                                        <span
-                                            class="text-xs sm:text-sm bg-gray-100 text-gray-600 px-2 py-1 rounded-full"
-                                        >
-                                            現在の管理者
-                                        </span>
-                                    </div>
-                                </div>
-                            </div>
                         </div>
 
                         <!-- ユーザー一覧 -->
@@ -425,6 +388,23 @@ const totalFilteredUsers = computed(() => {
                                                     >
                                                         {{ user.name }}
                                                     </span>
+                                                    <!-- 管理者アイコンとテキスト -->
+                                                    <div
+                                                        v-if="
+                                                            user.id ===
+                                                            currentAdminId
+                                                        "
+                                                        class="flex items-center ml-2"
+                                                    >
+                                                        <i
+                                                            class="bi bi-award-fill text-yellow-500 text-xl"
+                                                        ></i>
+                                                        <span
+                                                            class="text-xs bg-gray-100 text-gray-600 px-2 py-1 rounded-full ml-1"
+                                                        >
+                                                            現在の管理者
+                                                        </span>
+                                                    </div>
                                                 </div>
                                                 <i
                                                     v-if="showDeleteButtons"

--- a/resources/js/Pages/Users/Index.vue
+++ b/resources/js/Pages/Users/Index.vue
@@ -246,15 +246,6 @@ const totalFilteredUsers = computed(() => {
                         <div
                             class="flex flex-col space-y-4 sm:flex-row sm:space-y-0 sm:justify-between sm:items-start mb-6"
                         >
-                            <!-- 検索フォームコンポーネント -->
-                            <UserSearchForm
-                                :units="units"
-                                :selected-unit-id="selectedUnit"
-                                :total-results="totalFilteredUsers"
-                                @update:selected-unit="updateSelectedUnit"
-                                @update:search-query="updateSearchQuery"
-                            />
-
                             <!-- 管理者のみに表示するボタン群 -->
                             <div
                                 v-if="isAdmin"
@@ -289,6 +280,15 @@ const totalFilteredUsers = computed(() => {
                                     管理者権限
                                 </button>
                             </div>
+
+                            <!-- 検索フォームコンポーネント -->
+                            <UserSearchForm
+                                :units="units"
+                                :selected-unit-id="selectedUnit"
+                                :total-results="totalFilteredUsers"
+                                @update:selected-unit="updateSelectedUnit"
+                                @update:search-query="updateSearchQuery"
+                            />
                         </div>
 
                         <!-- モード説明 -->

--- a/resources/js/Pages/Users/Index.vue
+++ b/resources/js/Pages/Users/Index.vue
@@ -435,7 +435,7 @@ const totalFilteredUsers = computed(() => {
                             <!-- 表示する職員がいない場合 -->
                             <div
                                 v-if="Object.keys(groupedUsers).length === 0"
-                                class="text-center text-gray-500 mt-4"
+                                class="text-center text-gray-500 mt-4 text-lg font-medium"
                             >
                                 検索条件に一致する職員が見つかりませんでした。
                             </div>

--- a/resources/js/Pages/Users/Index.vue
+++ b/resources/js/Pages/Users/Index.vue
@@ -314,7 +314,7 @@ const totalFilteredUsers = computed(() => {
                         </div>
 
                         <!-- 現在の管理者 -->
-                        <div v-if="sortedUsers.currentAdmin" class="mb-8">
+                        <div v-if="sortedUsers.currentAdmin" class="my-8">
                             <div
                                 class="bg-white w-11/12 mx-auto sm:w-full overflow-hidden shadow rounded-lg p-3 flex items-center justify-between border-l-4 border-blue-500 group cursor-pointer hover:bg-gray-50 transition-all"
                                 @click="

--- a/resources/js/Pages/Users/Index.vue
+++ b/resources/js/Pages/Users/Index.vue
@@ -264,11 +264,11 @@ const totalFilteredUsers = computed(() => {
                     <div class="p-6 bg-white border-b border-gray-200">
                         <!-- コントロール部分のコンテナ -->
                         <div class="mb-6">
-                            <!-- ボタンと検索フォームの横並び部分 -->
+                            <!-- デスクトップでは横並び、モバイルでは縦並び -->
                             <div
-                                class="flex flex-col space-y-4 sm:flex-row sm:space-y-0 sm:justify-between sm:items-start"
+                                class="flex flex-col space-y-4 sm:flex-row sm:space-y-0 sm:space-x-4 sm:items-center"
                             >
-                                <!-- 検索フォーム -->
+                                <!-- 検索フォームとプルダウン -->
                                 <UserSearchForm
                                     :units="units"
                                     :selected-unit-id="selectedUnit"
@@ -277,42 +277,42 @@ const totalFilteredUsers = computed(() => {
                                     @update:search-query="updateSearchQuery"
                                     class="order-2 sm:order-1"
                                 />
-                            </div>
-                        </div>
 
-                        <!-- 管理者のみに表示するボタン群 -->
-                        <div
-                            v-if="isAdmin"
-                            class="flex items-center space-x-4 order-1 sm:order-2"
-                        >
-                            <Link
-                                :href="route('register')"
-                                class="w-32 px-4 py-2 bg-blue-100 text-blue-700 rounded-md transition hover:bg-blue-300 hover:text-white text-center"
-                            >
-                                新規登録
-                            </Link>
-                            <button
-                                @click="toggleDeleteMode"
-                                class="w-32 px-4 py-2 rounded-md transition bg-red-100 text-red-700 hover:bg-red-300 hover:text-white"
-                                :class="
-                                    showDeleteButtons
-                                        ? 'bg-red-300 !text-white'
-                                        : 'bg-red-200 text-red-600'
-                                "
-                            >
-                                削除モード
-                            </button>
-                            <button
-                                @click="toggleAdminMode"
-                                class="w-32 px-4 py-2 rounded-md transition bg-purple-100 text-purple-700 hover:bg-purple-300 hover:text-white"
-                                :class="
-                                    isAdminMode
-                                        ? 'bg-purple-300 !text-white'
-                                        : 'bg-purple-200 text-purple-600'
-                                "
-                            >
-                                管理者権限
-                            </button>
+                                <!-- 管理者専用ボタン群 -->
+                                <div
+                                    v-if="isAdmin"
+                                    class="flex space-x-2 order-1 sm:order-2"
+                                >
+                                    <Link
+                                        :href="route('register')"
+                                        class="w-32 px-4 py-2 bg-blue-100 text-blue-700 rounded-md transition hover:bg-blue-300 hover:text-white text-center"
+                                    >
+                                        新規登録
+                                    </Link>
+                                    <button
+                                        @click="toggleDeleteMode"
+                                        class="w-32 px-4 py-2 rounded-md transition bg-red-100 text-red-700 hover:bg-red-300 hover:text-white"
+                                        :class="
+                                            showDeleteButtons
+                                                ? 'bg-red-300 !text-white'
+                                                : 'bg-red-200 text-red-600'
+                                        "
+                                    >
+                                        削除モード
+                                    </button>
+                                    <button
+                                        @click="toggleAdminMode"
+                                        class="w-32 px-4 py-2 rounded-md transition bg-purple-100 text-purple-700 hover:bg-purple-300 hover:text-white"
+                                        :class="
+                                            isAdminMode
+                                                ? 'bg-purple-300 !text-white'
+                                                : 'bg-purple-200 text-purple-600'
+                                        "
+                                    >
+                                        管理者権限
+                                    </button>
+                                </div>
+                            </div>
                         </div>
 
                         <!-- 削除モード説明（管理者かつ削除モードの時のみ表示） -->

--- a/resources/js/Pages/Users/Index.vue
+++ b/resources/js/Pages/Users/Index.vue
@@ -271,17 +271,17 @@ const totalFilteredUsers = computed(() => {
                                 <!-- 管理者専用ボタン群 -->
                                 <div
                                     v-if="isAdmin"
-                                    class="flex items-center space-x-4 order-1 sm:order-2"
+                                    class="flex items-center space-x-1 sm:space-x-4 order-1 sm:order-2"
                                 >
                                     <Link
                                         :href="route('register')"
-                                        class="w-32 px-4 py-2 bg-blue-100 text-blue-700 rounded-md transition hover:bg-blue-300 hover:text-white text-center"
+                                        class="w-32 px-4 py-2 bg-blue-100 text-blue-700 rounded-md transition hover:bg-blue-300 hover:text-white text-center whitespace-nowrap"
                                     >
                                         新規登録
                                     </Link>
                                     <button
                                         @click="toggleDeleteMode"
-                                        class="w-32 px-4 py-2 rounded-md transition delete-mode-button bg-red-100 text-red-700 hover:bg-red-300 hover:text-white text-center"
+                                        class="w-32 px-4 py-2 rounded-md transition delete-mode-button bg-red-100 text-red-700 hover:bg-red-300 hover:text-white text-center whitespace-nowrap"
                                         :class="
                                             showDeleteButtons
                                                 ? 'bg-red-300 !text-white'
@@ -292,7 +292,7 @@ const totalFilteredUsers = computed(() => {
                                     </button>
                                     <button
                                         @click="toggleAdminMode"
-                                        class="w-32 px-4 py-2 rounded-md transition bg-purple-100 text-purple-700 hover:bg-purple-300 hover:text-white text-center"
+                                        class="w-32 px-4 py-2 rounded-md transition bg-purple-100 text-purple-700 hover:bg-purple-300 hover:text-white text-center whitespace-nowrap"
                                         :class="
                                             isAdminMode
                                                 ? 'bg-purple-300 !text-white'


### PR DESCRIPTION
## 目的

- モバイル・デスクトップ双方でのレイアウト不整合を解消し、全ページで一貫したユーザーインターフェイスを実現する。
- 検索フォーム、管理者表示、及び各操作モード（削除・管理者権限譲渡）の視認性と操作性を向上させる。

## 達成条件

- **レイアウトの統一**

  - デスクトップでは、検索フォームが左、管理者用ボタン群が右に配置。モバイルでは、管理者ボタン群が上、検索フォームが下に表示される。
  - 職員ページは、デスクトップではプルダウン、検索フォーム、管理者ボタン群が横並び、モバイルでは縦並びレイアウトとなる。
  - UsersページのレイアウトがResidentsページと統一される。

- **UI要素の改善**

  - 検索リセットアイコンを全ページで `bi-x-lg` に変更し、視認性・クリック性を向上。
  - 「職員が見つかりません」メッセージに `text-lg` と `font-medium` を適用。
  - ユーザー一覧に管理者表示を統合し、管理者権限を持つユーザーに「現在の管理者」テキストとアイコンを表示する。

- **操作性の向上**

  - 管理者権限譲渡モード説明に上余白（mt-4）を追加し、視覚的バランスを改善。
  - 削除モードおよび管理者権限モードが有効な際、画面の任意のクリックで自動解除される機能を実装（ボタン押下時は解除されない）。

## 実装の概要

- **レイアウト統一と配置調整**

  - 各画面（Users、職員、利用者、Residents）のコンポーネント配置を見直し、デスクトップでは左右、モバイルでは上下に均等配置するよう調整。
  - 親コンテナに `sm:justify-between`、`sm:items-center` などのクラスを適用し、各要素間の余白（例：`sm:space-x-4`、`gap-4`）を最適化。

- **UI要素の改善**

  - 検索リセットアイコンを `bi-x` から `bi-x-lg` に変更。
  - 「職員が見つかりません」メッセージに適切なテキストサイズと太さを適用。
  - ユーザー一覧において、管理者専用表示を廃止し、対象ユーザーに「現在の管理者」表示を追加。不要なコード（`isAdmin` 判定、`sortedUsers` 計算）は削除。

- **操作モードの改善**

  - 管理者権限譲渡モード説明の表示位置と余白（mt-4）を調整。
  - 画面クリックで削除モードおよび管理者権限モードが解除される機能を実装。ボタンなどの特定要素のクリック時はイベント伝播を防止し、モードが維持されるように設定。

## レビューしてほしいところ

- 各ページのレイアウト（デスクトップ・モバイル）が意図通りに統一されているか。
- 管理者表示統合、検索フォームの位置修正、及び職員ページの横並び／縦並び切替が他コンポーネントへ悪影響を与えていないか。
- UI要素（検索リセットアイコン、メッセージ、管理者権限譲渡モード説明）の視認性と操作性の向上が十分か。
- 画面クリックでのモード解除機能が期待通りに動作するか。

## 不安に思っていること

- 各種余白・配置調整により、ブラウザ間や他ページで予期せぬレイアウト崩れが発生しないか。
- 複数の変更が同時実施されたことによる細かなスタイル競合の可能性。

## 保留していること

- 全体のUI統一感について、フィードバックに基づきさらなる微調整が必要かどうか検証中。必要に応じて追加プルリクエストで対応予定。