### PR TITLE
iPhoneのスワイプバック時の意図しないページ遷移を防ぐ対応を追加

### DIFF
--- a/resources/js/Components/PopstateHandler.vue
+++ b/resources/js/Components/PopstateHandler.vue
@@ -1,0 +1,23 @@
+<template>
+    <div></div>
+</template>
+
+<script>
+export default {
+    name: "PopstateHandler",
+    mounted() {
+        window.addEventListener("popstate", this.handleBack);
+    },
+    beforeDestroy() {
+        window.removeEventListener("popstate", this.handleBack);
+    },
+    methods: {
+        handleBack(event) {
+            if (event.state === null) {
+                // 常にブラウザの1つ前の履歴に戻る
+                window.history.back();
+            }
+        },
+    },
+};
+</script>

--- a/resources/js/Pages/Legal/PrivacyPolicy.vue
+++ b/resources/js/Pages/Legal/PrivacyPolicy.vue
@@ -1,16 +1,21 @@
 <script>
 import Footer from "@/Layouts/Footer.vue";
+import PopstateHandler from "@/Components/PopstateHandler.vue";
 
 export default {
     name: "PrivacyPolicy",
     components: {
         Footer,
+        PopstateHandler,
     },
 };
 </script>
 
 <template>
     <div class="privacy-policy max-w-3xl mx-auto p-5 leading-relaxed">
+        <!-- ひとつ前のページに戻る -->
+        <PopstateHandler />
+
         <h1 class="text-3xl font-bold mb-4">プライバシーポリシー</h1>
 
         <h2 class="text-2xl font-semibold mt-6 mb-2 border-b border-gray-300">

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -46,6 +46,20 @@ createInertiaApp({
 
         app.mount(el);
 
+        // SPAの初期表示時に履歴を置き換える
+        window.history.replaceState(
+            {},
+            "",
+            window.location.pathname + window.location.search
+        );
+
+        // iPhoneスワイプバック対策
+        window.addEventListener("popstate", (event) => {
+            if (event.state === null) {
+                window.history.back();
+            }
+        });
+
         document.addEventListener("inertia:finish", (event) => {
             console.log("Inertia:finish イベントが発火しました");
 


### PR DESCRIPTION
## **目的**

iPhoneのスワイプバック機能を使用した際に、意図しないページに遷移してしまう問題を解決するため、適切に履歴を管理し、常に前のページに戻るようにする。

***

## **達成条件**

- **iPhoneのスワイプバック時に、アプリ内の前のページに正常に戻れること。**
- **スワイプバック時に、トップページやブラウザの初期ページに戻ってしまう現象を防ぐこと。**
- **他のブラウザやデバイスに影響を与えず、通常の「戻る」操作が期待通り動作すること。**

***

## **実装の概要**

### **1. `PopstateHandler.vue` の追加**

- **popstateイベントを監視し、iPhoneのスワイプバック時に `window.history.back()` を実行** することで、常に前のページに戻るようにした。

### **2. PrivacyPolicyページに `PopstateHandler` を追加**

- **スワイプバック時のページ遷移を適切に制御するため、PrivacyPolicyページに `PopstateHandler` を組み込んだ。**
- これにより、PrivacyPolicyページからスワイプで戻った際に意図しないページに遷移する現象を防ぐ。

### **3. `app.js` に `replaceState` と `popstate` の処理を追加**

- **SPAの初期表示時に `replaceState` を使用して履歴を適切に設定** することで、iPhoneのスワイプバック時にブラウザの最初のページ（トップページ）に戻ることを防ぐ。
- **`popstate` イベントリスナーを追加** し、スワイプバック時の挙動を適切に制御。

***

## **レビューしてほしいところ**

- `PopstateHandler.vue` の実装は、iPhoneのスワイプバック問題に適切に対応できているか。
- `app.js` に追加した `replaceState` と `popstate` の処理が、他のブラウザ環境で問題を引き起こしていないか。
- `PrivacyPolicy.vue` への `PopstateHandler` の適用が適切か。

***

## **不安に思っていること**

- `window.history.back()` を使用したスワイプバックの制御が、すべてのiPhoneのバージョン・ブラウザで正しく動作するか。
- `replaceState` の実装によって、他のデバイスやブラウザ（Android・PC）に影響を与えないか。
- 他のページにも `PopstateHandler` を適用すべきかどうか（必要なら別のプルリクで対応）。

***

## **保留していること**

- **他のページでのスワイプバック時の挙動の確認。**
  - **PrivacyPolicy以外のページでも同様の問題が発生する可能性があるため、今後のテスト結果次第で対応を検討する。**
- **iPhone以外のデバイス（Android・PC）での挙動確認。**
  - iPhone向けの修正が他のブラウザに予期しない影響を与えないか、追加テストが必要。