### PR TITLE
サイドバー表示時のスクロール制御の追加

### DIFF
--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -104,7 +104,8 @@ const onUserSelected = (user) => {
 // ユニット選択イベント
 const onForumSelected = async (unitId) => {
     const unit = units.value.find((u) => u.id === unitId); // 選択されたユニットを取得
-    if (!unit || !unit.forum) { // ユニットが見つからないか、掲示板が見つからない場合
+    // ユニットが見つからないか、掲示板が見つからない場合
+    if (!unit || !unit.forum) {
         console.error("対応する掲示板が見つかりませんでした");
         return; // 処理を中断
     }
@@ -126,6 +127,8 @@ const onForumSelected = async (unitId) => {
     router.get(route("forum.index", { forum_id: selectedForumId.value }), {
         preserveState: false, // ページの状態を保持しない
     });
+
+    document.body.classList.remove("no-scroll"); // 掲示版切り替え時にもボディのスクロールを許可
 };
 
 const onPageChange = (url) => {

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -86,6 +86,15 @@ watch(selectedForumId, (newForumId) => {
     fetchPostsByForumId(router, newForumId);
 });
 
+// サイドバーの表示状態を監視し、変更があるたびにボディのスクロールを禁止
+watch(sidebarVisible, (newVisible) => {
+    if (newVisible) {
+        document.body.classList.add("no-scroll");
+    } else {
+        document.body.classList.remove("no-scroll");
+    }
+});
+
 // サイドバーのユーザー選択イベントを受け取る関数
 const onUserSelected = (user) => {
     selectedPost.value = { user }; // `selectedPost`に選択したユーザーをセット
@@ -634,6 +643,11 @@ const openModal = (imageSrc) => {
 </template>
 
 <style>
+/* サイドバーが表示されている場合、ボディのスクロールを禁止 */
+body.no-scroll {
+    overflow: hidden;
+}
+
 /* モバイルサイズ用のスタイル（切り替え可能） */
 @media (max-width: 767px) {
     .sidebar-mobile {

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -89,9 +89,9 @@ watch(selectedForumId, (newForumId) => {
 // サイドバーの表示状態を監視し、変更があるたびにボディのスクロールを禁止
 watch(sidebarVisible, (newVisible) => {
     if (newVisible) {
-        document.body.classList.add("no-scroll");
+        document.body.classList.add("no-scroll"); // ボディのスクロールを禁止
     } else {
-        document.body.classList.remove("no-scroll");
+        document.body.classList.remove("no-scroll"); // ボディのスクロールを許可
     }
 });
 
@@ -103,10 +103,10 @@ const onUserSelected = (user) => {
 
 // ユニット選択イベント
 const onForumSelected = async (unitId) => {
-    const unit = units.value.find((u) => u.id === unitId);
-    if (!unit || !unit.forum) {
+    const unit = units.value.find((u) => u.id === unitId); // 選択されたユニットを取得
+    if (!unit || !unit.forum) { // ユニットが見つからないか、掲示板が見つからない場合
         console.error("対応する掲示板が見つかりませんでした");
-        return;
+        return; // 処理を中断
     }
 
     // users が配列であることを確認しつつフィルタリング
@@ -114,16 +114,17 @@ const onForumSelected = async (unitId) => {
         ? users.value.filter((user) => user.unit_id === unitId)
         : [];
 
-    selectedForumId.value = unit.forum.id;
-    selectedUnitName.value = unit.name;
-    selectedUnitUsers.value = filteredUsers;
+    selectedForumId.value = unit.forum.id; // 選択された掲示板のIDをセット
+    selectedUnitName.value = unit.name; // 選択されたユニットの名前をセット
+    selectedUnitUsers.value = filteredUsers; // 選択されたユニットのユーザーリストをセット
 
-    sessionStorage.setItem("selectedUnitName", selectedUnitName.value);
+    sessionStorage.setItem("selectedUnitName", selectedUnitName.value); // 選択されたユニットの名前をセット
     sessionStorage.setItem("selectedUnitUsers", JSON.stringify(filteredUsers));
     localStorage.setItem("lastSelectedUnitId", unitId);
 
+    // 掲示板のページをリロード
     router.get(route("forum.index", { forum_id: selectedForumId.value }), {
-        preserveState: false,
+        preserveState: false, // ページの状態を保持しない
     });
 };
 


### PR DESCRIPTION
## **目的**

- サイドバーが開いている間にページがスクロールできてしまう問題を修正する
- 掲示板を切り替えた際にスクロールができなくなる問題を解消する

***

## **達成条件**

- **サイドバーを開いたとき** に `body` に `no-scroll` クラスが追加され、ページ全体のスクロールが無効化されること
- **サイドバーを閉じたとき** に `no-scroll` クラスが削除され、スクロールが復活すること
- **掲示板を切り替えたとき** にも `no-scroll` クラスが削除され、スクロールが可能になること

***

## **実装の概要**

1. **サイドバー表示時にスクロールを禁止する処理を追加**

   - `watch(sidebarVisible, ...)` を使用し、`sidebarVisible` の変更に応じて `document.body.classList.add("no-scroll")` または `document.body.classList.remove("no-scroll")` を実行するよう修正。

2. **掲示板切り替え後にスクロールができなくなる問題を修正**

   - `onForumSelected` 内で `document.body.classList.remove("no-scroll")` を実行し、掲示板を切り替えた後に確実にスクロールができるようにした。
   - `watch` に `selectedForumId` を含める方法も検討したが、`onForumSelected` 内で直接 `no-scroll` を解除するほうがシンプルで確実なため採用を見送った。

3. **サイドバーのスクロール制御とユニット選択処理のコメントを追加**

   - 読みやすさ向上のため、スクロール制御処理やユニット選択処理の各所にコメントを追加。

***

## **レビューしてほしいところ**

- `onForumSelected` 内で `document.body.classList.remove("no-scroll")` を実行する方法は適切か？
- サイドバーのスクロール制御処理 (`watch(sidebarVisible, ...)`) に問題はないか？
- 他に考慮すべき副作用がないか？

***

## **不安に思っていること**

- サイドバーの開閉時の `watch` の影響で、他の機能に意図しない影響を与えていないか？
- `onForumSelected` で `document.body.classList.remove("no-scroll")` を実行する方法が、今後の拡張性に影響しないか？

***

## **保留していること**

- `watch` に `selectedForumId` を含める方法は、将来的に他の状態変更との関連を考慮する必要がある場合に再検討する可能性あり。
- 既存のスクロール制御の影響を受ける他の処理があれば、別の PR で調整予定。
