### PR TITLE
`activeUnitId`の初期化ロジック変更および各処理へのコメント追加による可読性・保守性向上対応

### DIFF
--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -53,11 +53,13 @@ const activeUnitId = ref(null); // 選択中の部署IDを管理
 const isModalOpen = ref(false); // モーダル表示
 const currentImage = ref(null); // 現在の画像を保持
 
+// 引用投稿フォームを表示する関数
 const quotePost = (post) => {
     quotedPost.value = post; // post全体をセットする
     showPostForm.value = true;
 };
 
+// マウント時の処理
 onMounted(() => {
     initSelectedForumId(selectedForumId);
     restoreSelectedUnit(selectedUnitUsers, selectedUnitName);
@@ -131,6 +133,7 @@ const onForumSelected = async (unitId) => {
     document.body.classList.remove("no-scroll"); // 掲示版切り替え時にもボディのスクロールを許可
 };
 
+// ページネーションの変更
 const onPageChange = (url) => {
     router.get(url, {
         preserveScroll: true,
@@ -139,15 +142,18 @@ const onPageChange = (url) => {
     });
 };
 
+// ユーザーの詳細ページを表示
 const openUserProfile = (post) => {
     selectedPost.value = post;
     isUserProfileVisible.value = true; // ユーザーの詳細ページを表示
 };
 
+// ユーザーの詳細ページを閉じる
 const closeUserProfile = () => {
     isUserProfileVisible.value = false;
 };
 
+// サイドバーの表示・非表示を切り替える関数
 const toggleSidebar = () => {
     sidebarVisible.value = !sidebarVisible.value;
 };
@@ -161,6 +167,7 @@ const toggleCommentForm = (postId, parentId = "post", replyToName = "") => {
         commentFormVisibility.value[postId] = {};
     }
 
+    // コメントフォームの表示・非表示を切り替える関数
     if (!commentFormVisibility.value[postId][parentId]) {
         commentFormVisibility.value[postId][parentId] = {
             isVisible: false,
@@ -177,8 +184,10 @@ const toggleCommentForm = (postId, parentId = "post", replyToName = "") => {
     commentFormVisibility.value = { ...commentFormVisibility.value };
 };
 
+// カスタムダイアログを使用
 const dialog = useDialog();
 
+// 投稿の削除を処理する関数
 const onDeleteItem = async (type, id) => {
     const confirmMessage =
         type === "post"
@@ -237,6 +246,7 @@ const handleCommentDeletion = (commentId) => {
         findCommentRecursive(post.comments, commentId)
     );
 
+    // コメントが見つかった場合
     if (postIndex !== -1) {
         const comments = posts.value.data[postIndex].comments;
 
@@ -276,6 +286,7 @@ const isCommentAuthor = (comment) => {
     return auth.user && comment.user && auth.user.id === comment.user.id;
 };
 
+// ユニット選択イベント
 const handleForumSelected = (unitId) => {
     activeUnitId.value = unitId; // 選択された部署IDを保存
     localStorage.setItem("lastSelectedUnitId", unitId); // ローカルストレージに保存

--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -61,24 +61,28 @@ const quotePost = (post) => {
 
 // マウント時の処理
 onMounted(() => {
-    initSelectedForumId(selectedForumId);
-    restoreSelectedUnit(selectedUnitUsers, selectedUnitName);
+    initSelectedForumId(selectedForumId); // 選択された掲示板のIDを初期化
+    restoreSelectedUnit(selectedUnitUsers, selectedUnitName); // 選択されたユニットのユーザーリストと名前を復元
 
-    // URLパラメータからactive_unit_idを取得
-    const urlParams = new URLSearchParams(window.location.search);
-    const urlUnitId = urlParams.get("active_unit_id");
-
-    if (urlUnitId) {
-        // URLパラメータがある場合はそれを優先
-        activeUnitId.value = parseInt(urlUnitId);
-        localStorage.setItem("lastSelectedUnitId", urlUnitId);
+    // ユーザーのunit_idを優先的に使用
+    if (auth.user.unit_id) {
+        activeUnitId.value = auth.user.unit_id; // ユーザーのunit_idをセット
+        localStorage.setItem("lastSelectedUnitId", auth.user.unit_id); // ローカルストレージに保存
     } else {
-        // URLパラメータがない場合は既存のロジックを使用
-        const savedUnitId = localStorage.getItem("lastSelectedUnitId");
-        if (savedUnitId) {
-            activeUnitId.value = parseInt(savedUnitId);
-        } else if (auth.user.unit_id) {
-            activeUnitId.value = auth.user.unit_id;
+        // URLパラメータから取得
+        const urlParams = new URLSearchParams(window.location.search); // URLパラメータを取得
+        const urlUnitId = urlParams.get("active_unit_id"); // URLパラメータからactive_unit_idを取得
+
+        // URLパラメータがある場合はそれを優先
+        if (urlUnitId) {
+            activeUnitId.value = parseInt(urlUnitId); // URLパラメータから取得したunit_idをセット
+            localStorage.setItem("lastSelectedUnitId", urlUnitId); // ローカルストレージに保存
+        } else {
+            // localStorageから取得
+            const savedUnitId = localStorage.getItem("lastSelectedUnitId"); // ローカルストレージから取得
+            if (savedUnitId) {
+                activeUnitId.value = parseInt(savedUnitId); // ローカルストレージから取得したunit_idをセット
+            }
         }
     }
 });


### PR DESCRIPTION
## 目的

ユーザー操作や画面制御処理の可読性と保守性を高めるとともに、プロフィール情報の更新後に掲示板画面のユニット表示が正しく行われるようにすることを目的としています。

***

## 達成条件

- ユーザーのプロフィール更新処理およびアカウント削除処理にわかりやすいコメントが追加されている

- Forumページの各種操作関数（モーダル、ユーザー詳細、サイドバー、ページネーション等）に適切な説明コメントが追加されている

- `activeUnitId` の初期化ロジックが `auth.user.unit_id` を最優先し、それがない場合に限りURLパラメータやlocalStorageを参照する仕様になっている

- プロフィール更新後、掲示板画面でサイドバーが正しい部署を表示できる

***

## 実装の概要

- プロフィール更新処理およびアカウント削除処理の各関数に、処理内容を明確にするためのコメントを追加

- Forumページ内の各ユーザー操作関連関数（モーダル表示、ユーザー詳細、サイドバー制御、ページネーションなど）に処理概要を示すコメントを追加

- `activeUnitId` の初期化処理を整理し、`auth.user.unit_id` を最優先として使用するよう変更。`unit_id` が存在しない場合のみ、URLパラメータ → ローカルストレージの順にフォールバックするように修正

***

## レビューしてほしいところ

- コメントの表現や位置が適切か（過不足がないか）

- `activeUnitId` 初期化ロジックの分岐構成が明確で、想定通りの挙動になるか

- 他の画面・機能への影響がないか（特に掲示板遷移やユニット選択部分）

***

## 不安に思っていること

- `auth.user.unit_id` を最優先にしたことで、特定ケースでURLパラメータが意図的に使われていた処理を上書きしてしまう可能性がないか少し気になっています。

***

## 保留していること

- 今回はコメントの追加と初期化ロジックの整理に絞って対応しており、ユニット選択UIやその反映タイミングなど、UI全体の改善は別タスクで検討中です。