### PR TITLE
部署管理ページリンクテキストの修正およびプロフィール情報入力欄へのプレースホルダー追加

### DIFF
--- a/lang/ja.json
+++ b/lang/ja.json
@@ -169,6 +169,7 @@
     "Unit Management": "部署管理",
     "Manage unit names.": "部署名を管理します",
     "Management page": "管理ページへ",
+    "Unit Management page": "部署管理ページへ",
     "New user registration": "職員新規登録",
     "No user available": "職員が登録されていません",
     "User registration": "職員登録",

--- a/resources/js/Pages/Admin/Dashboard.vue
+++ b/resources/js/Pages/Admin/Dashboard.vue
@@ -23,7 +23,7 @@ import { Link, Head } from "@inertiajs/vue3";
                         <Link
                             :href="route('units.create')"
                             class="text-blue-500 link-hover"
-                            >{{ $t("Management page") }}</Link
+                            >{{ $t("Unit Management page") }}</Link
                         >
                     </div>
                 </div>

--- a/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
+++ b/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
@@ -164,6 +164,7 @@ const handleSuccessMessage = (message) => {
                     v-model="form.name"
                     required
                     autocomplete="name"
+                    placeholder="例: 山田太郎"
                 />
                 <InputError class="mt-2" :message="form.errors.name" />
             </div>
@@ -176,6 +177,7 @@ const handleSuccessMessage = (message) => {
                     class="mt-1 block w-full"
                     v-model="form.username_id"
                     required
+                    placeholder="任意の英数字（255文字以内）"
                 />
                 <InputError class="mt-2" :message="form.errors.username_id" />
                 <!-- ゲストユーザー向けの説明文 -->
@@ -194,6 +196,7 @@ const handleSuccessMessage = (message) => {
                     type="text"
                     class="mt-1 block w-full"
                     v-model="form.tel"
+                    placeholder="例: 090-1234-5678（任意）"
                 />
             </div>
 
@@ -204,6 +207,7 @@ const handleSuccessMessage = (message) => {
                     type="email"
                     class="mt-1 block w-full"
                     v-model="form.email"
+                    placeholder="例: example@example.com（任意）"
                 />
             </div>
 


### PR DESCRIPTION
## 目的

- 部署管理ページのリンクがより明確に機能を示すことで、ユーザーの利便性を向上させるため。
- プロフィール情報入力欄にプレースホルダーを追加することで、入力内容を直感的に理解しやすくするため。

## 達成条件

- 部署管理ページのリンクテキストが「部署管理ページへ」と表示されていること。
- プロフィール情報入力欄（名前、ユーザーID、電話番号、メールアドレス）に適切なプレースホルダーが表示されていること。
- 変更後もページ遷移や入力機能に問題がないこと。

## 実装の概要

- 部署管理ページのリンクテキストを修正し、HTML内またはコンポーネントのラベルを「部署管理ページへ」に変更。
- プロフィール情報入力欄に対して、各フィールドに説明的なプレースホルダーを追加。

## レビューしてほしいところ

- リンクテキストの修正が適切に反映されているか。
- プレースホルダーの文言がユーザーにとってわかりやすいかどうか。
- 変更による他機能への影響がないか。

## 不安に思っていること

- プレースホルダーの表現がユーザーの理解を十分に助ける内容になっているかどうか。
- 部署管理ページへのリンク修正によって、既存のナビゲーションやデザインの整合性が崩れていないか。

## 保留していること

- 現時点では特に保留している項目はありません。