### PR TITLE
いいねしたユーザー一覧をツールチップで表示する機能の追加

### DIFF
--- a/app/Http/Controllers/LikeController.php
+++ b/app/Http/Controllers/LikeController.php
@@ -14,9 +14,9 @@ class LikeController extends Controller
         $likeableId = $request->input('likeable_id');
         $likeableType = $request->input('likeable_type');
 
-        // ポリモーフィックリレーションのため、対象モデルを動的に設定
-        $likeableModel = 'App\\Models\\' . $likeableType;
-        $likeable = $likeableModel::findOrFail($likeableId);
+        
+        $likeableModel = 'App\\Models\\' . ucfirst($likeableType); // モデル名を取得
+        $likeable = $likeableModel::findOrFail($likeableId); // 指定されたIDのモデルを取得
 
         // 既にいいねしているかを確認
         $existingLike = Like::where('user_id', $user->id)
@@ -36,4 +36,18 @@ class LikeController extends Controller
 
         return response()->json(['isLiked' => $isLiked]);
     }
+
+    // いいねしたユーザーを取得
+    public function getLikedUsers($type, $id)
+    {
+        $likeableModel = 'App\\Models\\' . ucfirst(rtrim($type, 's')); // モデル名を取得
+        $likeable = $likeableModel::findOrFail($id); // 指定されたIDのモデルを取得
+
+        // いいねしたユーザーの名前一覧を取得
+        $likedUsers = $likeable->likes()->with('user')->get()->pluck('user.name');
+
+        return response()->json($likedUsers);
+    }
+
+
 }

--- a/app/Models/Like.php
+++ b/app/Models/Like.php
@@ -9,11 +9,18 @@ class Like extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['tenant_id', 'user_id'];
+    protected $fillable = ['tenant_id', 'user_id', 'likeable_id', 'likeable_type'];
 
+    // いいねしたモデルを取得
     public function likeable()
     {
         return $this->morphTo(); // ポリモーフィックリレーション
+    }
+
+    // いいねしたユーザーを取得
+    public function user()
+    {
+        return $this->belongsTo(User::class); // 多対一のリレーション
     }
 }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -66,4 +66,9 @@ class User extends Authenticatable
     {
         return $this->unit->forum(); //単一のフォーラムを返す
     }
+
+    public function likes()
+    {
+        return $this->hasMany(Like::class); // 多対多のリレーション
+    }
 }

--- a/resources/js/Components/LikeButton.vue
+++ b/resources/js/Components/LikeButton.vue
@@ -31,6 +31,16 @@ const likedUsers = ref([]); // いいねしたユーザーの名前一覧
 const hoverTimeout = ref(null); // マウスオーバー時のタイムアウト
 const tooltipDelay = 1000; // ツールチップ表示の遅延時間
 
+// ツールチップをクリア
+const clearTooltip = () => {
+    // マウスオーバー時のタイムアウトが存在する場合
+    if (hoverTimeout.value) {
+        clearTimeout(hoverTimeout.value); // タイムアウトをクリア
+        hoverTimeout.value = null; // タイムアウトをnullに設定
+    }
+    likedUsers.value = []; // いいねしたユーザーの名前一覧を空にする
+};
+
 // いいねのトグル
 const toggleLike = async () => {
     isLiked.value = !isLiked.value; // いいねの状態をトグル
@@ -57,14 +67,14 @@ const fetchLikedUsers = async () => {
         try {
             // いいねしたユーザーの名前一覧を取得
             const response = await axios.get(
-            // モデル名を小文字に変換
-            `/api/${props.likeableType.toLowerCase()}s/${
-                props.likeableId // モデルのID
-            }/liked-users` // いいねしたユーザーの名前一覧を取得するためのエンドポイント
-        );
-        likedUsers.value = response.data; // 取得したユーザーの名前一覧を格納
-        console.log("取得したユーザー:", likedUsers.value); // デバッグ用
-    } catch (error) {
+                // モデル名を小文字に変換
+                `/api/${props.likeableType.toLowerCase()}s/${
+                    props.likeableId // モデルのID
+                }/liked-users` // いいねしたユーザーの名前一覧を取得するためのエンドポイント
+            );
+            likedUsers.value = response.data; // 取得したユーザーの名前一覧を格納
+            console.log("取得したユーザー:", likedUsers.value); // デバッグ用
+        } catch (error) {
             console.error("いいねしたユーザーの取得に失敗しました:", error);
         }
     }, tooltipDelay); // ツールチップ表示の遅延時間
@@ -72,7 +82,7 @@ const fetchLikedUsers = async () => {
 </script>
 
 <template>
-    <div class="relative" @mouseleave="likedUsers = []">
+    <div class="relative" @mouseout="clearTooltip">
         <button
             @click="toggleLike"
             @mouseover="fetchLikedUsers"

--- a/resources/js/Components/LikeButton.vue
+++ b/resources/js/Components/LikeButton.vue
@@ -28,6 +28,8 @@ const props = defineProps({
 const isLiked = ref(props.initialIsLiked); // いいねの状態
 const likeCount = ref(props.initialLikeCount); // いいねの数
 const likedUsers = ref([]); // いいねしたユーザーの名前一覧
+const hoverTimeout = ref(null); // マウスオーバー時のタイムアウト
+const tooltipDelay = 1000; // ツールチップ表示の遅延時間
 
 // いいねのトグル
 const toggleLike = async () => {
@@ -49,9 +51,12 @@ const toggleLike = async () => {
 // いいねしたユーザーの名前一覧を取得
 const fetchLikedUsers = async () => {
     console.log("fetchLikedUsers が実行されました！"); // デバッグ用
-    try {
-        // いいねしたユーザーの名前一覧を取得
-        const response = await axios.get(
+
+    // マウスオーバーで遅延して表示
+    hoverTimeout.value = setTimeout(async () => {
+        try {
+            // いいねしたユーザーの名前一覧を取得
+            const response = await axios.get(
             // モデル名を小文字に変換
             `/api/${props.likeableType.toLowerCase()}s/${
                 props.likeableId // モデルのID
@@ -60,8 +65,9 @@ const fetchLikedUsers = async () => {
         likedUsers.value = response.data; // 取得したユーザーの名前一覧を格納
         console.log("取得したユーザー:", likedUsers.value); // デバッグ用
     } catch (error) {
-        console.error("いいねしたユーザーの取得に失敗しました:", error);
-    }
+            console.error("いいねしたユーザーの取得に失敗しました:", error);
+        }
+    }, tooltipDelay); // ツールチップ表示の遅延時間
 };
 </script>
 

--- a/resources/js/Components/LikeButton.vue
+++ b/resources/js/Components/LikeButton.vue
@@ -29,7 +29,7 @@ const isLiked = ref(props.initialIsLiked); // いいねの状態
 const likeCount = ref(props.initialLikeCount); // いいねの数
 const likedUsers = ref([]); // いいねしたユーザーの名前一覧
 const hoverTimeout = ref(null); // マウスオーバー時のタイムアウト
-const tooltipDelay = 1000; // ツールチップ表示の遅延時間
+const tooltipDelay = 500; // ツールチップ表示の遅延時間
 
 // ツールチップをクリア
 const clearTooltip = () => {

--- a/resources/js/Components/LikeButton.vue
+++ b/resources/js/Components/LikeButton.vue
@@ -3,19 +3,23 @@ import axios from "axios";
 import { ref } from "vue";
 
 const props = defineProps({
-    likeableId: { // モデルのID
+    likeableId: {
+        // モデルのID
         type: Number,
         required: true,
     },
-    likeableType: { // モデル名
+    likeableType: {
+        // モデル名
         type: String,
         required: true, // 'Post'または'Comment'を指定
     },
-    initialLikeCount: { // いいねの数
+    initialLikeCount: {
+        // いいねの数
         type: Number,
         default: 0,
     },
-    initialIsLiked: { // いいねの状態
+    initialIsLiked: {
+        // いいねの状態
         type: Boolean,
         default: false,
     },
@@ -25,7 +29,8 @@ const isLiked = ref(props.initialIsLiked); // いいねの状態
 const likeCount = ref(props.initialLikeCount); // いいねの数
 const likedUsers = ref([]); // いいねしたユーザーの名前一覧
 
-const toggleLike = async () => { // いいねのトグル
+// いいねのトグル
+const toggleLike = async () => {
     isLiked.value = !isLiked.value; // いいねの状態をトグル
     likeCount.value += isLiked.value ? 1 : -1; // いいねの数を更新
 
@@ -37,16 +42,18 @@ const toggleLike = async () => { // いいねのトグル
     } catch (error) {
         isLiked.value = !isLiked.value; // いいねの状態をトグル
         likeCount.value += isLiked.value ? 1 : -1; // いいねの数を更新
-        console.error("いいねのトグルに失敗しました:", error); // エラーメッセージを出力
+        console.error("いいねのトグルに失敗しました:", error);
     }
 };
 
 // いいねしたユーザーの名前一覧を取得
-const fetchLikedUsers = async () => { // マウスオーバー時に実行
+const fetchLikedUsers = async () => {
     console.log("fetchLikedUsers が実行されました！"); // デバッグ用
     try {
-        const response = await axios.get( // いいねしたユーザーの名前一覧を取得
-            `/api/${props.likeableType.toLowerCase()}s/${ // モデル名を小文字に変換
+        // いいねしたユーザーの名前一覧を取得
+        const response = await axios.get(
+            // モデル名を小文字に変換
+            `/api/${props.likeableType.toLowerCase()}s/${
                 props.likeableId // モデルのID
             }/liked-users` // いいねしたユーザーの名前一覧を取得するためのエンドポイント
         );
@@ -76,12 +83,8 @@ const fetchLikedUsers = async () => { // マウスオーバー時に実行
             class="absolute bg-white border border-gray-300 rounded-md shadow-lg p-2 max-h-40 overflow-y-auto z-50 mt-2 w-48 transition-opacity duration-200"
         >
             <ul class="text-sm text-gray-700">
-                <li
-                    v-for="user in likedUsers"
-                    :key="user"
-                    class="py-1 px-2 hover:bg-gray-100 rounded-md"
-                >
-                    {{ user }}
+                <li class="py-1 px-2 hover:bg-gray-100 rounded-md">
+                    {{ likedUsers.join(", ") }} がいいねしました！
                 </li>
             </ul>
         </div>

--- a/routes/api.php
+++ b/routes/api.php
@@ -7,3 +7,5 @@ use App\Http\Controllers\LikeController;
 Route::get('/user', function (Request $request) {
     return $request->user();
 })->middleware('auth:sanctum');
+
+Route::get('/{type}/{id}/liked-users', [LikeController::class, 'getLikedUsers']);


### PR DESCRIPTION
## 目的

特定の投稿やコメントに対して「いいね」をしたユーザーの一覧を視覚的に表示し、ユーザー間の交流を促進するため。また、ツールチップの表示形式と遅延時間を改善し、使いやすくすること。

## 達成条件

- いいねボタンにマウスオーバーした際、いいねしたユーザーの一覧がツールチップで表示されること。
- APIエンドポイントから取得したデータが正しく反映されること。
- ツールチップの表示形式がカンマ区切りの文字列であること。
- ツールチップの表示に適切な遅延が設定されていること。
- ツールチップが意図せず表示され続ける問題が解消されていること。

## 実装の概要

1. **APIエンドポイントの追加**

   - LikeControllerに、いいねしたユーザー一覧を取得するためのAPIエンドポイント `/api/{type}/{id}/liked-users` を追加。

2. **いいねモデルの拡張**

   - ポリモーフィックリレーションを追加し、いいねした対象（投稿やコメントなど）とユーザー情報を取得できるように。
   - `likeable` メソッドで対象モデルを、`user` メソッドでユーザー情報を取得。

3. **Userモデルの修正**

   - Userモデルに `likes` メソッドを追加し、ユーザーが行ったいいねの一覧を取得可能に。

4. **ツールチップの表示形式の改善**

   - ツールチップで表示されるいいねしたユーザー名の形式を配列表示からカンマ区切りの文字列に変更。
   - 具体的には、 `["管理者", "Guest"]` のような配列形式を `.join(", ")` を使用して `管理者, Guest がいいねしました！` の形式に改善。

5. **ツールチップ表示に遅延を追加**

   - ツールチップが即座に表示されないように、 `setTimeout` を用いて表示までの遅延時間（500ms）を設定。
   - ユーザーの誤操作や頻繁なAPIリクエストを防止。

6. **ツールチップが意図せず表示され続ける問題を修正**

   - いいねボタンにマウスオーバーした後、ツールチップが表示される前にカーソルを外してもツールチップが表示される問題を解消。
   - `mouseleave` を `mouseout` に変更し、 `clearTooltip` 関数でタイムアウトのクリアとツールチップの非表示処理を追加。

7. **ツールチップ表示の遅延時間を調整**

   - ツールチップの表示が遅く感じられたため、表示の遅延時間を 1000ms から 500ms に短縮。

## レビューしてほしいところ

- ポリモーフィックリレーションの設計が適切かどうか。
- LikeButton.vue でのツールチップの表示処理が効率的か。
- 非同期処理やエラー処理が適切に行われているか。
- ツールチップの表示形式と遅延時間が適切かどうか。

## 不安に思っていること

- ユーザー数が増えた場合、ツールチップの表示速度やAPIの負荷が懸念される。
- `setTimeout` による遅延表示のタイミングが適切かどうか。

## 保留していること

- いいねしたユーザーが多い場合のスクロール対応や、最大表示件数の設定。
- ツールチップのアニメーション効果（ふわっと表示/非表示）は、挙動に不具合が見られたため見送りました。