### PR TITLE
引用元の投稿の改行保持と長文の省略表示対応

### DIFF
--- a/resources/js/Components/QuotePostForm.vue
+++ b/resources/js/Components/QuotePostForm.vue
@@ -115,7 +115,7 @@ const submitQuotePost = () => {
                 <h3 class="text-sm font-semibold text-gray-700">
                     引用元の投稿
                 </h3>
-                <p class="text-gray-600">{{ quotedPost.message }}</p>
+                <p class="text-gray-600 whitespace-pre-wrap">{{ quotedPost.message }}</p>
             </div>
 
             <!-- 新しい投稿の入力フォーム -->

--- a/resources/js/Components/QuotePostForm.vue
+++ b/resources/js/Components/QuotePostForm.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref } from "vue";
+import { ref, computed } from "vue";
 import { router } from "@inertiajs/vue3";
 import { handleImageChange } from "@/Utils/imageHandler";
 import ImageModal from "./ImageModal.vue";
@@ -102,6 +102,16 @@ const submitQuotePost = () => {
         },
     });
 };
+
+// 引用投稿元のプレビュー表示時の最大表示文字数
+const maxPreviewLength = 100;
+
+// 引用投稿元のプレビュー表示時の最大表示文字数を超えた場合、省略表示
+const truncatedMessage = computed(() => {
+    return props.quotedPost?.message.length > maxPreviewLength
+        ? props.quotedPost.message.slice(0, maxPreviewLength) + "..."
+        : props.quotedPost.message;
+});
 </script>
 
 <template>
@@ -115,7 +125,9 @@ const submitQuotePost = () => {
                 <h3 class="text-sm font-semibold text-gray-700">
                     引用元の投稿
                 </h3>
-                <p class="text-gray-600 whitespace-pre-wrap">{{ quotedPost.message }}</p>
+                <p class="text-gray-600 whitespace-pre-wrap">
+                    {{ truncatedMessage }}
+                </p>
             </div>
 
             <!-- 新しい投稿の入力フォーム -->


### PR DESCRIPTION
## 目的

引用元の投稿のメッセージが以下の問題を抱えていたため、改善しました。

1. **改行が保持されない** → 可読性が低下する。
2. **長文の場合、UIの下部が隠れる** → 送信ボタンなどが見えなくなる可能性がある。

## 達成条件

- 引用元の投稿のメッセージが改行を保持すること。
- 長文の引用投稿をプレビュー表示する際、100文字を超えた場合に「...」で省略されること。
- UIのレイアウトが崩れず、送信ボタンが正常に表示されること。

## 実装の概要

- `whitespace-pre-wrap` クラスを追加し、引用元の投稿のメッセージが改行を保持するように修正。
- Vueの`computed`を利用し、100文字を超える引用投稿のメッセージを省略表示する処理を追加。

## レビューしてほしいところ

- `truncatedMessage` のロジックに不備がないか。
- UIの見た目に違和感がないか（特に省略表示の動作）。
- 可読性やパフォーマンスに問題がないか。

## 不安に思っていること

- 省略表示の上限（100文字）は適切かどうか。
- 引用元の投稿が極端に短い場合でも、意図しない表示崩れが発生しないか。

## 保留していること

- 「続きを読む」ボタンの実装は、現時点では見送ったが、必要であれば後続対応として検討。
- 引用元をクリックすることで、引用元の投稿に飛べる機能は将来的に導入したい。
