### PR TITLE
投稿・引用投稿・コメントの `formatted_message` における改行の二重適用を修正

### DIFF
--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -45,11 +45,11 @@ class Comment extends Model
 
     public function getFormattedMessageAttribute()
     {
-        return nl2br(preg_replace(
-            '/(https?:\/\/[^\s]+)/',
-            '<a href="$1" target="_blank" rel="noopener noreferrer">$1</a>',
+        return preg_replace(
+        '/(https?:\/\/[^\s]+)/',
+        '<a href="$1" target="_blank" rel="noopener noreferrer">$1</a>',
             e($this->message)
-        ));
+        );
     }
 }
 

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -40,8 +40,8 @@ class Post extends Model
     }
 
     public function getFormattedMessageAttribute()
-{
-    return preg_replace(
+    {
+        return preg_replace (
         '/(https?:\/\/[^\s]+)/',
         '<a href="$1" target="_blank" rel="noopener noreferrer">$1</a>',
             e($this->message)

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -41,12 +41,11 @@ class Post extends Model
 
     public function getFormattedMessageAttribute()
 {
-    return nl2br(preg_replace(
+    return preg_replace(
         '/(https?:\/\/[^\s]+)/',
         '<a href="$1" target="_blank" rel="noopener noreferrer">$1</a>',
-        e($this->message)
-    ));
-}
-
+            e($this->message)
+        );
+    }
 }
 


### PR DESCRIPTION
## **目的**

投稿・引用投稿・コメントの `formatted_message` において、`nl2br()` により改行が二重に適用されていた問題を修正し、余計な改行が入らないようにする。  
また、`whitespace-pre-wrap` との競合を解消し、意図した通りの表示を実現する。

## **達成条件**

- **投稿本文 (`formatted_message`)** の改行が二重にならない
- **引用投稿 (`formatted_message`)** の改行が二重にならない
- **コメント (`formatted_message`)** の改行が二重にならない
- `nl2br()` を削除し、`preg_replace()` のみで URL をリンク化
- `whitespace-pre-wrap` を適切に適用し、不要な改行が入らないようにする

## **実装の概要**

- **投稿・引用投稿・コメントの `formatted_message` において、`nl2br()` を削除**

  - 改行が二重に適用される問題を解消
  - `whitespace-pre-wrap` を適用して適切な表示を維持

- **`preg_replace()` のみで URL をリンク化する処理に変更**
  - `nl2br()` を削除しても、URL のリンク化が適切に動作するように調整

## **レビューしてほしいところ**

- `nl2br()` を削除したことによる影響がないか
- `formatted_message` の改行処理が適切に動作しているか（投稿・引用投稿・コメントすべて）
- `preg_replace()` の処理が URL のリンク化に対して適切に動作するか
- `whitespace-pre-wrap` によるスタイルの影響が適切か

## **不安に思っていること**

- `nl2br()` を削除したことで、投稿・引用投稿・コメントの改行が意図通りに反映されるか
- `preg_replace()` による URL のリンク化処理がすべてのケースで正しく動作するか
- 他の箇所で `formatted_message` を使用している部分に影響が出ないか

## **保留していること**

- 他のコンテンツにも `formatted_message` を適用するかどうかの検討
- 追加のスタイル調整が必要かどうかの判断（必要なら別タスクで対応）