### PR TITLE
プライバシーポリシー・利用規約ページに `<title>` タグを追加

### DIFF
--- a/resources/js/Pages/Legal/PrivacyPolicy.vue
+++ b/resources/js/Pages/Legal/PrivacyPolicy.vue
@@ -1,15 +1,18 @@
 <script>
 import Footer from "@/Layouts/Footer.vue";
+import { Head } from "@inertiajs/vue3";
 
 export default {
     name: "PrivacyPolicy",
     components: {
         Footer,
+        Head,
     },
 };
 </script>
 
 <template>
+    <Head :title="'プライバシーポリシー'" />
     <div class="privacy-policy max-w-3xl mx-auto p-5 leading-relaxed">
         <h1 class="text-3xl font-bold mb-4">プライバシーポリシー</h1>
 

--- a/resources/js/Pages/Legal/TermsOfService.vue
+++ b/resources/js/Pages/Legal/TermsOfService.vue
@@ -1,15 +1,18 @@
 <script>
 import Footer from "@/Layouts/Footer.vue";
+import { Head } from "@inertiajs/vue3";
 
 export default {
     name: "TermsOfService",
     components: {
         Footer,
+        Head,
     },
 };
 </script>
 
 <template>
+    <Head :title="'利用規約'" />
     <div class="container mx-auto px-4 py-8">
         <h1 class="text-3xl font-bold mb-6 text-left">利用規約</h1>
 


### PR DESCRIPTION
## **目的**

プライバシーポリシーおよび利用規約ページで、ブラウザのタブに適切なタイトルを表示するため。  
これにより、ユーザーが複数のタブを開いた際に、どのページなのか判別しやすくなります。

## **達成条件**

- プライバシーポリシーページの `<title>` に「プライバシーポリシー」が適切に表示されること
- 利用規約ページの `<title>` に「利用規約」が適切に表示されること
- 他のページの動作に影響を与えないこと

## **実装の概要**

- **Inertia.js の `Head` コンポーネント** を使用し、各ページの `<title>` タグを設定しました。
- プライバシーポリシー (`PrivacyPolicy.vue`) に `<Head :title="'プライバシーポリシー'" />` を追加
- 利用規約 (`TermsOfService.vue`) に `<Head :title="'利用規約'" />` を追加

## **レビューしてほしいところ**

- Inertia.js の `Head` コンポーネントの使い方に問題がないか
- 他のページへの影響がないか
- タイトルの表記（例：「プライバシーポリシー」 vs 「プライバシーポリシー - CommuniCare」など）について

## **不安に思っていること**

- 他のページでも同様の修正が必要かどうか（例えば、トップページやその他の静的ページなど）
- SEO を考慮し、`meta` タグも追加すべきかどうか

## **保留していること**

- `meta` タグの追加については、別途検討する予定
- 他のページにも同様の対応が必要かどうかは、レビュー後に判断する