### PR TITLE
部署一覧の並び順を `sort_order` 順に修正

### DIFF
--- a/app/Http/Controllers/ResidentController.php
+++ b/app/Http/Controllers/ResidentController.php
@@ -23,7 +23,7 @@ class ResidentController extends Controller
 
         return Inertia::render('Residents/Index', [
             'residents' => $residents,
-            'units' => Unit::all(),
+            'units' => Unit::where('tenant_id', auth()->user()->tenant_id)->orderBy('sort_order')->get(),
             'selectedUnitId' => $unitId,
             'isAdmin' => auth()->user()->hasRole('admin'),
         ]);

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -18,7 +18,7 @@ class UserController extends Controller
     $tenantId = auth()->user()->tenant_id;  // 現在のユーザーのテナントIDを取得
 
     $users = User::where('tenant_id', $tenantId)->get();  // テナントIDでユーザーを絞り込み
-    $units = Unit::where('tenant_id', $tenantId)->get();  // ユニットも同様にフィルタリング
+    $units = Unit::where('tenant_id', $tenantId)->orderBy('sort_order')->get(); // 並び順を保存
     
     // 管理者ユーザーを取得
     $currentAdmin = User::role('admin')


### PR DESCRIPTION
## 目的

ユーザー一覧ページおよび利用者一覧ページの部署プルダウンにおいて、ドラッグ＆ドロップで並び替えた順番（`sort_order`順）が正しく反映されるようにすること。

## 達成条件

- ユーザー一覧ページの部署プルダウンが `sort_order`順で表示されること

- 利用者一覧ページの部署プルダウンが `sort_order`順で表示されること

## 実装の概要

- ユーザー一覧ページでの `units` 取得時に `orderBy('sort_order')` を追加

- 利用者一覧ページでの `units` 取得時に `orderBy('sort_order')` を追加

## レビューしてほしいところ

- `orderBy('sort_order')` の記述位置に問題がないか

- 他の影響範囲（別ページでの `units` 表示など）に問題がないか

## 不安に思っていること

特にありませんが、もし他ページでも `units` を取得・表示しており、並び順の仕様が異なる場合はご指摘いただけると助かります。

## 保留していること

現時点では特にありません。