### PR TITLE
同テナント内での `username_id` 重複チェックの修正

### DIFF
--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -35,7 +35,7 @@ class RegisteredUserController extends Controller
                 'string',
                 'max:255',
                 Rule::unique('users')->where(function ($query) {
-                    return $query->where('tenant_id', session('tenant_id'));
+                    return $query->where('tenant_id', tenant('id'));
                 })
             ],
             'password' => ['required', 'confirmed', Rules\Password::defaults()],


### PR DESCRIPTION
## **目的**

本番環境で、同じ `username_id` を同一テナント内で登録しようとした際に、**SQLSTATE\[23000] Duplicate entry** エラーが発生してしまう問題を修正する。  
エラーメッセージを適切にバリデーションで処理し、**SQLエラーが発生する前に、ユーザーに「ユーザーIDの値は既に存在しています。」と表示するようにする。**

## **達成条件**

- 同じ `username_id` を **同一テナント内で登録しようとすると**、バリデーションエラーとして処理され、適切なエラーメッセージ（「ユーザーIDの値は既に存在しています。」）が表示されること。
- **異なるテナントでは同じ `username_id` を登録できること。**
- 修正後、本番環境で **SQLSTATE\[23000] Duplicate entry** エラーが発生しなくなること。

## **実装の概要**

- ユーザー登録時の `username_id` のバリデーションにおいて、`session('tenant_id')` を使用していた部分を `tenant('id')` に変更。
- これにより、**適切なテナントごとの一意制約がバリデーションでチェックされるようになった。**
- 変更後、**SQLエラーが発生せず、適切なエラーメッセージが表示されることを確認済み。**

## **レビューしてほしいところ**

- `tenant('id')` を用いたバリデーションの実装が適切かどうか。
- `Rule::unique()` の適用範囲に問題がないか（特に **テナントごとのユニークチェック** が正しく機能しているか）。
- **修正が既存の登録・認証機能に影響を与えていないか。**

## **不安に思っていること**

- 他の認証関連機能（ログイン、パスワードリセットなど）に影響がないか。
- 他の登録処理においても、`session('tenant_id')` ではなく `tenant('id')` に変更する必要があるか。

## **保留していること**

- **パスワードにユニーク制約を設けることを検討したが、ハッシュ化されるため意味がないため採用を見送った。**