### PR TITLE
投稿・コメント内のURL自動リンク化、および表示・スタイル改善

### DIFF
--- a/app/Http/Controllers/ForumController.php
+++ b/app/Http/Controllers/ForumController.php
@@ -71,6 +71,7 @@ class ForumController extends Controller
                 'id' => $post->id,
                 'title' => $post->title,
                 'message' => $post->message,
+                'formatted_message' => $post->formatted_message,
                 'img' => $post->img,
                 'created_at' => $post->created_at,
                 'user' => $post->user,
@@ -81,6 +82,7 @@ class ForumController extends Controller
                 'quoted_post' => $post->quotedPost ? [
                     'id' => $post->quotedPost->id,
                     'message' => $post->quotedPost->trashed() ? null : $post->quotedPost->message,
+                    'formatted_message' => $post->quotedPost->trashed() ? null : $post->quotedPost->formatted_message,
                     'title' => $post->quotedPost->trashed() ? null : $post->quotedPost->title,
                     'user' => $post->quotedPost->trashed() ? null : $post->quotedPost->user,
                 ] : null,
@@ -88,6 +90,7 @@ class ForumController extends Controller
                     return [
                         'id' => $comment->id,
                         'message' => $comment->message,
+                        'formatted_message' => $comment->formatted_message,
                         'img' => $comment->img,
                         'created_at' => $comment->created_at,
                         'user' => $comment->user,

--- a/app/Http/Controllers/ForumController.php
+++ b/app/Http/Controllers/ForumController.php
@@ -71,7 +71,7 @@ class ForumController extends Controller
                 'id' => $post->id,
                 'title' => $post->title,
                 'message' => $post->message,
-                'formatted_message' => $post->formatted_message,
+                'formatted_message' => $post->formatted_message, //ここでモデルで定義したアクセサを適用
                 'img' => $post->img,
                 'created_at' => $post->created_at,
                 'user' => $post->user,
@@ -82,7 +82,7 @@ class ForumController extends Controller
                 'quoted_post' => $post->quotedPost ? [
                     'id' => $post->quotedPost->id,
                     'message' => $post->quotedPost->trashed() ? null : $post->quotedPost->message,
-                    'formatted_message' => $post->quotedPost->trashed() ? null : $post->quotedPost->formatted_message,
+                    'formatted_message' => $post->quotedPost->trashed() ? null : $post->quotedPost->formatted_message, //ここでモデルで定義したアクセサを適用
                     'title' => $post->quotedPost->trashed() ? null : $post->quotedPost->title,
                     'user' => $post->quotedPost->trashed() ? null : $post->quotedPost->user,
                 ] : null,
@@ -90,7 +90,7 @@ class ForumController extends Controller
                     return [
                         'id' => $comment->id,
                         'message' => $comment->message,
-                        'formatted_message' => $comment->formatted_message,
+                        'formatted_message' => $comment->formatted_message, //ここでモデルで定義したアクセサを適用
                         'img' => $comment->img,
                         'created_at' => $comment->created_at,
                         'user' => $comment->user,

--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -42,5 +42,14 @@ class Comment extends Model
     {
         return $this->belongsTo(Forum::class);
     }
+
+    public function getFormattedMessageAttribute()
+    {
+        return nl2br(preg_replace(
+            '/(https?:\/\/[^\s]+)/',
+            '<a href="$1" target="_blank" rel="noopener noreferrer">$1</a>',
+            e($this->message)
+        ));
+    }
 }
 

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -38,5 +38,15 @@ class Post extends Model
     {
         return $this->belongsTo(Post::class, 'quoted_post_id')->withTrashed();
     }
+
+    public function getFormattedMessageAttribute()
+{
+    return nl2br(preg_replace(
+        '/(https?:\/\/[^\s]+)/',
+        '<a href="$1" target="_blank" rel="noopener noreferrer">$1</a>',
+        e($this->message)
+    ));
+}
+
 }
 

--- a/resources/js/Components/ChildComment.vue
+++ b/resources/js/Components/ChildComment.vue
@@ -67,7 +67,8 @@ const openModal = (imagePath) => {
                 </div>
 
                 <!-- コメント本文 -->
-                <p class="mt-2 whitespace-pre-wrap">{{ comment.message }}</p>
+                <p class="mt-2 mb-2 whitespace-pre-wrap"
+                v-html="comment.formatted_message"></p>
 
                 <!-- コメント画像 -->
                 <div v-if="comment.img" class="mt-3">

--- a/resources/js/Components/ParentComment.vue
+++ b/resources/js/Components/ParentComment.vue
@@ -118,7 +118,7 @@ const getCommentCountRecursive = (comments) => {
 
                 <!-- コメント本文 -->
                 <p
-                    class="mt-3 whitespace-pre-wrap"
+                    class="mt-3 mb-2 whitespace-pre-wrap"
                     v-html="comment.formatted_message"
                 ></p>
 

--- a/resources/js/Components/ParentComment.vue
+++ b/resources/js/Components/ParentComment.vue
@@ -117,7 +117,10 @@ const getCommentCountRecursive = (comments) => {
                 </div>
 
                 <!-- コメント本文 -->
-                <p class="mt-3 whitespace-pre-wrap">{{ comment.message }}</p>
+                <p
+                    class="mt-3 whitespace-pre-wrap"
+                    v-html="comment.formatted_message"
+                ></p>
 
                 <!-- コメント画像 -->
                 <div v-if="comment.img" class="mt-3">

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -712,4 +712,15 @@ const openModal = (imageSrc) => {
         width: 50% !important;
     }
 }
+
+p.mb-2 a {
+    color: blue;
+    text-decoration: underline;
+    cursor: pointer;
+}
+
+p.mb-2 a:hover {
+    opacity: 0.7;
+}
+
 </style>

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -473,9 +473,10 @@ const openModal = (imageSrc) => {
                             <span v-else>＠Unknown</span>
                         </p>
                         <p class="mb-2 text-xl font-bold">{{ post.title }}</p>
-                        <p class="mb-2 whitespace-pre-wrap">
-                            {{ post.message }}
-                        </p>
+                        <p
+                            class="mb-2 whitespace-pre-wrap"
+                            v-html="post.formatted_message"
+                        ></p>
 
                         <!-- 投稿画像の表示 -->
                         <div v-if="post.img">

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -472,7 +472,11 @@ const openModal = (imageSrc) => {
                             </span>
                             <span v-else>＠Unknown</span>
                         </p>
+
+                        <!-- 投稿タイトルの表示 -->
                         <p class="mb-2 text-xl font-bold">{{ post.title }}</p>
+
+                        <!-- 投稿メッセージの表示 -->
                         <p
                             class="mb-2 whitespace-pre-wrap"
                             v-html="post.formatted_message"


### PR DESCRIPTION
## 目的

投稿やコメントのメッセージ内のURLを自動でリンク化し、ユーザーがよりスムーズにアクセスできるようにする。  
また、リンクの視認性向上やコードの可読性改善を行い、メンテナンス性を高める。

## 達成条件

- 投稿・引用投稿・コメント内のURLが自動でリンク化される
- `formatted_message` を利用し、リンク化したメッセージをフロントエンドに渡せるようにする
- `post.message` の表示を `v-html="post.formatted_message"` に変更し、URLをクリック可能にする
- フォーラムページのリンクの視認性を向上させる（青色＋下線追加、ホバー時の透明度変更）
- コメントデータのフォーマット処理を `formatComment()` に分離し、可読性と再利用性を向上させる

## 実装の概要

- **URLの自動リンク化:**

  - 投稿メッセージ内のURLを自動でリンク化するため、アクセサ `getFormattedMessageAttribute()` を追加
  - 投稿・引用投稿・コメントに `formatted_message` を追加し、リンク化した状態でフロントエンドに渡せるよう修正
  - 投稿・コメントの表示を `post.message` から `v-html="post.formatted_message"` に変更

- **表示・スタイルの改善:**

  - フォーラムページのリンクを青色＋下線付きにし、ホバー時の透明度変更を追加
  - コメント本文の `<p>` タグに `mb-2` クラスを追加し、親コンポーネントのリンクスタイルを適用
  - 子コメント本文にも `formatted_message` を適用し、適切にリンクを表示

- **コードの整理:**

  - `formatted_message` のアクセサ適用箇所にコメントを追加し、処理の意図を明確化
  - コメントデータのフォーマット処理を `formatComment()` に分離し、再利用しやすくした

## レビューしてほしいところ

- `formatted_message` の処理が適切か（特にアクセサの処理と `v-html` の適用）
- コメントデータのフォーマット処理 `formatComment()` の分離が適切か
- フォーラムページのリンクの視認性改善が十分か
- `v-html` の使用に関するXSSリスク対策が適切に行われているか

## 不安に思っていること

- `v-html` を使用することによるXSSリスクの対策が十分か
- 子コメントへのリンク適用が意図通りに動作しているか
- リンクスタイルの適用が他のUI要素に影響を与えていないか

## 保留していること

- さらなるリンクの装飾やスタイル改善（必要であれば別タスクで対応）
- その他のコンテンツにも `formatted_message` を適用するか検討