### PR TITLE
unitsテーブルの並び順管理と管理者専用のドラッグ&ドロップ機能の実装および関連バグ修正

### DIFF
--- a/app/Http/Controllers/ForumController.php
+++ b/app/Http/Controllers/ForumController.php
@@ -27,7 +27,7 @@ class ForumController extends Controller
             return Inertia::render('Forum', [
                 'errorMessage' => 'ユニットに所属していません。管理者に確認してください。',
                 'posts' => [],
-                'units' => Unit::with('forum')->get(),
+                'units' => Unit::orderBy('sort_order')->with('forum')->get(),
                 'users' => User::all(),
                 'selectedForumId' => null,
             ]);
@@ -93,7 +93,7 @@ class ForumController extends Controller
 
         return Inertia::render('Forum', [
             'posts' => $posts,
-            'units' => Unit::with('forum')->get(),
+            'units' => Unit::orderBy('sort_order')->with('forum')->get(),
             'users' => User::all(),
             'selectedForumId' => $forumId,
             'errorMessage' => null,

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -22,7 +22,7 @@ class ProfileController extends Controller
     {
         // 現在のテナントに属する部署のみを取得
         $units = Unit::where('tenant_id', auth()->user()->tenant_id)
-            ->orderBy('name')
+            ->orderBy('sort_order')
             ->get();
 
         return Inertia::render('Profile/Edit', [

--- a/app/Http/Controllers/UnitController.php
+++ b/app/Http/Controllers/UnitController.php
@@ -98,4 +98,16 @@ class UnitController extends Controller
         Unit::find($id)->delete();
         return redirect()->route("units.create")->with(["success" => "部署の削除が完了しました"]);
     }
+
+    /**
+     * 部署の並び順を保存
+     */
+    public function sort(Request $request)
+    {
+        $units = $request->input('units');
+        foreach ($units as $index => $unit) {
+            Unit::where('id', $unit['id'])->update(['sort_order' => $index]);
+        }
+        return response()->json(['message' => '部署の並び順が保存されました']);
+    }
 }

--- a/app/Http/Controllers/UnitController.php
+++ b/app/Http/Controllers/UnitController.php
@@ -104,10 +104,12 @@ class UnitController extends Controller
      */
     public function sort(Request $request)
     {
-        $units = $request->input('units');
+        $units = $request->input('units') ?? [];
         foreach ($units as $index => $unit) {
             Unit::where('id', $unit['id'])->update(['sort_order' => $index]);
         }
-        return response()->json(['message' => '部署の並び順が保存されました']);
+        return Inertia::render('Forum', [
+            'units' => $units,
+        ]);
     }
 }

--- a/app/Http/Controllers/UnitController.php
+++ b/app/Http/Controllers/UnitController.php
@@ -108,8 +108,6 @@ class UnitController extends Controller
         foreach ($units as $index => $unit) {
             Unit::where('id', $unit['id'])->update(['sort_order' => $index]);
         }
-        return Inertia::render('Forum', [
-            'units' => $units,
-        ]);
+        return redirect()->route('forum.index');
     }
 }

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -38,8 +38,6 @@ class HandleInertiaRequests extends Middleware
                 ->first();
         }
 
-        \Log::info('isAdmin (Inertia): ' . ($request->user() && $request->user()->hasRole('admin') ? 'true' : 'false'));
-
         return [
             ...parent::share($request),
             'auth' => [

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -38,10 +38,13 @@ class HandleInertiaRequests extends Middleware
                 ->first();
         }
 
+        \Log::info('isAdmin (Inertia): ' . ($request->user() && $request->user()->hasRole('admin') ? 'true' : 'false'));
+
         return [
             ...parent::share($request),
             'auth' => [
                 'user' => $request->user(),
+                'isAdmin' => $request->user() ? $request->user()->hasRole('admin') : false,
             ],
             'tenant' => $tenant,
             'isGuest' => $request->user() && $request->user()->guest_session_id ? true : false,

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -38,12 +38,23 @@ class HandleInertiaRequests extends Middleware
                 ->first();
         }
 
+        $currentAdminId = null;
+
+    if ($request->user()) {
+        $tenantId = $request->user()->tenant_id;
+        $admin = \App\Models\User::role('admin')
+            ->where('tenant_id', $tenantId)
+            ->first();
+        $currentAdminId = $admin ? $admin->id : null;
+    }
+
         return [
             ...parent::share($request),
             'auth' => [
                 'user' => $request->user(),
                 'isAdmin' => $request->user() ? $request->user()->hasRole('admin') : false,
             ],
+            'currentAdminId' => $currentAdminId,
             'tenant' => $tenant,
             'isGuest' => $request->user() && $request->user()->guest_session_id ? true : false,
             'guestSessionId' => $request->user() && $request->user()->guest_session_id ? $request->user()->guest_session_id : null,

--- a/app/Models/Unit.php
+++ b/app/Models/Unit.php
@@ -10,7 +10,7 @@ class Unit extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['name', 'tenant_id'];
+    protected $fillable = ['name', 'tenant_id', 'sort_order'];
 
     protected static function booted()
     {

--- a/database/migrations/2025_03_03_173139_add_sort_order_to_units_table.php
+++ b/database/migrations/2025_03_03_173139_add_sort_order_to_units_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('units', function (Blueprint $table) {
+            $table->integer('sort_order')->default(0)->after('name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('units', function (Blueprint $table) {
+            $table->dropColumn('sort_order');
+        });
+    }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "vuedraggable": "^2.24.3"
             },
             "devDependencies": {
-                "@inertiajs/vue3": "^1.0.0",
+                "@inertiajs/vue3": "^2.0.4",
                 "@tailwindcss/forms": "^0.5.3",
                 "@vitejs/plugin-vue": "^5.0.0",
                 "autoprefixer": "^10.4.12",
@@ -449,24 +449,25 @@
             }
         },
         "node_modules/@inertiajs/core": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@inertiajs/core/-/core-1.2.0.tgz",
-            "integrity": "sha512-6U0gqCPbGGGMcLoDm+ckKipc5gptZMmfVFfPGdO7vlO7yipWf1RD+TKkcZGJklFvfgFMKwK2VPw8GAv1OctuQA==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@inertiajs/core/-/core-2.0.4.tgz",
+            "integrity": "sha512-gCUqpwBRYOhz0hwBDWca2lkk+Mc+36GvbRoE0rEvYFpzQAMMP0xFhH9h8hr7VWTn+vVOZRuDvakI+4cazwtvCg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "axios": "^1.6.0",
                 "deepmerge": "^4.0.0",
-                "nprogress": "^0.2.0",
                 "qs": "^6.9.0"
             }
         },
         "node_modules/@inertiajs/vue3": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@inertiajs/vue3/-/vue3-1.2.0.tgz",
-            "integrity": "sha512-Y6AsvwIK/E1pQKAMp8B7i99CbNApcTYb7j8R+TXM/AFQG6yBlQ1Qb9oFMItb6VimXSnDyfO4+FWe/JPLk9OIVA==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@inertiajs/vue3/-/vue3-2.0.4.tgz",
+            "integrity": "sha512-QbVpWHhIEEjbhPoJmUBvt1SxreZmiPgq2gr1bnvhrGcwtGzDoVTN+1sTO5PBX0SebVQhabHHlJS8SzwoxGLgKw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@inertiajs/core": "1.2.0",
+                "@inertiajs/core": "2.0.4",
                 "lodash.clonedeep": "^4.5.0",
                 "lodash.isequal": "^4.5.0"
             },
@@ -1177,17 +1178,29 @@
                 "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
             }
         },
-        "node_modules/call-bind": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
-            "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
+        "node_modules/call-bind-apply-helpers": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "es-define-property": "^1.0.0",
                 "es-errors": "^1.3.0",
-                "function-bind": "^1.1.2",
-                "get-intrinsic": "^1.2.4",
-                "set-function-length": "^1.2.1"
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/call-bound": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+            "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "get-intrinsic": "^1.3.0"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -1343,25 +1356,9 @@
             "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
             "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/define-data-property": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-            "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-            "dev": true,
-            "dependencies": {
-                "es-define-property": "^1.0.0",
-                "es-errors": "^1.3.0",
-                "gopd": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/delayed-stream": {
@@ -1384,6 +1381,21 @@
             "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
             "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
             "dev": true
+        },
+        "node_modules/dunder-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.2.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
         },
         "node_modules/eastasianwidth": {
             "version": "0.2.0",
@@ -1415,13 +1427,11 @@
             }
         },
         "node_modules/es-define-property": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
-            "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
             "dev": true,
-            "dependencies": {
-                "get-intrinsic": "^1.2.4"
-            },
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             }
@@ -1431,6 +1441,20 @@
             "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
             "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
             "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-object-atoms": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0"
+            },
             "engines": {
                 "node": ">= 0.4"
             }
@@ -1623,22 +1647,42 @@
             }
         },
         "node_modules/get-intrinsic": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-            "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
                 "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.1.1",
                 "function-bind": "^1.1.2",
-                "has-proto": "^1.0.1",
-                "has-symbols": "^1.0.3",
-                "hasown": "^2.0.0"
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-symbols": "^1.1.0",
+                "hasown": "^2.0.2",
+                "math-intrinsics": "^1.1.0"
             },
             "engines": {
                 "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "dunder-proto": "^1.0.1",
+                "es-object-atoms": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/glob": {
@@ -1674,34 +1718,11 @@
             }
         },
         "node_modules/gopd": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-            "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
             "dev": true,
-            "dependencies": {
-                "get-intrinsic": "^1.1.3"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/has-property-descriptors": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-            "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-            "dev": true,
-            "dependencies": {
-                "es-define-property": "^1.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/has-proto": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
-            "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
-            "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -1710,10 +1731,11 @@
             }
         },
         "node_modules/has-symbols": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-            "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -1889,6 +1911,16 @@
                 "@jridgewell/sourcemap-codec": "^1.5.0"
             }
         },
+        "node_modules/math-intrinsics": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/merge2": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -2018,12 +2050,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/nprogress": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/nprogress/-/nprogress-0.2.0.tgz",
-            "integrity": "sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA==",
-            "dev": true
-        },
         "node_modules/object-assign": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -2043,10 +2069,11 @@
             }
         },
         "node_modules/object-inspect": {
-            "version": "1.13.2",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
-            "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
+            "version": "1.13.4",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+            "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -2287,12 +2314,13 @@
             "dev": true
         },
         "node_modules/qs": {
-            "version": "6.13.0",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-            "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+            "version": "6.14.0",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+            "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
             "dev": true,
+            "license": "BSD-3-Clause",
             "dependencies": {
-                "side-channel": "^1.0.6"
+                "side-channel": "^1.1.0"
             },
             "engines": {
                 "node": ">=0.6"
@@ -2429,23 +2457,6 @@
                 "queue-microtask": "^1.2.2"
             }
         },
-        "node_modules/set-function-length": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
-            "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-            "dev": true,
-            "dependencies": {
-                "define-data-property": "^1.1.4",
-                "es-errors": "^1.3.0",
-                "function-bind": "^1.1.2",
-                "get-intrinsic": "^1.2.4",
-                "gopd": "^1.0.1",
-                "has-property-descriptors": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
         "node_modules/shebang-command": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -2468,15 +2479,73 @@
             }
         },
         "node_modules/side-channel": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
-            "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+            "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.7",
                 "es-errors": "^1.3.0",
-                "get-intrinsic": "^1.2.4",
-                "object-inspect": "^1.13.1"
+                "object-inspect": "^1.13.3",
+                "side-channel-list": "^1.0.0",
+                "side-channel-map": "^1.0.1",
+                "side-channel-weakmap": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-list": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+            "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "object-inspect": "^1.13.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-map": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+            "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.5",
+                "object-inspect": "^1.13.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-weakmap": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+            "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.5",
+                "object-inspect": "^1.13.3",
+                "side-channel-map": "^1.0.1"
             },
             "engines": {
                 "node": ">= 0.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
                 "dayjs": "^1.11.13",
                 "vue-i18n": "^9.14.0",
                 "vue-slide-up-down": "^3.0.0",
+                "vue3-smooth-dnd": "^0.0.6",
                 "vuedraggable": "^2.24.3"
             },
             "devDependencies": {
@@ -2495,6 +2496,12 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/smooth-dnd": {
+            "version": "0.12.1",
+            "resolved": "https://registry.npmjs.org/smooth-dnd/-/smooth-dnd-0.12.1.tgz",
+            "integrity": "sha512-Dndj/MOG7VP83mvzfGCLGzV2HuK1lWachMtWl/Iuk6zV7noDycIBnflwaPuDzoaapEl3Pc4+ybJArkkx9sxPZg==",
+            "license": "MIT"
+        },
         "node_modules/sortablejs": {
             "version": "1.10.2",
             "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.10.2.tgz",
@@ -2875,6 +2882,18 @@
             "integrity": "sha512-4ckwKgpkPfjDmwVKdu5UANvxt7nKemIKpqbRGhcekgDuvEwep8YFwkb8G9dix4lL+Wt2G73X1Z90c1oPJvXdOQ==",
             "peerDependencies": {
                 "vue": ">=3.0.0"
+            }
+        },
+        "node_modules/vue3-smooth-dnd": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/vue3-smooth-dnd/-/vue3-smooth-dnd-0.0.6.tgz",
+            "integrity": "sha512-CH9ZZhEfE7qU1ef2rlfgBG+nZtQX8PnWlspB2HDDz1uVGU7fXM0Pr65DftBMz4X81S+edw2H+ZFG6Dyb5J81KA==",
+            "license": "MIT",
+            "dependencies": {
+                "smooth-dnd": "^0.12.1"
+            },
+            "peerDependencies": {
+                "vue": "^3.0.11"
             }
         },
         "node_modules/vuedraggable": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1206,9 +1206,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001660",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001660.tgz",
-            "integrity": "sha512-GacvNTTuATm26qC74pt+ad1fW15mlQ/zuTzzY1ZoIzECTP8HURDfF43kNxPgf7H1jmelCBQTTbBNxdSXOA7Bqg==",
+            "version": "1.0.30001701",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001701.tgz",
+            "integrity": "sha512-faRs/AW3jA9nTwmJBSO1PQ6L/EOgsB5HMQQq4iCu5zhPgVVgO/pZRHlmatwijZKetFw8/Pr4q6dEN8sJuq8qTw==",
             "dev": true,
             "funding": [
                 {
@@ -1223,7 +1223,8 @@
                     "type": "github",
                     "url": "https://github.com/sponsors/ai"
                 }
-            ]
+            ],
+            "license": "CC-BY-4.0"
         },
         "node_modules/chokidar": {
             "version": "3.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
-    "name": "CommuniCareV2",
+    "name": "html",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "CommuniCareV2",
             "dependencies": {
                 "bootstrap-icons": "^1.11.3",
                 "dayjs": "^1.11.13",
                 "vue-i18n": "^9.14.0",
-                "vue-slide-up-down": "^3.0.0"
+                "vue-slide-up-down": "^3.0.0",
+                "vuedraggable": "^2.24.3"
             },
             "devDependencies": {
                 "@inertiajs/vue3": "^1.0.0",
@@ -474,12 +474,13 @@
             }
         },
         "node_modules/@intlify/core-base": {
-            "version": "9.14.0",
-            "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-9.14.0.tgz",
-            "integrity": "sha512-zJn0imh9HIsZZUtt9v8T16PeVstPv6bP2YzlrYJwoF8F30gs4brZBwW2KK6EI5WYKFi3NeqX6+UU4gniz5TkGg==",
+            "version": "9.14.2",
+            "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-9.14.2.tgz",
+            "integrity": "sha512-DZyQ4Hk22sC81MP4qiCDuU+LdaYW91A6lCjq8AWPvY3+mGMzhGDfOCzvyR6YBQxtlPjFqMoFk9ylnNYRAQwXtQ==",
+            "license": "MIT",
             "dependencies": {
-                "@intlify/message-compiler": "9.14.0",
-                "@intlify/shared": "9.14.0"
+                "@intlify/message-compiler": "9.14.2",
+                "@intlify/shared": "9.14.2"
             },
             "engines": {
                 "node": ">= 16"
@@ -489,11 +490,12 @@
             }
         },
         "node_modules/@intlify/message-compiler": {
-            "version": "9.14.0",
-            "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-9.14.0.tgz",
-            "integrity": "sha512-sXNsoMI0YsipSXW8SR75drmVK56tnJHoYbPXUv2Cf9lz6FzvwsosFm6JtC1oQZI/kU+n7qx0qRrEWkeYFTgETA==",
+            "version": "9.14.2",
+            "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-9.14.2.tgz",
+            "integrity": "sha512-YsKKuV4Qv4wrLNsvgWbTf0E40uRv+Qiw1BeLQ0LAxifQuhiMe+hfTIzOMdWj/ZpnTDj4RSZtkXjJM7JDiiB5LQ==",
+            "license": "MIT",
             "dependencies": {
-                "@intlify/shared": "9.14.0",
+                "@intlify/shared": "9.14.2",
                 "source-map-js": "^1.0.2"
             },
             "engines": {
@@ -504,9 +506,10 @@
             }
         },
         "node_modules/@intlify/shared": {
-            "version": "9.14.0",
-            "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-9.14.0.tgz",
-            "integrity": "sha512-r+N8KRQL7LgN1TMTs1A2svfuAU0J94Wu9wWdJVJqYsoMMLIeJxrPjazihfHpmJqfgZq0ah3Y9Q4pgWV2O90Fyg==",
+            "version": "9.14.2",
+            "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-9.14.2.tgz",
+            "integrity": "sha512-uRAHAxYPeF+G5DBIboKpPgC/Waecd4Jz8ihtkpJQD5ycb5PwXp0k/+hBGl5dAjwF7w+l74kz/PKA8r8OK//RUw==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 16"
             },
@@ -1297,10 +1300,11 @@
             }
         },
         "node_modules/cross-spawn": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-            "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "path-key": "^3.1.0",
                 "shebang-command": "^2.0.0",
@@ -1971,15 +1975,16 @@
             }
         },
         "node_modules/nanoid": {
-            "version": "3.3.7",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-            "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+            "version": "3.3.8",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+            "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
             "funding": [
                 {
                     "type": "github",
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "license": "MIT",
             "bin": {
                 "nanoid": "bin/nanoid.cjs"
             },
@@ -2490,6 +2495,12 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/sortablejs": {
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.10.2.tgz",
+            "integrity": "sha512-YkPGufevysvfwn5rfdlGyrGjt7/CRHwvRPogD/lC+TnvcN29jDpCifKP+rBqf+LRldfXSTh+0CGLcSg0VIxq3A==",
+            "license": "MIT"
+        },
         "node_modules/source-map-js": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2749,10 +2760,11 @@
             "dev": true
         },
         "node_modules/vite": {
-            "version": "5.4.7",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.7.tgz",
-            "integrity": "sha512-5l2zxqMEPVENgvzTuBpHer2awaetimj2BGkhBPdnwKbPNOlHsODU+oiazEZzLK7KhAnOrO+XGYJYn4ZlUhDtDQ==",
+            "version": "5.4.14",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.14.tgz",
+            "integrity": "sha512-EK5cY7Q1D8JNhSaPKVK4pwBFvaTmZxEnoKXLG/U9gmdDcihQGNzFlgIvaxezFR4glP1LsuiedwMBqCXH3wZccA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "esbuild": "^0.21.3",
                 "postcss": "^8.4.43",
@@ -2838,12 +2850,13 @@
             }
         },
         "node_modules/vue-i18n": {
-            "version": "9.14.0",
-            "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-9.14.0.tgz",
-            "integrity": "sha512-LxmpRuCt2rI8gqU+kxeflRZMQn4D5+4M3oP3PWZdowW/ePJraHqhF7p4CuaME52mUxdw3Mmy2yAUKgfZYgCRjA==",
+            "version": "9.14.2",
+            "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-9.14.2.tgz",
+            "integrity": "sha512-JK9Pm80OqssGJU2Y6F7DcM8RFHqVG4WkuCqOZTVsXkEzZME7ABejAUqUdA931zEBedc4thBgSUWxeQh4uocJAQ==",
+            "license": "MIT",
             "dependencies": {
-                "@intlify/core-base": "9.14.0",
-                "@intlify/shared": "9.14.0",
+                "@intlify/core-base": "9.14.2",
+                "@intlify/shared": "9.14.2",
                 "@vue/devtools-api": "^6.5.0"
             },
             "engines": {
@@ -2862,6 +2875,15 @@
             "integrity": "sha512-4ckwKgpkPfjDmwVKdu5UANvxt7nKemIKpqbRGhcekgDuvEwep8YFwkb8G9dix4lL+Wt2G73X1Z90c1oPJvXdOQ==",
             "peerDependencies": {
                 "vue": ">=3.0.0"
+            }
+        },
+        "node_modules/vuedraggable": {
+            "version": "2.24.3",
+            "resolved": "https://registry.npmjs.org/vuedraggable/-/vuedraggable-2.24.3.tgz",
+            "integrity": "sha512-6/HDXi92GzB+Hcs9fC6PAAozK1RLt1ewPTLjK0anTYguXLAeySDmcnqE8IC0xa7shvSzRjQXq3/+dsZ7ETGF3g==",
+            "license": "MIT",
+            "dependencies": {
+                "sortablejs": "1.10.2"
             }
         },
         "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "build": "vite build"
     },
     "devDependencies": {
-        "@inertiajs/vue3": "^1.0.0",
+        "@inertiajs/vue3": "^2.0.4",
         "@tailwindcss/forms": "^0.5.3",
         "@vitejs/plugin-vue": "^5.0.0",
         "autoprefixer": "^10.4.12",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
         "dayjs": "^1.11.13",
         "vue-i18n": "^9.14.0",
         "vue-slide-up-down": "^3.0.0",
+        "vue3-smooth-dnd": "^0.0.6",
         "vuedraggable": "^2.24.3"
     }
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
         "bootstrap-icons": "^1.11.3",
         "dayjs": "^1.11.13",
         "vue-i18n": "^9.14.0",
-        "vue-slide-up-down": "^3.0.0"
+        "vue-slide-up-down": "^3.0.0",
+        "vuedraggable": "^2.24.3"
     }
 }

--- a/resources/js/Pages/Unit/ListForSidebar.vue
+++ b/resources/js/Pages/Unit/ListForSidebar.vue
@@ -50,7 +50,9 @@ export default {
         };
     },
     methods: {
+        // 並び替えのイベントデータを取得
         handleDrop(event) {
+            // 管理者だけ並び替えを可能にする
             if (this.auth.isAdmin) {
                 this.updateOrder(event);
             }

--- a/resources/js/Pages/Unit/ListForSidebar.vue
+++ b/resources/js/Pages/Unit/ListForSidebar.vue
@@ -50,6 +50,11 @@ export default {
         };
     },
     methods: {
+        handleDrop(event) {
+            if (this.auth.isAdmin) {
+                this.updateOrder(event);
+            }
+        },
         async handleUnitClick(unit) {
             if (this.isFetchingData) {
                 console.log("Already fetching data, skipping...");
@@ -148,7 +153,12 @@ export default {
 <template>
     <div class="sidebar bg-gray-100 w-56 h-screen p-4 shadow-lg">
         <h2 class="text-lg font-bold mb-4">{{ $t("Unit List") }}</h2>
-        <Container :items="units" @drop="updateOrder" class="list-none">
+        <Container
+            :items="units"
+            @drop="handleDrop"
+            :behaviour="auth.isAdmin ? 'move' : 'copy'"
+            class="list-none"
+        >
             <Draggable v-for="unit in units" :key="unit.id">
                 <li
                     class="mb-2 p-2 rounded cursor-pointer"

--- a/resources/js/Pages/Unit/ListForSidebar.vue
+++ b/resources/js/Pages/Unit/ListForSidebar.vue
@@ -2,11 +2,14 @@
 import { router } from "@inertiajs/vue3";
 import SlideUpDown from "vue-slide-up-down";
 import Show from "../Users/Show.vue";
+import { Container, Draggable } from "vue3-smooth-dnd";
 
 export default {
     components: {
         SlideUpDown,
         Show,
+        Container, // コンテナコンポーネント
+        Draggable, // ドラッグ可能なコンポーネント
     },
     props: {
         units: {
@@ -26,7 +29,7 @@ export default {
     },
     computed: {
         selectedUnitId() {
-            return this.activeUnitId;
+            return this.activeUnitId; // 選択された部署IDを取得
         },
     },
     data() {
@@ -77,6 +80,18 @@ export default {
                 },
             });
         },
+
+        // 並び順を保存
+        async updateOrder() {
+            try {
+                await router.post(route("units.sort"), this.units);
+                console.log("並び順が保存されました");
+            } catch (error) {
+                console.error("並び順の保存に失敗しました", error);
+            }
+        },
+
+        // ユーザー（職員）のプロフィールを開く
         openUserProfile(user) {
             this.$emit("user-profile-clicked", user);
         },
@@ -87,21 +102,21 @@ export default {
 <template>
     <div class="sidebar bg-gray-100 w-56 h-screen p-4 shadow-lg">
         <h2 class="text-lg font-bold mb-4">{{ $t("Unit List") }}</h2>
-        <ul>
-            <li
-                v-for="unit in units"
-                :key="unit.id"
-                class="mb-2 p-2 rounded cursor-pointer"
-                :class="{
-                    'text-gray-500 hover:text-black hover:bg-gray-200':
-                        activeUnitId !== unit.id,
-                    'bg-gray-200': activeUnitId === unit.id,
-                }"
-                @click="handleUnitClick(unit)"
-            >
-                <span class="font-bold">{{ unit.name }}</span>
-            </li>
-        </ul>
+        <Container :items="units" @drop="updateOrder">
+            <Draggable v-for="unit in units" :key="unit.id">
+                <li
+                    class="mb-2 p-2 rounded cursor-pointer"
+                    :class="{
+                        'text-gray-500 hover:text-black hover:bg-gray-200':
+                            activeUnitId !== unit.id,
+                        'bg-gray-200': activeUnitId === unit.id,
+                    }"
+                    @click="handleUnitClick(unit)"
+                >
+                    <span class="font-bold">{{ unit.name }}</span>
+                </li>
+            </Draggable>
+        </Container>
     </div>
 </template>
 

--- a/resources/js/Pages/Unit/ListForSidebar.vue
+++ b/resources/js/Pages/Unit/ListForSidebar.vue
@@ -1,5 +1,5 @@
 <script>
-import { router } from "@inertiajs/vue3";
+import { router, usePage } from "@inertiajs/vue3";
 import SlideUpDown from "vue-slide-up-down";
 import Show from "../Users/Show.vue";
 import { Container, Draggable } from "vue3-smooth-dnd";
@@ -37,7 +37,18 @@ export default {
             isFetchingData: false, // データ取得中かどうかを判定するフラグ
         };
     },
+    setup() {
+        // usePage で props を取得
+        const { auth } = usePage().props;
 
+        // auth.isAdmin を console に表示 (デバッグ用)
+        console.log("isAdmin:", auth.isAdmin);
+
+        // auth を返して template で使えるようにする
+        return {
+            auth,
+        };
+    },
     methods: {
         async handleUnitClick(unit) {
             if (this.isFetchingData) {
@@ -58,7 +69,7 @@ export default {
             this.isFetchingData = false;
         },
 
-        // toggleUnitメソッドを復活
+        // toggleUnitメソッド
         toggleUnit(unitId) {
             console.log("Toggling unit:", unitId);
             // 親コンポーネントの状態を変更するためにイベントを発火
@@ -114,7 +125,8 @@ export default {
         // 最新の部署データを取得
         async fetchLatestUnits() {
             try {
-                return await router.get(route("units.index"), { // 最新の部署データを取得するメソッド。awaitは非同期処理を待つためのキーワード。
+                // 最新の部署データを取得するメソッド。awaitは非同期処理を待つためのキーワード。
+                return await router.get(route("units.index"), {
                     preserveState: true,
                     onSuccess: (page) => {
                         this.units = page.props.units ?? [];

--- a/resources/js/Pages/Unit/ListForSidebar.vue
+++ b/resources/js/Pages/Unit/ListForSidebar.vue
@@ -136,7 +136,7 @@ export default {
 <template>
     <div class="sidebar bg-gray-100 w-56 h-screen p-4 shadow-lg">
         <h2 class="text-lg font-bold mb-4">{{ $t("Unit List") }}</h2>
-        <Container :items="units" @drop="updateOrder">
+        <Container :items="units" @drop="updateOrder" class="list-none">
             <Draggable v-for="unit in units" :key="unit.id">
                 <li
                     class="mb-2 p-2 rounded cursor-pointer"

--- a/resources/js/Pages/Unit/ListForSidebar.vue
+++ b/resources/js/Pages/Unit/ListForSidebar.vue
@@ -82,18 +82,52 @@ export default {
         },
 
         // 並び順を保存
-        async updateOrder() {
+        async updateOrder(event) {
+            // 並び替えのイベントデータを取得
+            const { removedIndex, addedIndex } = event;
+
+            // エラーチェック
+            if (removedIndex === null || addedIndex === null) {
+                // 並び替えのイベントデータがnullの場合エラーメッセージを出力
+                console.error("Invalid drop event data:", event);
+                return;
+            }
+
+            // フロントエンドで並び替え
+            const movedItem = this.units.splice(removedIndex, 1)[0]; // 並び替えのイベントデータから削除されたアイテムを取得
+            this.units.splice(addedIndex, 0, movedItem); // 並び替えのイベントデータから追加されたアイテムを取得
+
+            // 並び替えのイベントデータを取得
+            const sortedUnits = this.units.map((unit, index) => ({
+                id: unit.id, // 並び替えのイベントデータからアイテムのidを取得
+                sort_order: index, // 並び替えのイベントデータからアイテムの並び順を取得
+            }));
+
             try {
-                await router.post(route("units.sort"), this.units);
+                await router.post(route("units.sort"), { units: sortedUnits });
                 console.log("並び順が保存されました");
             } catch (error) {
                 console.error("並び順の保存に失敗しました", error);
             }
         },
 
+        // 最新の部署データを取得
+        async fetchLatestUnits() {
+            try {
+                return await router.get(route("units.index"), { // 最新の部署データを取得するメソッド。awaitは非同期処理を待つためのキーワード。
+                    preserveState: true,
+                    onSuccess: (page) => {
+                        this.units = page.props.units ?? [];
+                    },
+                });
+            } catch (error) {
+                console.error("最新の部署データの取得に失敗しました", error);
+            }
+        },
+
         // ユーザー（職員）のプロフィールを開く
         openUserProfile(user) {
-            this.$emit("user-profile-clicked", user);
+            this.$emit("user-profile-clicked", user); // ユーザー（職員）のプロフィールを開くメソッド。$emitはVueのコンポーネント間でメッセージを送信するメソッド。
         },
     },
 };

--- a/routes/web.php
+++ b/routes/web.php
@@ -65,6 +65,9 @@ Route::middleware(['auth'])->group(function () {
 
     // 管理者権限の譲渡
     Route::post('/admin/transfer-admin', [AdminUserController::class, 'transferAdmin'])->name('admin.transferAdmin');
+
+    // 部署の並び順を保存
+    Route::post('/units/sort', [UnitController::class, 'sort'])->name('units.sort');
 });
 
 // 法的情報


### PR DESCRIPTION
## 目的

ユニット一覧の並び順を管理しやすくし、管理者のみが並び替えを行えるようにすることで、操作ミスを防ぎ、利便性を向上させる。また、関連するバグの修正と管理者権限の管理を強化する。

***

## 達成条件

1. `units` テーブルに `sort_order` カラムが追加されていること。
2. 管理者のみがドラッグ&ドロップでユニット一覧の順序を変更できること。
3. 並び替え結果が `/units/sort` エンドポイントを通じてデータベースに保存されること。
4. 並び替え後のリロードで順序が維持されること。
5. `isAdmin` フラグと `currentAdminId` を Inertia 経由で共有し、フロントエンドで利用できること。
6. `@inertiajs/vue3` を v2.0.4 にバージョンアップし、正常に動作すること。

***

## 実装の概要

1. **`units` テーブルに `sort_order` カラムを追加**

   - 並び順を管理するための `sort_order` カラムを追加。
   - `nullable` で初期は空でもエラーが出ないように設計。

2. **`units` モデルに `sort_order` を `fillable` に追加**

   - `sort_order` カラムを更新できるように `fillable` に追加。

3. **部署の並び順を保存するルートと処理を追加**

   - `/units/sort` エンドポイントを追加し、並び替え結果を受け取れるように設定。
   - `UnitController` に `sort` メソッドを実装し、`sort_order` の更新処理を追加。
   - `return redirect()->route('forum.index')` で並び替え後のリロード時の画面真っ白問題を修正。

4. **並び順の保持と表示に関する修正**

   - `Unit::orderBy('sort_order')->with('forum')->get()` に変更し、並び替え順でデータを取得。
   - リロード後も反映された並び順が維持されるように修正。
   - プロフィール編集画面でも `sort_order` 順で部署一覧を表示。

5. **管理者専用のドラッグ&ドロップ機能の実装**

   - `vue3-smooth-dnd` パッケージを導入。
   - `Container` と `Draggable` コンポーネントを使用して、ユニット一覧を並び替え可能に。
   - `:behaviour="auth.isAdmin ? 'move' : 'copy'"` を設定し、管理者のみ並び替え可能に。
   - 一般ユーザーはドラッグ操作自体ができないように設定。

6. **`isAdmin` フラグと `currentAdminId` の Inertia 共有**

   - `HandleInertiaRequests.php` で `isAdmin` と `currentAdminId` を共有。
   - フロントエンドで管理者専用機能の制御に使用。

7. **`@inertiajs/vue3` を v2.0.4 にバージョンアップ**

   - バグ修正と新機能への対応のため、`@inertiajs/vue3` を v2.0.4 にアップデート。
   - 互換性チェックを行い、正常に動作することを確認。

***

## レビューしてほしいところ

1. `sort_order` カラムの追加と `fillable` 設定が適切かどうか。
2. `/units/sort` エンドポイントのバリデーションと処理の流れ。
3. `vue3-smooth-dnd` を用いたドラッグ&ドロップ機能の実装方法。
4. `isAdmin` フラグと `currentAdminId` の Inertia 共有方法とフロントエンドでの利用方法。
5. `@inertiajs/vue3` のバージョンアップによる副作用がないか。

***

## 不安に思っていること

1. `sort_order` カラムの追加による既存データへの影響。
   - 初期値が `null` になるが、問題ないか。
2. `/units/sort` エンドポイントでのバリデーションと例外処理の漏れがないか。
3. `@inertiajs/vue3` バージョンアップによる互換性問題。
4. `return redirect()` と `Inertia::render` の併用による動作への影響。
5. `isAdmin` 判定が適切に機能しているかどうか。

***

## 保留していること

1. `sort_order` の初期値設定と既存データへの一括適用。
   - 現在は `nullable` を許容しているが、要件次第で一括更新の検討。
2. `/units/sort` エンドポイントのPOSTリクエストをPATCHに変更するか検討中。
3. `isAdmin` フラグをローカルストレージやセッションに保存するかの検討。