### PR TITLE
ソーシャルリンクの表示条件を追加

### DIFF
--- a/resources/js/Layouts/Footer.vue
+++ b/resources/js/Layouts/Footer.vue
@@ -6,6 +6,17 @@ export default {
     components: {
         Link,
     },
+    computed: {
+        showSocialLinks() {
+            const hostname = window.location.hostname;
+            const port = window.location.port;
+            return (
+                hostname === "communi-care.jp" ||
+                (hostname === "localhost" && port === "9000") ||
+                hostname.includes("guestdemo")
+            );
+        },
+    },
 };
 </script>
 
@@ -31,7 +42,7 @@ export default {
                     <Link href="/legal/terms-of-service"> 利用規約 </Link>
                 </div>
                 <!-- ソーシャルリンク -->
-                <div class="flex space-x-4">
+                <div class="flex space-x-4" v-if="showSocialLinks">
                     <a
                         href="https://twitter.com/shoprogramming"
                         rel="noopener noreferrer"


### PR DESCRIPTION
# 目的

テナント作成前のwelcomeページおよび、ゲスト環境でのみソーシャルリンクを表示するため。  
介護施設などの正式な使用場面で、開発者個人のソーシャルリンクが表示されるのは不適切であり、ユーザーの混乱や信頼性の低下を防ぐため。

# 達成条件

- テナント作成前のwelcomeページでソーシャルリンクが表示されること。
- hostnameが `communi-care.jp` または `localhost` かつポートが `9000` の場合、または `guestdemo` を含む場合にのみソーシャルリンクが表示されること。
- それ以外の環境ではソーシャルリンクが表示されないこと。

# 実装の概要

- `computed` プロパティに `showSocialLinks` を追加し、hostname と port に基づいて表示条件を設定。
- ソーシャルリンクの親要素に `v-if="showSocialLinks"` を追加して条件分岐を実施。
- `hostname` が `communi-care.jp`、`localhost` かつポートが `9000`、または `guestdemo` を含む場合にのみリンクが表示されるように修正。

# レビューしてほしいところ

- `showSocialLinks` の条件分岐が適切かどうか。
- コードの可読性および保守性について。
- hostname と port の条件設定に漏れがないか。

# 不安に思っていること

- 今後、新しいサブドメインや環境が追加された際に、条件が増える可能性がある点。
- `window.location` への依存が原因で、サーバーサイドレンダリング時にエラーが発生しないか。
- 開発者個人のソーシャルリンクを表示しない方針について、意見があれば伺いたい。

# 保留していること

- ソーシャルリンクの表示条件に関して、特定の環境が追加された際の拡張。
- `window.location` への依存を解消するためのサーバーサイドレンダリング対応。
- ソーシャルリンクの内容およびリンク先の更新（今回は見送った）。