### PR TITLE
ユニット選択ロジックをURLパラメータ優先に戻し、サイドバー表示の不整合を修正

### DIFF
--- a/resources/js/Pages/Forum.vue
+++ b/resources/js/Pages/Forum.vue
@@ -61,28 +61,24 @@ const quotePost = (post) => {
 
 // マウント時の処理
 onMounted(() => {
-    initSelectedForumId(selectedForumId); // 選択された掲示板のIDを初期化
-    restoreSelectedUnit(selectedUnitUsers, selectedUnitName); // 選択されたユニットのユーザーリストと名前を復元
+    initSelectedForumId(selectedForumId);
+    restoreSelectedUnit(selectedUnitUsers, selectedUnitName);
 
-    // ユーザーのunit_idを優先的に使用
-    if (auth.user.unit_id) {
-        activeUnitId.value = auth.user.unit_id; // ユーザーのunit_idをセット
-        localStorage.setItem("lastSelectedUnitId", auth.user.unit_id); // ローカルストレージに保存
-    } else {
-        // URLパラメータから取得
-        const urlParams = new URLSearchParams(window.location.search); // URLパラメータを取得
-        const urlUnitId = urlParams.get("active_unit_id"); // URLパラメータからactive_unit_idを取得
+    // URLパラメータからactive_unit_idを取得
+    const urlParams = new URLSearchParams(window.location.search);
+    const urlUnitId = urlParams.get("active_unit_id");
 
+    if (urlUnitId) {
         // URLパラメータがある場合はそれを優先
-        if (urlUnitId) {
-            activeUnitId.value = parseInt(urlUnitId); // URLパラメータから取得したunit_idをセット
-            localStorage.setItem("lastSelectedUnitId", urlUnitId); // ローカルストレージに保存
-        } else {
-            // localStorageから取得
-            const savedUnitId = localStorage.getItem("lastSelectedUnitId"); // ローカルストレージから取得
-            if (savedUnitId) {
-                activeUnitId.value = parseInt(savedUnitId); // ローカルストレージから取得したunit_idをセット
-            }
+        activeUnitId.value = parseInt(urlUnitId);
+        localStorage.setItem("lastSelectedUnitId", urlUnitId);
+    } else {
+        // URLパラメータがない場合は既存のロジックを使用
+        const savedUnitId = localStorage.getItem("lastSelectedUnitId");
+        if (savedUnitId) {
+            activeUnitId.value = parseInt(savedUnitId);
+        } else if (auth.user.unit_id) {
+            activeUnitId.value = auth.user.unit_id;
         }
     }
 });


### PR DESCRIPTION
## 目的

前回の対応（[PR #138](https://github.com/shotasato0/CommuniCareV2/pull/138)）にて `auth.user.unit_id` を優先するロジックへ変更しましたが、その結果、左サイドバーのユニット選択がカレントフォーラムと連動しなくなり、右サイドバーに表示される職員もログインユーザーの所属部署基準で表示される問題が発生しました。  
今回の修正では、URLパラメータを優先する元のロジックに戻すことで、画面表示と実際の掲示板内容が一致する状態に整え、ユーザーの混乱を防ぐことを目的としています。

## 達成条件

- 左サイドバーのユニット選択がカレントフォーラムと一致している

- 右サイドバーに、カレントフォーラムに所属する職員が表示されている

- `auth.user.unit_id` に関わらず、URLパラメータに基づいたユニット情報が優先される

## 実装の概要

- `activeUnitId` の初期化ロジックを、`auth.user.unit_id` を優先する形から、URLパラメータ → ローカルストレージ → `auth.user.unit_id` の順で参照するロジックへと戻しました。

- これにより、掲示板URLに対応したユニットが優先的に選択され、サイドバー表示との不整合を解消しました。

なお、前回の対応では「プロフィール更新後にもユニットが正しく表示される」などの課題に対処する意図がありましたが、今回のロジックではそれらの意図とトレードオフになる可能性があるため、今後はユースケースごとの表示優先ロジックを整理する必要があります。

## レビューしてほしいところ

- カレントフォーラムのユニットとサイドバー表示が一致しているか

- カレントユニットの切り替えに伴って表示される職員が正しいか

- 既存のユニット選択UIとの整合性が取れているか

## 不安に思っていること

- 再度URLパラメータ優先に戻したことで、プロフィール更新直後など、別の箇所でユニット表示に影響が出ないか懸念があります。

## 保留していること

- 今後の改善として、ユースケース（プロフィール画面／掲示板／新規作成など）ごとにユニット選択ロジックを切り替える必要性の検討

- ユニット選択UIと反映タイミングの整理、及びユーザーにとって直感的な挙動の設計は別タスクで対応予定です

- 前回の対応によって実現されていた「プロフィール更新後に掲示板画面でサイドバーが正しい部署を表示できる」挙動が、今回の修正により失われています。一方で、今回修正した「カレントフォーラムとサイドバーの連動」「表示職員の不整合」も重要な課題であり、**両方の要件を両立できる実装方針の検討**が今後の課題です。