### PR TITLE
コメントの画像添付機能の追加、スレッド表示の修正、および関連コードのリファクタリング

### DIFF
--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -17,7 +17,7 @@ class CommentController extends Controller
             'post_id' => 'required|exists:posts,id',
             'parent_id' => 'nullable|exists:comments,id',
             'message' => 'required|string|max:1000',
-            'img' => 'nullable|image|mimes:jpeg,png,jpg,gif|max:2048',
+            'img' => 'nullable|image|mimes:jpeg,png,jpg,gif|max:10240',
         ]);
 
         // 画像がアップロードされた場合は保存

--- a/app/Http/Controllers/ForumController.php
+++ b/app/Http/Controllers/ForumController.php
@@ -88,6 +88,7 @@ class ForumController extends Controller
                     return [
                         'id' => $comment->id,
                         'message' => $comment->message,
+                        'img' => $comment->img,
                         'created_at' => $comment->created_at,
                         'user' => $comment->user,
                         'like_count' => $comment->likes_count, // コメントのいいね数

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -17,7 +17,7 @@ class PostController extends Controller
             'message' => 'required|string',
             'forum_id' => 'required|exists:forums,id',
             'quoted_post_id' => 'nullable|exists:posts,id',
-            'img' => 'nullable|image|mimes:jpeg,png,jpg,gif|max:2048',
+            'img' => 'nullable|image|mimes:jpeg,png,jpg,gif|max:10240',
         ]);
 
         $imgPath = null;

--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -10,7 +10,7 @@ class Comment extends Model
 {
     use HasFactory, SoftDeletes;
 
-    protected $fillable = ['tenant_id', 'user_id', 'post_id', 'parent_id', 'message', 'img'];
+    protected $fillable = ['tenant_id', 'user_id', 'post_id', 'parent_id', 'message', 'img', 'forum_id'];
 
     public function post()
     {

--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -10,7 +10,7 @@ class Comment extends Model
 {
     use HasFactory, SoftDeletes;
 
-    protected $fillable = ['tenant_id', 'user_id', 'post_id', 'parent_id', 'message'];
+    protected $fillable = ['tenant_id', 'user_id', 'post_id', 'parent_id', 'message', 'img'];
 
     public function post()
     {

--- a/database/migrations/2025_02_08_081428_add_img_to_comments_table.php
+++ b/database/migrations/2025_02_08_081428_add_img_to_comments_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('comments', function (Blueprint $table) {
+            $table->string('img')->nullable()->after('message'); // 画像の保存先
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('comments', function (Blueprint $table) {
+            $table->dropColumn('img'); // 画像の保存先
+        });
+    }
+};

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -3,7 +3,7 @@
         "baseUrl": ".",
         "paths": {
             "@/*": ["resources/js/*"],
-            "ziggy-js": ["./vendor/tightenco/ziggy"]
+            "ziggy-js": ["./vendor/tightenco/ziggy/dist/ziggy.js"]
         }
     },
     "exclude": ["node_modules", "public"]

--- a/resources/js/Components/ChildComment.vue
+++ b/resources/js/Components/ChildComment.vue
@@ -1,5 +1,7 @@
 <script setup>
+import { ref } from "vue";
 import CommentForm from "./CommentForm.vue"; // CommentFormをインポート
+import ImageModal from "./ImageModal.vue";
 
 const props = defineProps({
     childComments: Array, // 子コメントリスト
@@ -12,6 +14,16 @@ const props = defineProps({
     openUserProfile: Function, // ユーザープロフィールを開く関数
     selectedForumId: Number, // 選択されたフォーラムのID
 });
+
+// コメント画像モーダルの表示状態を管理
+const isModalOpen = ref(false); // コメント画像モーダルの表示状態
+const currentImage = ref(null); // 現在表示中の画像パス
+
+// コメント画像モーダルを開く
+const openModal = (imagePath) => {
+    currentImage.value = imagePath; // 現在表示中の画像パスを更新
+    isModalOpen.value = true; // コメント画像モーダルを開く
+};
 </script>
 
 <template>
@@ -124,4 +136,13 @@ const props = defineProps({
             </div>
         </div>
     </div>
+
+    <!-- コメント画像モーダル -->
+    <ImageModal :isOpen="isModalOpen" @close="isModalOpen = false">
+        <img
+            :src="currentImage"
+            alt="投稿画像"
+            class="max-w-full max-h-full rounded-lg"
+        />
+    </ImageModal>
 </template>

--- a/resources/js/Components/ChildComment.vue
+++ b/resources/js/Components/ChildComment.vue
@@ -57,6 +57,16 @@ const props = defineProps({
                 <!-- コメント本文 -->
                 <p class="mt-2 whitespace-pre-wrap">{{ comment.message }}</p>
 
+                <!-- コメント画像 -->
+                <div v-if="comment.img" class="mt-3">
+                    <img
+                        :src="`/storage/${comment.img}`"
+                        alt="添付画像"
+                        class="w-32 h-32 object-cover rounded-md cursor-pointer hover:opacity-80 transition"
+                        @click="openModal(`/storage/${comment.img}`)"
+                    />
+                </div>
+
                 <div class="flex justify-end space-x-2 mt-2">
                     <!-- 返信ボタン -->
                     <button

--- a/resources/js/Components/CommentForm.vue
+++ b/resources/js/Components/CommentForm.vue
@@ -2,6 +2,7 @@
 import { ref, onMounted } from "vue";
 import { router } from "@inertiajs/vue3";
 import { getCsrfToken } from "@/Utils/csrf";
+import ImageModal from "./ImageModal.vue";
 
 const props = defineProps({
     postId: {
@@ -38,6 +39,13 @@ const commentData = ref({
     replyToName: props.replyToName,
 });
 
+// 画像関連のrefを追加
+const image = ref(null);
+const imagePreview = ref(null);
+const fileInput = ref(null);
+const isModalOpen = ref(false);
+const localErrorMessage = ref(null);
+
 onMounted(() => {
     // コメントに対する返信の場合のみメンションを追加
     if (props.replyToName && props.parentId) {
@@ -45,37 +53,79 @@ onMounted(() => {
     }
 });
 
-// コメントの送信処理
+// 画像ファイルのチェック
+const handleImageChange = (e) => {
+    const file = e.target.files[0];
+    if (file) {
+        const validImageTypes = [
+            "image/jpeg",
+            "image/png",
+            "image/gif",
+            "image/webp",
+        ];
+        if (!validImageTypes.includes(file.type)) {
+            localErrorMessage.value =
+                "対応していないファイル形式です。png, jpg, gif, webpのいずれかを選択してください。";
+            setTimeout(() => {
+                localErrorMessage.value = null;
+            }, 8000);
+            return;
+        }
+        image.value = file;
+        imagePreview.value = URL.createObjectURL(file);
+    }
+};
+
+// ファイル選択ボタンをクリックしたときの処理
+const triggerFileInput = () => {
+    fileInput.value.click();
+};
+
+// 画像を削除する処理
+const removeImage = () => {
+    image.value = null;
+    imagePreview.value = null;
+    if (fileInput.value) {
+        fileInput.value.value = "";
+    }
+};
+
+// コメントの送信処理に画像データを追加
 const submitComment = () => {
     commentData.value._token = getCsrfToken();
     commentData.value.post_id = props.postId;
 
-    router.post(
-        route("comment.store", { post: props.postId }),
-        commentData.value,
-        {
-            preserveScroll: true,
-            onSuccess: () => {
-                // フォームのリセット
-                commentData.value = {
-                    post_id: props.postId,
-                    parent_id: props.parentId,
-                    message: "",
-                };
+    const formData = new FormData();
+    formData.append("message", commentData.value.message);
+    formData.append("post_id", commentData.value.post_id);
+    formData.append("_token", commentData.value._token);
 
-                router.visit(
-                    route("forum.index", { forum_id: props.selectedForumId }),
-                    {
-                        preserveScroll: true,
-                        replace: true,
-                    }
-                );
-            },
-            onError: (errors) => {
-                console.error("コメントの投稿に失敗しました:", errors);
-            },
-        }
-    );
+    if (image.value) {
+        formData.append("image", image.value);
+    }
+
+    router.post(route("comment.store", { post: props.postId }), formData, {
+        preserveScroll: true,
+        onSuccess: () => {
+            commentData.value = {
+                post_id: props.postId,
+                parent_id: props.parentId,
+                message: "",
+            };
+            image.value = null;
+            imagePreview.value = null;
+            router.visit(
+                route("forum.index", { forum_id: props.selectedForumId }),
+                {
+                    preserveScroll: true,
+                    replace: true,
+                }
+            );
+        },
+        onError: (errors) => {
+            console.error("コメントの投稿に失敗しました:", errors);
+        },
+    });
 };
 
 // キャンセルハンドラーを追加
@@ -94,13 +144,60 @@ const handleCancel = () => {
 
 <template>
     <div class="mt-4">
-        <form @submit.prevent="submitComment">
-            <textarea
-                v-model="commentData.message"
-                class="w-full p-2 border rounded-md"
-                :placeholder="placeholder"
-                rows="3"
-            ></textarea>
+        <form @submit.prevent="submitComment" enctype="multipart/form-data">
+            <div class="relative">
+                <textarea
+                    v-model="commentData.message"
+                    class="w-full p-2 border rounded-md"
+                    :placeholder="placeholder"
+                    rows="3"
+                ></textarea>
+                <!-- ファイル選択アイコン -->
+                <div
+                    class="absolute right-2 bottom-4 bg-gray-300 text-black transition hover:bg-gray-400 hover:text-white rounded-md flex items-center justify-center cursor-pointer"
+                    style="width: 40px; height: 40px"
+                    @click="triggerFileInput"
+                    title="ファイルを選択"
+                >
+                    <i class="bi bi-card-image text-2xl"></i>
+                </div>
+            </div>
+            <input
+                type="file"
+                accept="image/*"
+                ref="fileInput"
+                @change="handleImageChange"
+                style="display: none"
+            />
+            <!-- エラーメッセージ表示 -->
+            <div v-if="localErrorMessage" class="text-red-500 mt-2">
+                {{ localErrorMessage }}
+            </div>
+            <!-- プレビュー表示 -->
+            <div v-if="imagePreview" class="relative mt-2 inline-block">
+                <img
+                    :src="imagePreview"
+                    alt="画像プレビュー"
+                    class="w-32 h-32 object-cover rounded-md cursor-pointer hover:opacity-80 transition"
+                    @click="isModalOpen = true"
+                />
+                <div
+                    class="absolute top-0 right-0 bg-white rounded-full p-1 cursor-pointer flex items-center justify-center"
+                    @click="removeImage"
+                    title="画像を削除"
+                    style="width: 24px; height: 24px"
+                >
+                    <i
+                        class="bi bi-x-circle text-black hover:text-gray-500"
+                    ></i>
+                </div>
+            </div>
+            <ImageModal :isOpen="isModalOpen" @close="isModalOpen = false">
+                <img
+                    :src="imagePreview"
+                    class="max-w-full max-h-full rounded-lg"
+                />
+            </ImageModal>
             <div class="flex justify-end space-x-2 mt-2">
                 <button
                     type="button"

--- a/resources/js/Components/CommentForm.vue
+++ b/resources/js/Components/CommentForm.vue
@@ -5,48 +5,49 @@ import { getCsrfToken } from "@/Utils/csrf";
 import ImageModal from "./ImageModal.vue";
 import { handleImageChange } from "@/Utils/imageHandler";
 
+// コメントフォームのプロパティを定義
 const props = defineProps({
-    postId: {
+    postId: { // 投稿ID
         type: Number,
         required: true,
     },
-    parentId: {
+    parentId: { // 親コメントID
         type: Number,
         default: null,
     },
-    selectedForumId: {
+    selectedForumId: { // 選択中の掲示版ID
         type: Number,
         required: true,
     },
-    replyToName: {
+    replyToName: { // 返信先のユーザー名
         type: String,
         default: "",
     },
-    title: {
+    title: { // フォームのタイトル
         type: String,
         default: "返信",
     },
 });
 
-const emit = defineEmits(["cancel"]);
-const message = ref("");
-const placeholder = ref(`@${props.replyToName} さんへの返信を入力`);
+const emit = defineEmits(["cancel"]); // キャンセルイベントを発行するためのemit
+const placeholder = ref(`@${props.replyToName} さんへの返信を入力`); // プレースホルダー
 
 // コメントデータを管理するref
-const commentData = ref({
-    post_id: props.postId,
-    parent_id: props.parentId,
-    message: "",
-    replyToName: props.replyToName,
+const commentData = ref({ // コメントデータ
+    post_id: props.postId, // 投稿ID
+    parent_id: props.parentId, // 親コメントID
+    message: "", // コメントメッセージ
+    replyToName: props.replyToName, // 返信先のユーザー名
 });
 
 // 画像関連のrefを追加
-const img = ref(null);
-const imgPreview = ref(null);
-const fileInput = ref(null);
-const isModalOpen = ref(false);
-const localErrorMessage = ref(null);
+const img = ref(null); // 画像ファイル
+const imgPreview = ref(null); // 画像プレビュー
+const fileInput = ref(null); // ファイル選択ボタン
+const isModalOpen = ref(false); // モーダル表示
+const localErrorMessage = ref(null); // エラーメッセージ
 
+// コンポーネントのマウント時に初期値を設定
 onMounted(() => {
     // コメントに対する返信の場合のみメンションを追加
     if (props.replyToName && props.parentId) {
@@ -75,38 +76,41 @@ const removeImage = () => {
 
 // コメントの送信処理に画像データを追加
 const submitComment = () => {
-    commentData.value._token = getCsrfToken();
-    commentData.value.post_id = props.postId;
+    commentData.value._token = getCsrfToken(); // CSRFトークンを追加
+    commentData.value.post_id = props.postId; // 投稿IDを追加
 
+    // フォームデータを作成
     const formData = new FormData();
-    formData.append("message", commentData.value.message);
-    formData.append("post_id", commentData.value.post_id);
-    formData.append("_token", commentData.value._token);
+    formData.append("message", commentData.value.message); // コメントメッセージを追加
+    formData.append("post_id", commentData.value.post_id); // 投稿IDを追加
+    formData.append("_token", commentData.value._token); // CSRFトークンを追加
 
-    if (img.value) {
-        formData.append("img", img.value);
+    // 画像データが存在する場合はフォームデータに追加
+    if (img.value) { // 画像データが存在する場合
+        formData.append("img", img.value); // 画像データをフォームデータに追加
     }
 
+    // コメントの投稿処理を実行
     router.post(route("comment.store", { post: props.postId }), formData, {
-        preserveScroll: true,
-        onSuccess: () => {
+        preserveScroll: true, // スクロール位置を維持
+        onSuccess: () => { // 投稿成功時の処理
             commentData.value = {
-                post_id: props.postId,
-                parent_id: props.parentId,
-                message: "",
+                post_id: props.postId, // 投稿IDをリセット
+                parent_id: props.parentId, // 親コメントIDをリセット
+                message: "", // コメントメッセージをリセット
             };
-            img.value = null;
-            imgPreview.value = null;
+            img.value = null; // 画像ファイルをリセット
+            imgPreview.value = null; // 画像プレビューをリセット
             router.visit(
-                route("forum.index", { forum_id: props.selectedForumId }),
+                route("forum.index", { forum_id: props.selectedForumId }), // 掲示板にリダイレクト
                 {
-                    preserveScroll: true,
-                    replace: true,
+                    preserveScroll: true, // スクロール位置を維持
+                    replace: true, // ページを置換
                 }
             );
         },
-        onError: (errors) => {
-            console.error("コメントの投稿に失敗しました:", errors);
+        onError: (errors) => { // 投稿失敗時の処理
+            console.error("コメントの投稿に失敗しました:", errors); // エラーメッセージをコンソールに出力
         },
     });
 };
@@ -115,13 +119,13 @@ const submitComment = () => {
 const handleCancel = () => {
     // フォームをリセット
     commentData.value = {
-        post_id: props.postId,
-        parent_id: props.parentId,
-        message: "",
-        replyToName: props.replyToName,
+        post_id: props.postId, // 投稿IDをリセット
+        parent_id: props.parentId, // 親コメントIDをリセット
+        message: "", // コメントメッセージをリセット
+        replyToName: props.replyToName, // 返信先のユーザー名をリセット
     };
     // 親コンポーネントにキャンセルイベントを発行
-    emit("cancel");
+    emit("cancel"); // キャンセルイベントを発行
 };
 </script>
 

--- a/resources/js/Components/CommentForm.vue
+++ b/resources/js/Components/CommentForm.vue
@@ -41,8 +41,8 @@ const commentData = ref({
 });
 
 // 画像関連のrefを追加
-const image = ref(null);
-const imagePreview = ref(null);
+const img = ref(null);
+const imgPreview = ref(null);
 const fileInput = ref(null);
 const isModalOpen = ref(false);
 const localErrorMessage = ref(null);
@@ -56,7 +56,7 @@ onMounted(() => {
 
 // 画像ファイルのチェック
 const onImageChange = (event) => {
-    handleImageChange(event, image, imagePreview, localErrorMessage);
+    handleImageChange(event, img, imgPreview, localErrorMessage);
 };
 
 // ファイル選択ボタンをクリックしたときの処理
@@ -66,8 +66,8 @@ const triggerFileInput = () => {
 
 // 画像を削除する処理
 const removeImage = () => {
-    image.value = null;
-    imagePreview.value = null;
+    img.value = null;
+    imgPreview.value = null;
     if (fileInput.value) {
         fileInput.value.value = "";
     }
@@ -83,8 +83,8 @@ const submitComment = () => {
     formData.append("post_id", commentData.value.post_id);
     formData.append("_token", commentData.value._token);
 
-    if (image.value) {
-        formData.append("image", image.value);
+    if (img.value) {
+        formData.append("img", img.value);
     }
 
     router.post(route("comment.store", { post: props.postId }), formData, {
@@ -95,8 +95,8 @@ const submitComment = () => {
                 parent_id: props.parentId,
                 message: "",
             };
-            image.value = null;
-            imagePreview.value = null;
+            img.value = null;
+            imgPreview.value = null;
             router.visit(
                 route("forum.index", { forum_id: props.selectedForumId }),
                 {
@@ -157,9 +157,9 @@ const handleCancel = () => {
                 {{ localErrorMessage }}
             </div>
             <!-- プレビュー表示 -->
-            <div v-if="imagePreview" class="relative mt-2 inline-block">
+            <div v-if="imgPreview" class="relative mt-2 inline-block">
                 <img
-                    :src="imagePreview"
+                    :src="imgPreview"
                     alt="画像プレビュー"
                     class="w-32 h-32 object-cover rounded-md cursor-pointer hover:opacity-80 transition"
                     @click="isModalOpen = true"
@@ -177,7 +177,7 @@ const handleCancel = () => {
             </div>
             <ImageModal :isOpen="isModalOpen" @close="isModalOpen = false">
                 <img
-                    :src="imagePreview"
+                    :src="imgPreview"
                     class="max-w-full max-h-full rounded-lg"
                 />
             </ImageModal>

--- a/resources/js/Components/CommentForm.vue
+++ b/resources/js/Components/CommentForm.vue
@@ -85,6 +85,11 @@ const submitComment = () => {
     formData.append("post_id", commentData.value.post_id); // 投稿IDを追加
     formData.append("_token", commentData.value._token); // CSRFトークンを追加
 
+    // 親コメントIDが存在する場合はフォームデータに追加
+    if (props.parentId) {
+        formData.append("parent_id", props.parentId); // 親コメントIDを追加
+    }
+
     // 画像データが存在する場合はフォームデータに追加
     if (img.value) { // 画像データが存在する場合
         formData.append("img", img.value); // 画像データをフォームデータに追加

--- a/resources/js/Components/CommentForm.vue
+++ b/resources/js/Components/CommentForm.vue
@@ -148,11 +148,10 @@ const handleCancel = () => {
         <!-- コメントフォーム -->
         <form @submit.prevent="submitComment" enctype="multipart/form-data">
             <div class="relative">
-
                 <!-- コメントメッセージ入力欄 -->
                 <textarea
                     v-model="commentData.message"
-                    class="w-full p-2 border rounded-md"
+                    class="w-full p-2 border border-gray-300 rounded-md"
                     required
                     :placeholder="placeholder"
                     rows="3"

--- a/resources/js/Components/CommentForm.vue
+++ b/resources/js/Components/CommentForm.vue
@@ -7,23 +7,28 @@ import { handleImageChange } from "@/Utils/imageHandler";
 
 // コメントフォームのプロパティを定義
 const props = defineProps({
-    postId: { // 投稿ID
+    postId: {
+        // 投稿ID
         type: Number,
         required: true,
     },
-    parentId: { // 親コメントID
+    parentId: {
+        // 親コメントID
         type: Number,
         default: null,
     },
-    selectedForumId: { // 選択中の掲示版ID
+    selectedForumId: {
+        // 選択中の掲示版ID
         type: Number,
         required: true,
     },
-    replyToName: { // 返信先のユーザー名
+    replyToName: {
+        // 返信先のユーザー名
         type: String,
         default: "",
     },
-    title: { // フォームのタイトル
+    title: {
+        // フォームのタイトル
         type: String,
         default: "返信",
     },
@@ -33,7 +38,8 @@ const emit = defineEmits(["cancel"]); // キャンセルイベントを発行す
 const placeholder = ref(`@${props.replyToName} さんへの返信を入力`); // プレースホルダー
 
 // コメントデータを管理するref
-const commentData = ref({ // コメントデータ
+const commentData = ref({
+    // コメントデータ
     post_id: props.postId, // 投稿ID
     parent_id: props.parentId, // 親コメントID
     message: "", // コメントメッセージ
@@ -91,14 +97,16 @@ const submitComment = () => {
     }
 
     // 画像データが存在する場合はフォームデータに追加
-    if (img.value) { // 画像データが存在する場合
+    if (img.value) {
+        // 画像データが存在する場合
         formData.append("img", img.value); // 画像データをフォームデータに追加
     }
 
     // コメントの投稿処理を実行
     router.post(route("comment.store", { post: props.postId }), formData, {
         preserveScroll: true, // スクロール位置を維持
-        onSuccess: () => { // 投稿成功時の処理
+        onSuccess: () => {
+            // 投稿成功時の処理
             commentData.value = {
                 post_id: props.postId, // 投稿IDをリセット
                 parent_id: props.parentId, // 親コメントIDをリセット
@@ -114,7 +122,8 @@ const submitComment = () => {
                 }
             );
         },
-        onError: (errors) => { // 投稿失敗時の処理
+        onError: (errors) => {
+            // 投稿失敗時の処理
             console.error("コメントの投稿に失敗しました:", errors); // エラーメッセージをコンソールに出力
         },
     });
@@ -136,14 +145,19 @@ const handleCancel = () => {
 
 <template>
     <div class="mt-4">
+        <!-- コメントフォーム -->
         <form @submit.prevent="submitComment" enctype="multipart/form-data">
             <div class="relative">
+
+                <!-- コメントメッセージ入力欄 -->
                 <textarea
                     v-model="commentData.message"
                     class="w-full p-2 border rounded-md"
+                    required
                     :placeholder="placeholder"
                     rows="3"
                 ></textarea>
+
                 <!-- ファイル選択アイコン -->
                 <div
                     class="absolute right-2 bottom-4 bg-gray-300 text-black transition hover:bg-gray-400 hover:text-white rounded-md flex items-center justify-center cursor-pointer"
@@ -154,6 +168,8 @@ const handleCancel = () => {
                     <i class="bi bi-card-image text-2xl"></i>
                 </div>
             </div>
+
+            <!-- 隠しファイル入力 -->
             <input
                 type="file"
                 accept="image/*"
@@ -167,12 +183,14 @@ const handleCancel = () => {
             </div>
             <!-- プレビュー表示 -->
             <div v-if="imgPreview" class="relative mt-2 inline-block">
+                <!-- プレビュー画像 -->
                 <img
                     :src="imgPreview"
                     alt="画像プレビュー"
                     class="w-32 h-32 object-cover rounded-md cursor-pointer hover:opacity-80 transition"
                     @click="isModalOpen = true"
                 />
+                <!-- プレビュー画像削除ボタン -->
                 <div
                     class="absolute top-0 right-0 bg-white rounded-full p-1 cursor-pointer flex items-center justify-center"
                     @click="removeImage"
@@ -184,13 +202,18 @@ const handleCancel = () => {
                     ></i>
                 </div>
             </div>
+
+            <!-- コメント画像モーダル -->
             <ImageModal :isOpen="isModalOpen" @close="isModalOpen = false">
                 <img
                     :src="imgPreview"
                     class="max-w-full max-h-full rounded-lg"
                 />
             </ImageModal>
+
+            <!-- コメントフォームボタン群 -->
             <div class="flex justify-end space-x-2 mt-2">
+                <!-- キャンセルボタン -->
                 <button
                     type="button"
                     @click="handleCancel"
@@ -198,6 +221,8 @@ const handleCancel = () => {
                 >
                     <i class="bi bi-x-lg"></i>
                 </button>
+
+                <!-- コメント送信ボタン -->
                 <button
                     type="submit"
                     class="my-2 px-4 py-2 rounded-md bg-blue-100 text-blue-700 transition hover:bg-blue-300 hover:text-white cursor-pointer"

--- a/resources/js/Components/CommentForm.vue
+++ b/resources/js/Components/CommentForm.vue
@@ -3,6 +3,7 @@ import { ref, onMounted } from "vue";
 import { router } from "@inertiajs/vue3";
 import { getCsrfToken } from "@/Utils/csrf";
 import ImageModal from "./ImageModal.vue";
+import { handleImageChange } from "@/Utils/imageHandler";
 
 const props = defineProps({
     postId: {
@@ -54,26 +55,8 @@ onMounted(() => {
 });
 
 // 画像ファイルのチェック
-const handleImageChange = (e) => {
-    const file = e.target.files[0];
-    if (file) {
-        const validImageTypes = [
-            "image/jpeg",
-            "image/png",
-            "image/gif",
-            "image/webp",
-        ];
-        if (!validImageTypes.includes(file.type)) {
-            localErrorMessage.value =
-                "対応していないファイル形式です。png, jpg, gif, webpのいずれかを選択してください。";
-            setTimeout(() => {
-                localErrorMessage.value = null;
-            }, 8000);
-            return;
-        }
-        image.value = file;
-        imagePreview.value = URL.createObjectURL(file);
-    }
+const onImageChange = (event) => {
+    handleImageChange(event, image, imagePreview, localErrorMessage);
 };
 
 // ファイル選択ボタンをクリックしたときの処理
@@ -166,7 +149,7 @@ const handleCancel = () => {
                 type="file"
                 accept="image/*"
                 ref="fileInput"
-                @change="handleImageChange"
+                @change="onImageChange"
                 style="display: none"
             />
             <!-- エラーメッセージ表示 -->

--- a/resources/js/Components/ParentComment.vue
+++ b/resources/js/Components/ParentComment.vue
@@ -109,6 +109,15 @@ const getCommentCountRecursive = (comments) => {
                 <!-- コメント本文 -->
                 <p class="mt-3 whitespace-pre-wrap">{{ comment.message }}</p>
 
+                <!-- コメント画像 -->
+                <div v-if="comment.img" class="mt-3">
+                    <img
+                        :src="`/storage/${comment.img}`"
+                        alt="添付画像"
+                        class="w-32 h-32 object-cover rounded-md cursor-pointer hover:opacity-80 transition"
+                    />
+                </div>
+
                 <!-- 子コメント -->
                 <div
                     v-if="comment.children && comment.children.length > 0"

--- a/resources/js/Components/ParentComment.vue
+++ b/resources/js/Components/ParentComment.vue
@@ -3,6 +3,7 @@ import { ref, onMounted } from "vue";
 import ChildComment from "./ChildComment.vue";
 import CommentForm from "./CommentForm.vue"; // CommentFormをインポート
 import LikeButton from "./LikeButton.vue";
+import ImageModal from "./ImageModal.vue";
 
 const props = defineProps({
     comments: Array, // 親コメントからのコメントデータ
@@ -18,6 +19,15 @@ const props = defineProps({
 
 // 子コメントの折りたたみ状態を管理
 const collapsedComments = ref({});
+
+// コメント画像モーダルの表示状態を管理
+const isModalOpen = ref(false);
+const currentImage = ref(null);
+
+const openModal = (imagePath) => {
+    currentImage.value = imagePath;
+    isModalOpen.value = true;
+};
 
 // コンポーネントのマウント時に初期値を設定
 onMounted(() => {
@@ -115,6 +125,7 @@ const getCommentCountRecursive = (comments) => {
                         :src="`/storage/${comment.img}`"
                         alt="添付画像"
                         class="w-32 h-32 object-cover rounded-md cursor-pointer hover:opacity-80 transition"
+                        @click="openModal(`/storage/${comment.img}`)"
                     />
                 </div>
 
@@ -209,4 +220,12 @@ const getCommentCountRecursive = (comments) => {
             </div>
         </div>
     </div>
+
+    <ImageModal :isOpen="isModalOpen" @close="isModalOpen = false">
+        <img
+            :src="currentImage"
+            alt="投稿画像"
+            class="max-w-full max-h-full rounded-lg"
+        />
+    </ImageModal>
 </template>

--- a/resources/js/Components/PostForm.vue
+++ b/resources/js/Components/PostForm.vue
@@ -3,6 +3,7 @@ import { ref, watch } from "vue";
 import { router } from "@inertiajs/vue3";
 import { getCsrfToken } from "@/Utils/csrf";
 import ImageModal from "./ImageModal.vue"; // ImageModalコンポーネントをインポート
+import { handleImageChange } from "@/Utils/imageHandler";
 
 const props = defineProps({
     forumId: [String, Number], // String または Number 型を許容
@@ -29,31 +30,8 @@ watch(
 );
 
 // 画像ファイルのチェック
-const handleImageChange = (e) => {
-    const file = e.target.files[0];
-    if (file) {
-        // 画像形式のチェック（jpeg, png, gif などのみ許可）
-        const validImageTypes = [
-            "image/jpeg",
-            "image/png",
-            "image/gif",
-            "image/webp",
-        ];
-        if (!validImageTypes.includes(file.type)) {
-            localErrorMessage.value =
-                "対応していないファイル形式です。png, jpg, gif, webpのいずれかを選択してください。";
-
-            // 8秒後にエラーメッセージを自動的に消す処理
-            setTimeout(() => {
-                localErrorMessage.value = null;
-            }, 8000);
-
-            return;
-        }
-
-        image.value = file; // 画像ファイルを設定
-        imagePreview.value = URL.createObjectURL(file); // ローカルプレビュー用にBlob URLをセット
-    }
+const onImageChange = (e) => {
+    handleImageChange(e, image, imagePreview, localErrorMessage);
 };
 
 // ファイル選択ボタンをクリックしたときの処理
@@ -156,7 +134,7 @@ const submitPost = () => {
                     type="file"
                     accept="image/*"
                     ref="fileInput"
-                    @change="handleImageChange"
+                    @change="onImageChange"
                     style="display: none"
                 />
             </div>

--- a/resources/js/Pages/Profile/Partials/IconEditForm.vue
+++ b/resources/js/Pages/Profile/Partials/IconEditForm.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { useForm, usePage } from "@inertiajs/vue3";
 import { ref } from "vue";
+import { handleImageChange } from "@/Utils/imageHandler";
 
 const props = defineProps({
     user: Object,
@@ -13,6 +14,10 @@ const form = useForm({
     icon: null, // アイコンを追加
 });
 
+// 画像プレビュー用の `ref` を定義
+const image = ref(null);
+const imagePreview = ref(null);
+
 // アイコンのプレビューURLを定義
 const previewUrl = ref(
     props.user.icon &&
@@ -24,39 +29,18 @@ const previewUrl = ref(
         : "/images/default_user_icon.png"
 );
 
-// ローカルプレビュー用の一時的なBlob URLかどうかを識別するフラグ
-const isLocalPreview = ref(false);
-
 // 成功メッセージとエラーメッセージのrefを定義
 const localSuccessMessage = ref(null); // 初期値をnullに設定
 const localErrorMessage = ref(null); // 初期値をnullに設定
 
 // 画像ファイルのチェック
-const handleImageChange = (e) => {
-    const file = e.target.files[0];
-    if (file) {
-        // 画像形式のチェック（jpeg, png, gif などのみ許可）
-        const validImageTypes = [
-            "image/jpeg",
-            "image/png",
-            "image/gif",
-            "image/webp",
-        ];
-        if (!validImageTypes.includes(file.type)) {
-            localErrorMessage.value =
-                "対応していないファイル形式です。png, jpg, gif, webpのいずれかを選択してください。";
+const onImageChange = (e) => {
+    handleImageChange(e, image, imagePreview, localErrorMessage);
 
-            // 8秒後にエラーメッセージを自動的に消す処理
-            setTimeout(() => {
-                localErrorMessage.value = null;
-            }, 8000);
-
-            return;
-        }
-
-        form.icon = file;
-        previewUrl.value = URL.createObjectURL(file); // ローカルプレビュー用にBlob URLをセット
-        isLocalPreview.value = true; // ローカルプレビュー用のフラグを立てる
+    // プレビューURLを更新する
+    if (image.value) {
+        form.icon = image.value;
+        previewUrl.value = imagePreview.value;
     }
 };
 
@@ -146,7 +130,7 @@ const submit = () => {
                     <input
                         type="file"
                         id="icon"
-                        @change="handleImageChange"
+                        @change="onImageChange"
                         class="w-full border border-gray-300 p-2 rounded"
                     />
                 </div>

--- a/resources/js/Utils/imageHandler.js
+++ b/resources/js/Utils/imageHandler.js
@@ -1,0 +1,17 @@
+export const handleImageChange = (event, imageRef, imagePreviewRef, errorMessageRef) => {
+    const file = event.target.files[0];
+    if (!file) return;
+
+    const validImageTypes = ["image/jpeg", "image/png", "image/gif", "image/webp"];
+
+    if (!validImageTypes.includes(file.type)) {
+        errorMessageRef.value = "対応していないファイル形式です。png, jpg, gif, webpのいずれかを選択してください。";
+        setTimeout(() => {
+            errorMessageRef.value = null;
+        }, 8000);
+        return;
+    }
+
+    imageRef.value = file;
+    imagePreviewRef.value = URL.createObjectURL(file);
+};


### PR DESCRIPTION
## **目的**

- **コメント投稿時に画像を添付できるようにし、ユーザー体験を向上させる**
- **親コメントの紐付けが正しく行われるよう修正し、スレッド構造を適切に維持する**
- **子コメントの画像表示・拡大機能を追加し、視認性を向上させる**
- **画像のアップロード容量制限を緩和し、大きな画像の投稿を可能にする**
- **画像処理のロジックを共通化し、メンテナンス性を向上させる**
- **Ziggy のパス設定を修正し、新しいディレクトリ構成に対応する**

***

## **達成条件**

- **コメント投稿時に画像を添付できるようにする**
- **画像のプレビュー表示および削除機能を追加する**
- **親コメントの紐付けを修正し、子コメントが親コメントの下に表示されるようにする**
- **子コメントの画像を表示し、クリックで拡大できるようにする**
- **投稿およびコメントの画像サイズ上限を 2MB から 10MB に拡大する**
- **画像選択処理を `handleImageChange` に統一し、再利用可能な形にする**
- **コメント作成処理を `Comment::create()` に統一し、保守性を向上させる**
- **Ziggy のパス設定を修正し、新しいディレクトリ構成に対応する**

***

## **実装の概要**

### **1. コメント投稿時の画像添付機能を追加**

- `CommentForm.vue` に画像選択、プレビュー、削除機能を追加
- 画像データを `FormData` に含めて送信するよう変更
- `ImageModal.vue` を利用して画像を拡大表示できるようにした

### **2. 親コメントの紐付けが正しく行われない不具合を修正**

- `props.parentId` が正しく送信されず、子コメントが独立した投稿として処理される問題を修正
- これにより、子コメントが親コメントの下に適切に表示されるようになった

### **3. 子コメントに添付画像の表示・モーダル拡大機能を追加**

- `ChildComment.vue` に画像表示処理を追加し、添付された画像を適切に表示
- 画像をクリックすると `ImageModal` で拡大表示できるようにした

### **4. 画像アップロード容量制限の緩和**

- 投稿およびコメントの画像サイズ上限を 2MB から 10MB に拡大
- これにより、連続した画像投稿時のエラー発生頻度を軽減し、大きな画像のアップロードが可能になった

### **5. 画像選択処理をユーティリティ関数として共通化**

- `resources/js/Utils/imageHandler.js` に `handleImageChange` を追加
- `CommentForm.vue` の画像バリデーション処理を `handleImageChange` に統一
- `PostForm.vue` でも `handleImageChange` を利用し、コードの重複を削減

### **6. コメントの作成処理を `Comment::create()` に統一**

- `CommentController@store` において、`new Comment()` を使用して個別にプロパティを設定し保存する方法から、`Comment::create()` を用いた一括保存に変更。
- これにより、コードの簡潔化、可読性の向上、および `fillable` を活用したセキュリティの強化を実現し、コードの一貫性と保守性を向上させた


### **7. Ziggy のパス設定を修正**

- 新しいディレクトリ構成に適応するため、Ziggy のパス設定を修正

***

## **レビューしてほしいところ**

- **親コメントと子コメントの紐付けが正しく動作するか**
- **子コメントの画像表示・拡大機能が期待通り動作するか**
- **画像選択・プレビュー・削除の流れが適切に実装されているか**
- **コメントデータの `img` が正しく格納・取得・表示されるか**
- **ユーティリティ関数 `handleImageChange` の処理が適切か**
- **コードの統一性や可読性に問題がないか**
- **Ziggy のパス設定の修正が他の機能に影響を与えていないか**

***

## **不安に思っていること**

- **`Comment::create()` に統一した影響で、想定外の挙動が発生しないか**
- **画像アップロード時のエラーハンドリングが適切か**
- **投稿とコメントで異なるバリデーション要件が必要になった場合の影響範囲**
- **画像のサイズ制限を増やしたことで、ストレージへの影響がどの程度あるか**

***

## **保留していること**

- **投稿ごととコメントごとの画像容量制限の分離（現在は容量制限を緩和して対応）**
- **画像のリサイズ処理の導入（現在はフロントエンドではリサイズせず、そのまま送信）**