### PR TITLE
テナント作成前の welcome ページから利用規約にアクセスできるよう修正

### DIFF
--- a/app/Http/Middleware/InitializeTenancyCustom.php
+++ b/app/Http/Middleware/InitializeTenancyCustom.php
@@ -17,6 +17,7 @@ class InitializeTenancyCustom extends InitializeTenancyByDomain
             'tenant/register',
             'guest/login',
             'legal/privacy-policy',
+            'legal/terms-of-service',
             // 他にもスキップしたいパスを追加
         ];
 


### PR DESCRIPTION
## **目的**

テナント作成前の **welcome ページ（アプリに初めてアクセスした際のページ）** から利用規約にアクセスできない状態だったため、適切に閲覧できるよう修正する。

***

## **達成条件**

- **テナント作成前の welcome ページ から `/legal/terms-of-service` にアクセスできること**
- **既存のテナント認証の動作に影響を与えないこと**
- **利用規約とプライバシーポリシーのアクセス条件を統一すること**

***

## **実装の概要**

- **`legal/terms-of-service` を `app/Http/Middleware/InitializeTenancyCustom.php` のスキップリストに追加**
  - `guest/login` や `legal/privacy-policy` と同様に、**テナント作成前の welcome ページ からもアクセス可能に変更**
- **`Tenant could not be identified on domain communi-care.jp` エラーが発生しないように修正**
- **テナント作成前の welcome ページ からも利用規約を閲覧できるよう変更**
- **利用規約ページとプライバシーポリシーページのアクセス基準を統一**

***

## **レビューしてほしいところ**

- **テナント作成前の welcome ページ からのアクセス時に、適切に利用規約が表示されるか**
- **テナント認証の仕組みに影響を与えていないか**
- **テナント作成後の各テナント（介護事業所）のトップページからは、もともと問題なくアクセスできていたため、そちらの動作に影響を与えていないか**

***

## **不安に思っていること**

- **スキップリストの適用範囲が適切か（他に影響が及ぶ可能性はないか）**
- **テナント作成前にアクセス可能にすることで、意図しないセキュリティリスクが発生しないか**

***

## **保留していること**

- **「本サービス」と「本アプリ」の用語統一については、今回は対応せず、今後の改善対象とする**
- **プライバシーポリシーの見直しについては、別のタスクで対応予定*