### PR TITLE
引用投稿の画像添付機能の追加と送信処理の統一

### DIFF
--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -22,8 +22,8 @@ class CommentController extends Controller
 
         // 画像がアップロードされた場合は保存
         $imgPath = null;
-        if ($request->hasFile('img')) {
-            $imgPath = $request->file('img')->store('images', 'public');
+        if ($request->hasFile('image')) {
+            $imgPath = $request->file('image')->store('images', 'public');
         }
 
         $post = Post::find($validated['post_id']); // 投稿を取得

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -12,6 +12,7 @@ class PostController extends Controller
 
     public function store(Request $request)
     {
+        // バリデーション
         $validated = $request->validate([
             'title' => $request->input('quoted_post_id') ? 'nullable|string|max:255' : 'required|string|max:255',
             'message' => 'required|string',
@@ -20,11 +21,13 @@ class PostController extends Controller
             'img' => 'nullable|image|mimes:jpeg,png,jpg,gif|max:10240',
         ]);
 
+        // 画像パスを取得
         $imgPath = null;
         if ($request->hasFile('image')) {
             $imgPath = $request->file('image')->store('images', 'public');
         }
 
+        // 投稿を作成
         $post = Post::create([
             'user_id' => auth()->id(),
             'title' => $validated['title'],
@@ -34,14 +37,8 @@ class PostController extends Controller
             'img' => $imgPath
         ]);
 
-        // 引用投稿の場合は Inertia::location、通常投稿の場合はリダイレクト
-        if ($request->has('quoted_post_id')) {
-            // Inertia::locationでリロードしつつ、フォーラムページへ
-            return Inertia::location(route('forum.index', ['forum_id' => $validated['forum_id']]));
-        } else {
-            // 通常投稿はリダイレクトでフォーラムページへ
-            return redirect()->route('forum.index');
-        }
+        // 掲示板ページにリダイレクト
+        return redirect()->route('forum.index');
     }
 
     public function destroy($id)

--- a/resources/js/Components/CommentForm.vue
+++ b/resources/js/Components/CommentForm.vue
@@ -47,8 +47,8 @@ const commentData = ref({
 });
 
 // 画像関連のrefを追加
-const img = ref(null); // 画像ファイル
-const imgPreview = ref(null); // 画像プレビュー
+const image = ref(null); // 画像ファイル
+const imagePreview = ref(null); // 画像プレビュー
 const fileInput = ref(null); // ファイル選択ボタン
 const isModalOpen = ref(false); // モーダル表示
 const localErrorMessage = ref(null); // エラーメッセージ
@@ -63,7 +63,7 @@ onMounted(() => {
 
 // 画像ファイルのチェック
 const onImageChange = (event) => {
-    handleImageChange(event, img, imgPreview, localErrorMessage);
+    handleImageChange(event, image, imagePreview, localErrorMessage);
 };
 
 // ファイル選択ボタンをクリックしたときの処理
@@ -73,8 +73,8 @@ const triggerFileInput = () => {
 
 // 画像を削除する処理
 const removeImage = () => {
-    img.value = null;
-    imgPreview.value = null;
+    image.value = null;
+    imagePreview.value = null;
     if (fileInput.value) {
         fileInput.value.value = "";
     }
@@ -97,9 +97,9 @@ const submitComment = () => {
     }
 
     // 画像データが存在する場合はフォームデータに追加
-    if (img.value) {
+    if (image.value) {
         // 画像データが存在する場合
-        formData.append("img", img.value); // 画像データをフォームデータに追加
+        formData.append("image", image.value); // 画像データをフォームデータに追加
     }
 
     // コメントの投稿処理を実行
@@ -112,8 +112,8 @@ const submitComment = () => {
                 parent_id: props.parentId, // 親コメントIDをリセット
                 message: "", // コメントメッセージをリセット
             };
-            img.value = null; // 画像ファイルをリセット
-            imgPreview.value = null; // 画像プレビューをリセット
+            image.value = null; // 画像ファイルをリセット
+            imagePreview.value = null; // 画像プレビューをリセット
             router.visit(
                 route("forum.index", { forum_id: props.selectedForumId }), // 掲示板にリダイレクト
                 {
@@ -181,10 +181,10 @@ const handleCancel = () => {
                 {{ localErrorMessage }}
             </div>
             <!-- プレビュー表示 -->
-            <div v-if="imgPreview" class="relative mt-2 inline-block">
+            <div v-if="imagePreview" class="relative mt-2 inline-block">
                 <!-- プレビュー画像 -->
                 <img
-                    :src="imgPreview"
+                    :src="imagePreview"
                     alt="画像プレビュー"
                     class="w-32 h-32 object-cover rounded-md cursor-pointer hover:opacity-80 transition"
                     @click="isModalOpen = true"
@@ -205,7 +205,7 @@ const handleCancel = () => {
             <!-- コメント画像モーダル -->
             <ImageModal :isOpen="isModalOpen" @close="isModalOpen = false">
                 <img
-                    :src="imgPreview"
+                    :src="imagePreview"
                     class="max-w-full max-h-full rounded-lg"
                 />
             </ImageModal>

--- a/resources/js/Components/QuotePostForm.vue
+++ b/resources/js/Components/QuotePostForm.vue
@@ -4,24 +4,29 @@ import { router } from "@inertiajs/vue3";
 import { handleImageChange } from "@/Utils/imageHandler";
 import ImageModal from "./ImageModal.vue";
 
+// 引用付き投稿フォームのprops
 const props = defineProps({
-    show: Boolean,
-    quotedPost: Object,
-    forumId: Number,
+    show: Boolean, // フォームの表示
+    quotedPost: Object, // 引用元の投稿
+    forumId: Number, // 論壇ID
 });
 
-const emit = defineEmits(["close"]);
+// 引用付き投稿フォームのemit
+const emit = defineEmits(["close"]); // フォームを閉じる
 
-const newPostContent = ref("");
-const newPostTitle = ref("");
+// 新しい投稿の内容
+const newPostContent = ref(""); // 投稿の内容
+const newPostTitle = ref(""); // 投稿のタイトル
 
-const img = ref(null);
-const imgPreview = ref(null);
-const isModalOpen = ref(false);
-const fileInput = ref(null);
+// 画像関連のref
+const img = ref(null); // 画像ファイル
+const imgPreview = ref(null); // 画像プレビュー
+const isModalOpen = ref(false); // モーダル表示
+const fileInput = ref(null); // ファイル選択ボタン
 
-const localErrorMessage = ref(null);
+const localErrorMessage = ref(null); // エラーメッセージ
 
+// 画像変更時の処理
 const onImageChange = (event) => {
     handleImageChange(event, img, imgPreview, localErrorMessage);
 };
@@ -33,27 +38,28 @@ const triggerFileInput = () => {
 
 // 画像を削除する
 const removeImage = () => {
-    img.value = null;
-    imgPreview.value = null;
-    localErrorMessage.value = null;
+    img.value = null; // 画像を削除
+    imgPreview.value = null; // 画像プレビューを削除
+    localErrorMessage.value = null; // エラーメッセージを削除
 };
 
 // キャンセルボタン
 const cancel = () => {
-    emit("close");
+    emit("close"); // フォームを閉じる
 };
 
 // 引用付き投稿を送信
 const submitQuotePost = () => {
     router.post(route("forum.store"), {
         title: newPostTitle.value || null, // 投稿のタイトルを追加
-        message: newPostContent.value,
+        message: newPostContent.value, // 投稿の内容を追加
         forum_id: props.forumId, // Forum IDを追加
-        quoted_post_id: props.quotedPost.id,
+        quoted_post_id: props.quotedPost.id, // 引用元の投稿IDを追加
     });
 
+    // 画像が存在する場合はフォームデータに追加
     if (img.value) {
-        formData.append("img", img.value);
+        formData.append("img", img.value); // 画像を追加
     }
 
     emit("close"); // フォームを閉じる

--- a/resources/js/Components/QuotePostForm.vue
+++ b/resources/js/Components/QuotePostForm.vue
@@ -1,6 +1,8 @@
 <script setup>
 import { ref } from "vue";
 import { router } from "@inertiajs/vue3";
+import { handleImageChange } from "@/Utils/imageHandler";
+import ImageModal from "./ImageModal.vue";
 
 const props = defineProps({
     show: Boolean,
@@ -12,6 +14,29 @@ const emit = defineEmits(["close"]);
 
 const newPostContent = ref("");
 const newPostTitle = ref("");
+
+const img = ref(null);
+const imgPreview = ref(null);
+const isModalOpen = ref(false);
+const fileInput = ref(null);
+
+const localErrorMessage = ref(null);
+
+const onImageChange = (event) => {
+    handleImageChange(event, img, imgPreview, localErrorMessage);
+};
+
+// ファイル選択ボタンをクリックしたときの処理
+const triggerFileInput = () => {
+    fileInput.value.click();
+};
+
+// 画像を削除する
+const removeImage = () => {
+    img.value = null;
+    imgPreview.value = null;
+    localErrorMessage.value = null;
+};
 
 // キャンセルボタン
 const cancel = () => {
@@ -31,6 +56,10 @@ const submitQuotePost = () => {
     console.log("props.forumId:", props.forumId);
     console.log("newPostTitle.value:", newPostTitle.value);
     console.log("newPostContent.value:", newPostContent.value);
+
+    if (img.value) {
+        formData.append("img", img.value);
+    }
 
     emit("close"); // フォームを閉じる
 };
@@ -52,12 +81,57 @@ const submitQuotePost = () => {
             </div>
 
             <!-- 新しい投稿の入力フォーム -->
-            <textarea
-                v-model="newPostContent"
-                class="w-full border rounded p-2 mb-4"
-                placeholder="投稿文を入力してください"
-                rows="4"
-            ></textarea>
+            <div class="relative">
+                <textarea
+                    v-model="newPostContent"
+                    class="w-full border rounded p-2 mb-4"
+                    placeholder="投稿文を入力してください"
+                    rows="4"
+                ></textarea>
+                <!-- ファイル選択アイコン -->
+                <div
+                    class="absolute right-2 bottom-8 bg-gray-300 text-black transition hover:bg-gray-400 hover:text-white rounded-md flex items-center justify-center cursor-pointer"
+                    style="width: 40px; height: 40px"
+                    @click="triggerFileInput"
+                    title="ファイルを選択"
+                >
+                    <i class="bi bi-card-image text-2xl"></i>
+                </div>
+            </div>
+
+            <!-- 隠しファイル入力 -->
+            <input
+                type="file"
+                accept="image/*"
+                ref="fileInput"
+                @change="onImageChange"
+                style="display: none"
+            />
+            <!-- エラーメッセージ表示 -->
+            <div v-if="localErrorMessage" class="text-red-500 mt-2">
+                {{ localErrorMessage }}
+            </div>
+            <!-- プレビュー表示 -->
+            <div v-if="imgPreview" class="relative mt-2 inline-block">
+                <!-- プレビュー画像 -->
+                <img
+                    :src="imgPreview"
+                    alt="画像プレビュー"
+                    class="w-32 h-32 object-cover rounded-md cursor-pointer hover:opacity-80 transition"
+                    @click="isModalOpen = true"
+                />
+                <!-- プレビュー画像削除ボタン -->
+                <div
+                    class="absolute top-0 right-0 bg-white rounded-full p-1 cursor-pointer flex items-center justify-center"
+                    @click="removeImage"
+                    title="画像を削除"
+                    style="width: 24px; height: 24px"
+                >
+                    <i
+                        class="bi bi-x-circle text-black hover:text-gray-500"
+                    ></i>
+                </div>
+            </div>
 
             <!-- 送信ボタン -->
             <div class="flex justify-end space-x-2">
@@ -75,6 +149,15 @@ const submitQuotePost = () => {
                 </button>
             </div>
         </div>
+
+        <!-- コメント画像モーダル -->
+        <ImageModal :isOpen="isModalOpen" @close="isModalOpen = false">
+            <img
+                :src="imgPreview"
+                alt="投稿画像"
+                class="max-w-full max-h-full rounded-lg"
+            />
+        </ImageModal>
     </div>
 </template>
 

--- a/resources/js/Components/QuotePostForm.vue
+++ b/resources/js/Components/QuotePostForm.vue
@@ -41,6 +41,9 @@ const removeImage = () => {
     img.value = null; // 画像を削除
     imgPreview.value = null; // 画像プレビューを削除
     localErrorMessage.value = null; // エラーメッセージを削除
+    if (fileInput.value) {
+        fileInput.value.value = ""; // ファイル入力の値をリセット
+    }
 };
 
 // キャンセルボタン

--- a/resources/js/Components/QuotePostForm.vue
+++ b/resources/js/Components/QuotePostForm.vue
@@ -52,11 +52,6 @@ const submitQuotePost = () => {
         quoted_post_id: props.quotedPost.id,
     });
 
-    console.log("props.quotedPost.id:", props.quotedPost.id);
-    console.log("props.forumId:", props.forumId);
-    console.log("newPostTitle.value:", newPostTitle.value);
-    console.log("newPostContent.value:", newPostContent.value);
-
     if (img.value) {
         formData.append("img", img.value);
     }

--- a/resources/js/Components/QuotePostForm.vue
+++ b/resources/js/Components/QuotePostForm.vue
@@ -19,8 +19,8 @@ const newPostContent = ref(""); // 投稿の内容
 const newPostTitle = ref(""); // 投稿のタイトル
 
 // 画像関連のref
-const img = ref(null); // 画像ファイル
-const imgPreview = ref(null); // 画像プレビュー
+const image = ref(null); // 画像ファイル
+const imagePreview = ref(null); // 画像プレビュー
 const isModalOpen = ref(false); // モーダル表示
 const fileInput = ref(null); // ファイル選択ボタン
 
@@ -39,7 +39,7 @@ function getCsrfToken() {
 
 // 画像変更時の処理
 const onImageChange = (event) => {
-    handleImageChange(event, img, imgPreview, localErrorMessage);
+    handleImageChange(event, image, imagePreview, localErrorMessage);
 };
 
 // ファイル選択ボタンをクリックしたときの処理
@@ -49,8 +49,8 @@ const triggerFileInput = () => {
 
 // 画像を削除する
 const removeImage = () => {
-    img.value = null; // 画像を削除
-    imgPreview.value = null; // 画像プレビューを削除
+    image.value = null; // 画像を削除
+    imagePreview.value = null; // 画像プレビューを削除
     localErrorMessage.value = null; // エラーメッセージを削除
     if (fileInput.value) {
         fileInput.value.value = ""; // ファイル入力の値をリセット
@@ -79,8 +79,8 @@ const submitQuotePost = () => {
     formData.append("_token", getCsrfToken()); // CSRFトークンを追加
 
     // 画像データが存在する場合、フォームデータに追加
-    if (img.value) {
-        formData.append("img", img.value);
+    if (image.value) {
+        formData.append("image", image.value);
     }
 
     // 投稿の送信
@@ -89,8 +89,8 @@ const submitQuotePost = () => {
             // 投稿成功後の処理
             newPostTitle.value = ""; // タイトルをリセット
             newPostContent.value = ""; // 投稿内容をリセット
-            img.value = null; // 画像をリセット
-            imgPreview.value = null; // 画像プレビューをリセット
+            image.value = null; // 画像をリセット
+            imagePreview.value = null; // 画像プレビューをリセット
             // 掲示板ページにリダイレクト
             router.get(route("forum.index", { forum_id: props.forumId }), {
                 preserveState: true, // ページの状態を保存
@@ -151,10 +151,10 @@ const submitQuotePost = () => {
                 {{ localErrorMessage }}
             </div>
             <!-- プレビュー表示 -->
-            <div v-if="imgPreview" class="relative mt-2 inline-block">
+            <div v-if="imagePreview" class="relative mt-2 inline-block">
                 <!-- プレビュー画像 -->
                 <img
-                    :src="imgPreview"
+                    :src="imagePreview"
                     alt="画像プレビュー"
                     class="w-32 h-32 object-cover rounded-md cursor-pointer hover:opacity-80 transition"
                     @click="isModalOpen = true"
@@ -192,7 +192,7 @@ const submitQuotePost = () => {
         <!-- 引用投稿の画像モーダル -->
         <ImageModal :isOpen="isModalOpen" @close="isModalOpen = false">
             <img
-                :src="imgPreview"
+                :src="imagePreview"
                 alt="投稿画像"
                 class="max-w-full max-h-full rounded-lg"
             />


### PR DESCRIPTION
## **目的**

- **引用投稿で画像を添付できるようにする**
  - 画像のアップロード、プレビュー、削除機能を実装し、投稿の表現力を向上。
- **フロントエンドとバックエンドのデータ構造を統一し、処理を整理する**
  - 画像データのキー名を `img` から `image` に統一し、送受信の整合性を確保。
- **リダイレクト処理を統一し、投稿後の挙動を統一する**
  - 投稿・引用投稿・コメント投稿の送信フローを改善し、一貫したユーザー体験を提供。

***

## **達成条件**

- **引用投稿で画像を添付できること**
  - 画像選択・プレビュー・削除が正しく動作すること。
- **画像データが適切に渡ること**
  - フロントエンドとバックエンドで `image` を共通のキーとして使用し、正常に処理されること。
- **投稿後のリダイレクト処理が統一されること**
  - 投稿後の画面遷移が一貫して動作し、不要なリロードが発生しないこと。

***

## **実装の概要**

### **1. 引用投稿の画像添付機能を追加**

- ファイル選択、プレビュー、削除機能を実装。
- `handleImageChange` を利用して画像の変更を処理。
- 画像モーダル機能を組み込み、大きい画像のプレビューを可能に。

### **2. 画像データのキー名を統一**

- フロントエンド (`Vue`) とバックエンド (`Laravel`) で使用するキーを `img` から `image` に統一。
- これにより、データの送受信における不整合を解消。

### **3. 送信処理とリダイレクト処理の統一**

- フォームデータ (`FormData`) を使用して画像を送信する形に統一。
- 投稿・引用投稿・コメント投稿で、共通のリダイレクト処理を適用し、不必要な `Inertia::location` を削除。

***

## **レビューしてほしいところ**

- **画像の添付機能**
  - 引用投稿において、画像選択・プレビュー・削除が正常に動作するか？

- **送信処理・リダイレクト処理の統一**

  - 投稿後の画面遷移が一貫した動作になっているか？
  - 不要なリロードが発生していないか？

- **コードの一貫性**
  - 変数名・データ構造の統一で可読性が向上しているか？

***

## **不安に思っていること**

- 画像の添付処理で想定外の動作が発生していないか？
- `FormData` の扱いに問題がないか？（特にモバイル環境での挙動）
- 既存の投稿機能と競合していないか？

***

## **保留していること**

- **画像の圧縮処理**
  - 現在、アップロードされた画像はそのまま送信されており、ファイルサイズの最適化を検討中。
- **画像のバリデーション強化**
  - `max:2048` の制限が適切かどうか要検討。