### PR TITLE
管理者専用メニューのダークモード対応

### DIFF
--- a/resources/js/Components/ChildComment.vue
+++ b/resources/js/Components/ChildComment.vue
@@ -90,7 +90,7 @@ const openModal = (imagePath) => {
                                 comment.user?.name || 'Unknown'
                             )
                         "
-                        class="px-4 py-2 rounded-md bg-green-100 dark:bg-green-800 text-green-700 dark:text-green-300 transition hover:bg-green-300 dark:hover:bg-green-600 hover:text-white cursor-pointer flex items-center"
+                        class="px-4 py-2 rounded-md bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-100 transition hover:bg-green-300 dark:hover:bg-green-600 hover:text-white cursor-pointer flex items-center"
                         title="返信"
                     >
                         <i class="bi bi-reply"></i>

--- a/resources/js/Components/CustomDialog.vue
+++ b/resources/js/Components/CustomDialog.vue
@@ -18,7 +18,7 @@
                 <button
                     v-if="showProfileLink"
                     @click="goToProfile"
-                    class="w-40 bg-green-100 dark:bg-green-800 text-green-700 dark:text-green-300 font-medium py-2 px-4 rounded-md transition hover:bg-green-300 dark:hover:bg-green-600 hover:text-white focus:outline-none focus:shadow-outline"
+                    class="w-40 bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-100 font-medium py-2 px-4 rounded-md transition hover:bg-green-300 dark:hover:bg-green-600 hover:text-white focus:outline-none focus:shadow-outline"
                 >
                     アカウント情報へ
                 </button>

--- a/resources/js/Components/LikeButton.vue
+++ b/resources/js/Components/LikeButton.vue
@@ -102,7 +102,8 @@ const fetchLikedUsers = async () => {
         <button
             @click="toggleLike"
             @mouseover="!isMobile ? fetchLikedUsers() : null"
-            :class="{ 'text-red-500': isLiked }"
+            :class="{ 'text-red-500 dark:text-red-400': isLiked, 'text-gray-600 dark:text-gray-300': !isLiked }"
+            class="transition-colors duration-200 hover:text-red-500 dark:hover:text-red-400"
         >
             <i v-if="isLiked" class="bi bi-heart-fill"></i>
             <i v-else class="bi bi-heart"></i>
@@ -113,7 +114,7 @@ const fetchLikedUsers = async () => {
         <button
             v-if="isMobile"
             @click="fetchLikedUsers"
-            class="ml-2 text-gray-500"
+            class="ml-2 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors duration-200"
         >
             ...
         </button>
@@ -121,10 +122,10 @@ const fetchLikedUsers = async () => {
         <!-- ツールチップ表示 -->
         <div
             v-if="likedUsers.length"
-            class="absolute bg-white border border-gray-300 rounded-md shadow-lg p-2 max-h-40 overflow-y-auto z-50 mt-2 w-48 transition-opacity duration-200"
+            class="absolute bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md shadow-lg p-2 max-h-40 overflow-y-auto z-50 mt-2 w-48 transition-opacity duration-200"
         >
-            <ul class="text-sm text-gray-700">
-                <li class="py-1 px-2 hover:bg-gray-100 rounded-md">
+            <ul class="text-sm text-gray-700 dark:text-gray-300">
+                <li class="py-1 px-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md transition-colors duration-200">
                     {{ likedUsers.join(", ") }} がいいねしました！
                 </li>
             </ul>

--- a/resources/js/Components/LikeButton.vue
+++ b/resources/js/Components/LikeButton.vue
@@ -31,16 +31,20 @@ const likedUsers = ref([]); // いいねしたユーザーの名前一覧
 const hoverTimeout = ref(null); // マウスオーバー時のタイムアウト
 const tooltipDelay = 500; // ツールチップ表示の遅延時間
 
-// デバイスサイズを判断するための定数
-const mediaQuery = window.matchMedia("(max-width: 1024px)");
+// デバイスサイズを判断するための定数（SSR対応）
+let mediaQuery = null;
+const isMobile = ref(false); // 初期値はfalse（デスクトップ前提）
 
-// 初回のサイズ判定
-const isMobile = ref(mediaQuery.matches);
+// ブラウザ環境でのみ初期化
+if (typeof window !== 'undefined' && window.matchMedia) {
+    mediaQuery = window.matchMedia("(max-width: 1024px)");
+    isMobile.value = mediaQuery.matches;
 
-// ウィンドウの幅が変更された時にモバイルかどうかを再判定
-mediaQuery.addEventListener("change", (event) => {
-    isMobile.value = event.matches;
-});
+    // ウィンドウの幅が変更された時にモバイルかどうかを再判定
+    mediaQuery.addEventListener("change", (event) => {
+        isMobile.value = event.matches;
+    });
+}
 
 // ツールチップをクリア
 const clearTooltip = () => {

--- a/resources/js/Components/ParentComment.vue
+++ b/resources/js/Components/ParentComment.vue
@@ -169,7 +169,7 @@ const getCommentCountRecursive = (comments) => {
                                 comment.user?.name || 'Unknown'
                             )
                         "
-                        class="px-4 py-2 rounded-md bg-green-100 dark:bg-green-800 text-green-700 dark:text-green-300 transition hover:bg-green-300 dark:hover:bg-green-600 hover:text-white cursor-pointer flex items-center"
+                        class="px-4 py-2 rounded-md bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-100 transition hover:bg-green-300 dark:hover:bg-green-600 hover:text-white cursor-pointer flex items-center"
                         title="返信"
                     >
                         <i class="bi bi-reply"></i>

--- a/resources/js/Pages/Admin/Dashboard.vue
+++ b/resources/js/Pages/Admin/Dashboard.vue
@@ -5,24 +5,24 @@ import { Link, Head } from "@inertiajs/vue3";
 <template>
     <Head :title="$t('Dashboard')" />
     <div class="max-w-6xl mx-auto py-10 px-4 sm:px-8 lg:px-16">
-        <h1 class="text-xl font-bold mb-6">
+        <h1 class="text-xl font-bold mb-6 text-gray-900 dark:text-gray-100">
             {{ $t("Admin Dashboard") }}
         </h1>
 
         <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
             <!-- 部署管理 -->
-            <div class="bg-white overflow-hidden shadow rounded-lg">
+            <div class="bg-white dark:bg-gray-800 overflow-hidden shadow rounded-lg">
                 <div class="px-4 py-5 sm:p-6">
-                    <h3 class="text-lg font-medium leading-6 text-gray-900">
+                    <h3 class="text-lg font-medium leading-6 text-gray-900 dark:text-gray-100">
                         {{ $t("Unit Management") }}
                     </h3>
-                    <p class="mt-2 max-w-4xl text-sm text-gray-500">
+                    <p class="mt-2 max-w-4xl text-sm text-gray-500 dark:text-gray-400">
                         {{ $t("Register or delete departments.") }}
                     </p>
                     <div class="mt-4">
                         <Link
                             :href="route('units.create')"
-                            class="text-blue-500 link-hover"
+                            class="text-blue-500 dark:text-blue-400 link-hover"
                             >{{ $t("Unit Management page") }}</Link
                         >
                     </div>

--- a/resources/js/Pages/Profile/Partials/IconEditForm.vue
+++ b/resources/js/Pages/Profile/Partials/IconEditForm.vue
@@ -96,7 +96,7 @@ const submit = () => {
             <!-- 成功メッセージ -->
             <div
                 v-if="localSuccessMessage"
-                class="bg-green-100 dark:bg-green-800 text-green-700 dark:text-green-200 p-3 mb-6 rounded"
+                class="bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-100 p-3 mb-6 rounded"
             >
                 {{ localSuccessMessage }}
             </div>

--- a/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
+++ b/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
@@ -97,7 +97,7 @@ const handleSuccessMessage = (message) => {
         >
             <div
                 v-if="isSuccess || successMessage"
-                class="bg-green-100 dark:bg-green-800 border-l-4 border-green-500 dark:border-green-400 text-green-700 dark:text-green-200 p-4 m-2 rounded fixed bottom-10 left-1/2 transform -translate-x-1/2 z-50 w-full max-w-md mx-auto sm:rounded-lg shadow-lg"
+                class="bg-green-100 dark:bg-green-900 border-l-4 border-green-500 dark:border-green-400 text-green-700 dark:text-green-100 p-4 m-2 rounded fixed bottom-10 left-1/2 transform -translate-x-1/2 z-50 w-full max-w-md mx-auto sm:rounded-lg shadow-lg"
             >
                 <p class="font-bold text-center">
                     {{ successMessage || $t("Saved.") }}

--- a/resources/js/Pages/Residents/Index.vue
+++ b/resources/js/Pages/Residents/Index.vue
@@ -230,7 +230,7 @@ const isAdmin = computed(() => page.props.isAdmin);
             <div
                 v-if="localFlashMessage && showFlashMessage"
                 :class="{
-                    'bg-green-100 dark:bg-green-800 border-l-4 border-green-500 dark:border-green-400 text-green-700 dark:text-green-200 p-4':
+                    'bg-green-100 dark:bg-green-900 border-l-4 border-green-500 dark:border-green-400 text-green-700 dark:text-green-100 p-4':
                         flashType === 'success',
                     'bg-red-100 dark:bg-red-800 border-l-4 border-red-500 dark:border-red-400 text-red-700 dark:text-red-200 p-4':
                         flashType === 'error',

--- a/resources/js/Pages/Residents/Show.vue
+++ b/resources/js/Pages/Residents/Show.vue
@@ -39,7 +39,7 @@ const flashType = computed(() => (flash.value.success ? "success" : "error"));
             <div
                 v-if="flashMessage && showFlashMessage"
                 :class="{
-                    'bg-green-100 dark:bg-green-800 border-l-4 border-green-500 dark:border-green-400 text-green-700 dark:text-green-200 p-4':
+                    'bg-green-100 dark:bg-green-900 border-l-4 border-green-500 dark:border-green-400 text-green-700 dark:text-green-100 p-4':
                         flashType === 'success',
                     'bg-red-100 dark:bg-red-800 border-l-4 border-red-500 dark:border-red-400 text-red-700 dark:text-red-200 p-4':
                         flashType === 'error',

--- a/resources/js/Pages/Unit/Register.vue
+++ b/resources/js/Pages/Unit/Register.vue
@@ -75,7 +75,7 @@ watchEffect(() => {
         />
 
         <template #header>
-            <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
                 {{ $t("Unit Management") }}
             </h2>
         </template>
@@ -87,35 +87,35 @@ watchEffect(() => {
             <transition name="fade">
                 <div
                     v-if="flashMessage"
-                    class="fixed bottom-10 left-1/2 transform -translate-x-1/2 w-full max-w-md bg-green-100 border-l-4 border-green-500 text-green-700 p-4 rounded shadow-lg z-50"
+                    class="fixed bottom-10 left-1/2 transform -translate-x-1/2 w-full max-w-md bg-green-100 dark:bg-green-800 border-l-4 border-green-500 dark:border-green-400 text-green-700 dark:text-green-200 p-4 rounded shadow-lg z-50"
                 >
                     <p class="font-bold text-center">{{ flashMessage }}</p>
                 </div>
             </transition>
 
-            <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
                 {{ $t("Unit Registration") }}
             </h2>
             <!-- 部署登録フォーム -->
             <form
                 @submit.prevent="submit"
-                class="bg-white p-6 rounded-lg shadow"
+                class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow"
             >
                 <div class="mb-4">
                     <label
                         for="name"
-                        class="block text-sm font-medium text-gray-700"
+                        class="block text-sm font-medium text-gray-700 dark:text-gray-300"
                         >{{ $t("Unit Name") }}</label
                     >
                     <input
                         type="text"
                         id="name"
                         v-model="form.name"
-                        class="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+                        class="mt-1 block w-full border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 rounded-md shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
                     />
                     <div
                         v-if="form.errors.name"
-                        class="text-red-600 text-sm mt-1"
+                        class="text-red-600 dark:text-red-400 text-sm mt-1"
                     >
                         {{ form.errors.name }}
                     </div>
@@ -123,27 +123,27 @@ watchEffect(() => {
 
                 <button
                     type="submit"
-                    class="w-full sm:w-auto px-4 py-2 bg-blue-100 text-blue-700 rounded-md transition hover:bg-blue-300 hover:text-white text-center"
+                    class="w-full sm:w-auto px-4 py-2 bg-blue-100 dark:bg-blue-800 text-blue-700 dark:text-blue-300 rounded-md transition hover:bg-blue-300 dark:hover:bg-blue-600 hover:text-white text-center"
                 >
                     {{ $t("Register Unit") }}
                 </button>
             </form>
 
-            <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
                 {{ $t("Unit List") }}
             </h2>
             <!-- 部署一覧 -->
-            <div class="bg-white p-6 rounded-lg shadow">
-                <ul class="divide-y divide-gray-200">
+            <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow">
+                <ul class="divide-y divide-gray-200 dark:divide-gray-600">
                     <li
                         v-for="unit in units"
                         :key="unit.id"
                         class="flex justify-between items-center py-4"
                     >
-                        <span class="text-gray-800">{{ unit.name }}</span>
+                        <span class="text-gray-800 dark:text-gray-200">{{ unit.name }}</span>
                         <button
                             @click="deleteUnit(unit)"
-                            class="px-4 py-2 bg-red-100 text-red-700 rounded-md transition hover:bg-red-300 hover:text-white text-center"
+                            class="px-4 py-2 bg-red-100 dark:bg-red-800 text-red-700 dark:text-red-300 rounded-md transition hover:bg-red-300 dark:hover:bg-red-600 hover:text-white text-center"
                         >
                             <i class="bi bi-trash"></i>
                         </button>
@@ -151,7 +151,7 @@ watchEffect(() => {
                 </ul>
 
                 <!-- 部署がない場合のメッセージ -->
-                <p v-if="units.length === 0" class="text-gray-500 mt-4">
+                <p v-if="units.length === 0" class="text-gray-500 dark:text-gray-400 mt-4">
                     {{ $t("No units available.") }}
                 </p>
             </div>

--- a/resources/js/Pages/Unit/Register.vue
+++ b/resources/js/Pages/Unit/Register.vue
@@ -87,7 +87,7 @@ watchEffect(() => {
             <transition name="fade">
                 <div
                     v-if="flashMessage"
-                    class="fixed bottom-10 left-1/2 transform -translate-x-1/2 w-full max-w-md bg-green-100 dark:bg-green-800 border-l-4 border-green-500 dark:border-green-400 text-green-700 dark:text-green-200 p-4 rounded shadow-lg z-50"
+                    class="fixed bottom-10 left-1/2 transform -translate-x-1/2 w-full max-w-md bg-green-100 dark:bg-green-900 border-l-4 border-green-500 dark:border-green-400 text-green-700 dark:text-green-100 p-4 rounded shadow-lg z-50"
                 >
                     <p class="font-bold text-center">{{ flashMessage }}</p>
                 </div>

--- a/resources/js/Pages/Users/Index.vue
+++ b/resources/js/Pages/Users/Index.vue
@@ -252,7 +252,7 @@ const totalFilteredUsers = computed(() => {
         >
             <div
                 v-if="flashMessage"
-                class="fixed bottom-10 left-1/2 transform -translate-x-1/2 w-full max-w-md bg-green-100 dark:bg-green-800 border-l-4 border-green-500 dark:border-green-400 text-green-700 dark:text-green-200 p-4 rounded shadow-lg z-50"
+                class="fixed bottom-10 left-1/2 transform -translate-x-1/2 w-full max-w-md bg-green-100 dark:bg-green-900 border-l-4 border-green-500 dark:border-green-400 text-green-700 dark:text-green-100 p-4 rounded shadow-lg z-50"
             >
                 <p class="font-bold text-center">{{ flashMessage }}</p>
             </div>


### PR DESCRIPTION
## 目的

管理者専用画面（ダッシュボード、部署管理）のダークモード対応を実装し、全体的な統一感のあるユーザーエクスペリエンスを提供する。

## 達成条件

- [x] 管理者ダッシュボードのダークモード対応
- [x] 部署管理カードのダークモード対応
- [x] 部署登録・一覧ページのダークモード対応
- [x] フォームコンポーネントのダークモード対応
- [x] ボタンとインタラクティブ要素のダークモード対応

## 実装の概要

### Admin/Dashboard.vue の修正

- **ページタイトル**: `text-gray-900 dark:text-gray-100` を追加

- **部署管理カード**: 背景、タイトル、説明文、リンクの全てにダークモード用のクラスを適用

  - 背景: `bg-white dark:bg-gray-800`
  - カードタイトル: `text-gray-900 dark:text-gray-100`
  - 説明文: `text-gray-500 dark:text-gray-400`
  - リンク: `text-blue-500 dark:text-blue-400`

### Unit/Register.vue の修正

- **ヘッダー・セクションタイトル**: 統一的に `text-gray-800 dark:text-gray-200` を適用

- **フラッシュメッセージ**: `bg-green-100 dark:bg-green-800`、`text-green-700 dark:text-green-200`

- **フォームエリア**:

  - 背景、ラベル、入力フィールド、エラーメッセージの全てにダークモード対応
  - 入力フィールド: `border-gray-300 dark:border-gray-600`、`bg-white dark:bg-gray-700`、`text-gray-900 dark:text-gray-100`

- **ボタンスタイル**:

  - 登録ボタン: `bg-blue-100 dark:bg-blue-800`、`text-blue-700 dark:text-blue-300`
  - 削除ボタン: `bg-red-100 dark:bg-red-800`、`text-red-700 dark:text-red-300`

- **一覧表示**: 背景、区切り線、テキスト、空状態メッセージの全てにダークモード対応

## 対処したバグ

特になし（新機能実装のため）

## 必要なかった実装

特になし（管理者画面の完全なダークモード対応という目標に対して、全ての実装が必要でした）

## レビューしてほしいところ

- 色のコントラストが適切かどうか（アクセシビリティ観点）
- ダークモード時のボタンの視認性
- フォーム入力フィールドの可読性
- 全体的な色の統一感

## 不安に思っていること

- ダークモード時のエラーメッセージの視認性が十分かどうか
- 部署一覧の空状態メッセージがダークモードで適切に表示されるか

## 保留していること

特になし（管理者専用メニューのダークモード対応は完了）