### PR TITLE
検索バーのXアイコンを `bi-x-lg` に統一  

### DIFF
--- a/resources/js/Components/SearchForm.vue
+++ b/resources/js/Components/SearchForm.vue
@@ -72,7 +72,7 @@ const compositionEnd = () => {
             class="absolute right-3 cursor-pointer text-gray-400 hover:text-gray-600"
             @click="resetSearch"
         >
-            <i class="bi bi-x"></i>
+            <i class="bi bi-x-lg"></i>
         </div>
     </div>
 </template>


### PR DESCRIPTION
## 目的  
職員ページや利用者ページのXアイコンと統一し、デザインの一貫性を向上させるため。  

## 達成条件  
- 検索バーのXアイコンを `bi-x` から `bi-x-lg` に変更すること  
- 職員ページや利用者ページのXアイコンとデザインを統一すること  

## 実装の概要  
- 検索バー内の閉じるボタンのアイコンを `bi-x` から `bi-x-lg` に変更  
- 既存の職員ページや利用者ページのXアイコンと統一  

## レビューしてほしいところ  
- デザインの統一が適切に行われているか  
- 他に影響が出る箇所がないか  

## 不安に思っていること  
- 他のページやコンポーネントで異なるアイコンが使用されている可能性がないか  

## 保留していること  
特になし  