### PR TITLE
テキスト入力時に画像選択アイコンと重なる問題を修正

### DIFF
--- a/resources/js/Components/CommentForm.vue
+++ b/resources/js/Components/CommentForm.vue
@@ -151,15 +151,15 @@ const handleCancel = () => {
                 <!-- コメントメッセージ入力欄 -->
                 <textarea
                     v-model="commentData.message"
-                    class="w-full p-2 border border-gray-300 rounded-md"
+                    class="w-full p-2 pr-12 border border-gray-300 rounded-md"
                     required
                     :placeholder="placeholder"
                     rows="3"
                 ></textarea>
 
-                <!-- ファイル選択アイコン -->
+                <!-- 画像選択アイコン -->
                 <div
-                    class="absolute right-2 bottom-4 bg-gray-300 text-black transition hover:bg-gray-400 hover:text-white rounded-md flex items-center justify-center cursor-pointer"
+                    class="absolute right-3 bottom-5 bg-gray-300 text-black transition hover:bg-gray-400 hover:text-white rounded-md flex items-center justify-center cursor-pointer p-2"
                     style="width: 40px; height: 40px"
                     @click="triggerFileInput"
                     title="ファイルを選択"

--- a/resources/js/Components/PostForm.vue
+++ b/resources/js/Components/PostForm.vue
@@ -113,31 +113,33 @@ const submitPost = () => {
             <!-- 本文 -->
             <div class="flex flex-col mt-2 relative">
                 <p class="font-medium">本文</p>
+                <!-- テキスト入力ボックス -->
                 <textarea
                     v-model="postData.message"
-                    class="w-full p-2 border border-gray-300 rounded-md"
+                    class="w-full p-2 pr-12 border border-gray-300 rounded-md"
                     required
                     placeholder="本文を入力してください"
                     rows="3"
                 ></textarea>
-                <!-- ファイル選択アイコン -->
+
+                <!-- 画像選択アイコン -->
                 <div
-                    class="absolute right-2 bottom-2 bg-gray-300 text-black transition hover:bg-gray-400 hover:text-white rounded-md flex items-center justify-center cursor-pointer"
+                    class="absolute right-3 bottom-3 bg-gray-300 text-black transition hover:bg-gray-400 hover:text-white rounded-md flex items-center justify-center cursor-pointer p-2"
                     style="width: 40px; height: 40px"
                     @click="triggerFileInput"
                     title="ファイルを選択"
                 >
                     <i class="bi bi-card-image text-2xl"></i>
                 </div>
-                <!-- 隠しファイル入力 -->
-                <input
-                    type="file"
-                    accept="image/*"
-                    ref="fileInput"
-                    @change="onImageChange"
-                    style="display: none"
-                />
             </div>
+            <!-- 隠しファイル入力 -->
+            <input
+                type="file"
+                accept="image/*"
+                ref="fileInput"
+                @change="onImageChange"
+                style="display: none"
+            />
 
             <!-- エラーメッセージ表示 -->
             <div v-if="localErrorMessage" class="text-red-500 mt-2">

--- a/resources/js/Components/QuotePostForm.vue
+++ b/resources/js/Components/QuotePostForm.vue
@@ -116,20 +116,20 @@ const submitQuotePost = () => {
                     引用元の投稿
                 </h3>
                 <p class="text-gray-600">{{ quotedPost.message }}</p>
-                <!-- メッセージを直接表示 -->
             </div>
 
             <!-- 新しい投稿の入力フォーム -->
             <div class="relative">
                 <textarea
                     v-model="newPostContent"
-                    class="w-full border rounded p-2 mb-4"
+                    class="w-full p-2 pr-12 border rounded mb-4"
                     placeholder="投稿文を入力してください"
                     rows="4"
                 ></textarea>
-                <!-- ファイル選択アイコン -->
+
+                <!-- 画像選択アイコン -->
                 <div
-                    class="absolute right-2 bottom-8 bg-gray-300 text-black transition hover:bg-gray-400 hover:text-white rounded-md flex items-center justify-center cursor-pointer"
+                    class="absolute right-3 bottom-9 bg-gray-300 text-black transition hover:bg-gray-400 hover:text-white rounded-md flex items-center justify-center cursor-pointer p-2"
                     style="width: 40px; height: 40px"
                     @click="triggerFileInput"
                     title="ファイルを選択"
@@ -187,16 +187,16 @@ const submitQuotePost = () => {
                     <i class="bi bi-send"></i>
                 </button>
             </div>
-        </div>
 
-        <!-- 引用投稿の画像モーダル -->
-        <ImageModal :isOpen="isModalOpen" @close="isModalOpen = false">
-            <img
-                :src="imagePreview"
-                alt="投稿画像"
-                class="max-w-full max-h-full rounded-lg"
-            />
-        </ImageModal>
+            <!-- 引用投稿の画像モーダル -->
+            <ImageModal :isOpen="isModalOpen" @close="isModalOpen = false">
+                <img
+                    :src="imagePreview"
+                    alt="投稿画像"
+                    class="max-w-full max-h-full rounded-lg"
+                />
+            </ImageModal>
+        </div>
     </div>
 </template>
 


### PR DESCRIPTION
## **目的**

投稿、コメント、引用投稿の入力欄において、入力テキストが画像選択アイコンと重なる問題を修正し、ユーザーがスムーズに入力できるようにする。  
また、各入力フォームのレイアウトを統一し、視認性と操作性を向上させる。

## **達成条件**

- **投稿フォーム** で入力テキストと画像選択アイコンが重ならない
- **コメントフォーム** で入力テキストと画像選択アイコンが重ならない
- **引用投稿フォーム** で入力テキストと画像選択アイコンが重ならない
- すべての入力欄でアイコンが適切な位置に配置され、レイアウトが統一されている

## **実装の概要**

- **投稿フォーム:**

  - `pr-12` を追加し、入力テキストとアイコンの重なりを防止
  - 画像選択アイコンを `right-3 bottom-3` に調整し、見た目のバランスを改善

- **コメントフォーム:**

  - `pr-12` を追加し、入力テキストとアイコンの重なりを防止
  - 画像選択アイコンを `right-3 bottom-5` に変更し、投稿フォームと統一感を持たせる

- **引用投稿フォーム:**

  - `pr-12` を追加し、入力テキストとアイコンの重なりを防止
  - 画像選択アイコンを `right-3 bottom-9` に調整し、投稿フォームとの統一感を持たせる

## **レビューしてほしいところ**

- 各入力フォームでテキストとアイコンの重なりが解消されているか
- 画像選択アイコンの配置が適切で、レイアウトの統一感が取れているか
- `pr-12` の追加によるテキスト入力エリアの見た目に違和感がないか

## **不安に思っていること**

- 各フォームのレイアウト変更による意図しない影響がないか
- アイコンの配置がモバイル環境でも適切に表示されるか
- **投稿・コメント・引用投稿フォームで `bottom` の値が異なっているため、統一の必要性があるか**
- 追加の調整が必要になった場合、`pr-12` 以外の方法が必要になる可能性

## **保留していること**

- さらなるデザイン調整の必要性（フォントサイズや間隔の最適化）
- **`bottom` の値を統一するかどうかの検討**
- 他のUIコンポーネントへの適用（今後の改修で検討）