### PR TITLE
職員・利用者登録ページのダークモード対応

### DIFF
--- a/resources/js/Pages/Auth/Register.vue
+++ b/resources/js/Pages/Auth/Register.vue
@@ -46,7 +46,7 @@ const submit = () => {
 <template>
     <AuthenticatedLayout>
         <template #header>
-            <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
                 {{ $t("User registration") }}
             </h2>
         </template>

--- a/resources/js/Pages/Auth/Register.vue
+++ b/resources/js/Pages/Auth/Register.vue
@@ -4,7 +4,7 @@ import InputError from "@/Components/InputError.vue";
 import InputLabel from "@/Components/InputLabel.vue";
 import TextInput from "@/Components/TextInput.vue";
 import { Head, useForm } from "@inertiajs/vue3";
-import { ref } from "vue";
+import { ref, computed } from "vue";
 
 const props = defineProps({
     units: {
@@ -17,6 +17,17 @@ const props = defineProps({
 const csrfToken = ref(
     document.querySelector('meta[name="csrf-token"]').getAttribute("content")
 );
+
+// セレクトボックスのクラス定義（フォーカスカラーをblueに統一）
+const selectClasses = computed(() => [
+    "mt-1 block w-full rounded-md shadow-sm",
+    "border-gray-300 dark:border-gray-600",
+    "bg-white dark:bg-gray-700",
+    "text-gray-900 dark:text-gray-100",
+    "focus:border-blue-500 dark:focus:border-blue-400",
+    "focus:ring focus:ring-blue-200 dark:focus:ring-blue-400",
+    "focus:ring-opacity-50"
+].join(" "));
 
 // フォームの初期データを定義
 const form = useForm({
@@ -126,7 +137,7 @@ const submit = () => {
                     <select
                         id="unit_id"
                         v-model="form.unit_id"
-                        class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 shadow-sm focus:border-indigo-300 dark:focus:border-indigo-500 focus:ring focus:ring-indigo-200 dark:focus:ring-indigo-400 focus:ring-opacity-50"
+                        :class="selectClasses"
                         required
                     >
                         <option value="" disabled>

--- a/resources/js/Pages/Auth/Register.vue
+++ b/resources/js/Pages/Auth/Register.vue
@@ -146,7 +146,7 @@ const submit = () => {
                 <div class="flex items-center justify-end">
                     <button
                         type="submit"
-                        class="w-full sm:w-auto px-4 py-2 bg-blue-100 text-blue-700 rounded-md transition hover:bg-blue-300 hover:text-white text-center"
+                        class="w-full sm:w-auto px-4 py-2 bg-blue-100 dark:bg-blue-800 text-blue-700 dark:text-blue-300 rounded-md transition hover:bg-blue-300 dark:hover:bg-blue-600 hover:text-white text-center"
                         :class="{ 'opacity-25': form.processing }"
                         :disabled="form.processing"
                     >

--- a/resources/js/Pages/Auth/Register.vue
+++ b/resources/js/Pages/Auth/Register.vue
@@ -56,7 +56,7 @@ const submit = () => {
         <div class="max-w-md mx-auto mt-16 px-4 sm:px-6 lg:px-8">
             <form
                 @submit.prevent="submit"
-                class="bg-white p-6 rounded-lg shadow space-y-6"
+                class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow space-y-6"
             >
                 <input type="hidden" name="_token" :value="csrfToken" />
 

--- a/resources/js/Pages/Auth/Register.vue
+++ b/resources/js/Pages/Auth/Register.vue
@@ -126,7 +126,7 @@ const submit = () => {
                     <select
                         id="unit_id"
                         v-model="form.unit_id"
-                        class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50"
+                        class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 shadow-sm focus:border-indigo-300 dark:focus:border-indigo-500 focus:ring focus:ring-indigo-200 dark:focus:ring-indigo-400 focus:ring-opacity-50"
                         required
                     >
                         <option value="" disabled>

--- a/resources/js/Pages/Residents/Register.vue
+++ b/resources/js/Pages/Residents/Register.vue
@@ -44,7 +44,7 @@ const submit = () => {
                         type="text"
                         id="name"
                         v-model="form.name"
-                        class="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:border-blue-500"
+                        class="mt-1 block w-full border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 rounded-md shadow-sm focus:border-blue-500 dark:focus:border-blue-400"
                         placeholder="利用者名を入力してください"
                     />
                     <div

--- a/resources/js/Pages/Residents/Register.vue
+++ b/resources/js/Pages/Residents/Register.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { Head } from "@inertiajs/vue3";
 import { useForm } from "@inertiajs/vue3";
+import { computed } from "vue";
 import AuthenticatedLayout from "@/Layouts/AuthenticatedLayout.vue";
 
 defineProps({
@@ -11,6 +12,14 @@ const form = useForm({
     name: "",
     unit_id: "",
 });
+
+const inputClasses = computed(() => [
+    "mt-1 block w-full rounded-md shadow-sm",
+    "border-gray-300 dark:border-gray-600",
+    "bg-white dark:bg-gray-700",
+    "text-gray-900 dark:text-gray-100",
+    "focus:border-blue-500 dark:focus:border-blue-400"
+].join(" "));
 
 const submit = () => {
     form.post(route("residents.store"));
@@ -44,7 +53,7 @@ const submit = () => {
                         type="text"
                         id="name"
                         v-model="form.name"
-                        class="mt-1 block w-full border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 rounded-md shadow-sm focus:border-blue-500 dark:focus:border-blue-400"
+                        :class="inputClasses"
                         placeholder="利用者名を入力してください"
                     />
                     <div
@@ -65,7 +74,7 @@ const submit = () => {
                     <select
                         id="unit_id"
                         v-model="form.unit_id"
-                        class="mt-1 block w-full border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 rounded-md shadow-sm focus:border-blue-500 dark:focus:border-blue-400"
+                        :class="inputClasses"
                         placeholder="所属部署を選択してください"
                     >
                         <option value="" disabled selected>

--- a/resources/js/Pages/Residents/Register.vue
+++ b/resources/js/Pages/Residents/Register.vue
@@ -89,7 +89,7 @@ const submit = () => {
 
                 <button
                     type="submit"
-                    class="bg-blue-100 text-blue-700 font-medium py-2 px-4 rounded-md transition hover:bg-blue-300 hover:text-white focus:outline-none focus:shadow-outline"
+                    class="bg-blue-100 dark:bg-blue-800 text-blue-700 dark:text-blue-300 font-medium py-2 px-4 rounded-md transition hover:bg-blue-300 dark:hover:bg-blue-600 hover:text-white focus:outline-none focus:shadow-outline"
                 >
                     {{ $t("Register Resident") }}
                 </button>

--- a/resources/js/Pages/Residents/Register.vue
+++ b/resources/js/Pages/Residents/Register.vue
@@ -65,7 +65,7 @@ const submit = () => {
                     <select
                         id="unit_id"
                         v-model="form.unit_id"
-                        class="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:border-blue-500"
+                        class="mt-1 block w-full border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 rounded-md shadow-sm focus:border-blue-500 dark:focus:border-blue-400"
                         placeholder="所属部署を選択してください"
                     >
                         <option value="" disabled selected>

--- a/resources/js/Pages/Residents/Register.vue
+++ b/resources/js/Pages/Residents/Register.vue
@@ -49,7 +49,7 @@ const submit = () => {
                     />
                     <div
                         v-if="form.errors.name"
-                        class="text-red-600 text-sm mt-1"
+                        class="text-red-600 dark:text-red-400 text-sm mt-1"
                     >
                         {{ form.errors.name }}
                     </div>

--- a/resources/js/Pages/Residents/Register.vue
+++ b/resources/js/Pages/Residents/Register.vue
@@ -81,7 +81,7 @@ const submit = () => {
                     </select>
                     <div
                         v-if="form.errors.unit_id"
-                        class="text-red-600 text-sm mt-1"
+                        class="text-red-600 dark:text-red-400 text-sm mt-1"
                     >
                         {{ form.errors.unit_id }}
                     </div>

--- a/resources/js/Pages/Residents/Register.vue
+++ b/resources/js/Pages/Residents/Register.vue
@@ -20,7 +20,7 @@ const submit = () => {
 <template>
     <AuthenticatedLayout>
         <template #header>
-            <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
                 {{ $t("Resident Registration") }}
             </h2>
         </template>

--- a/resources/js/Pages/Residents/Register.vue
+++ b/resources/js/Pages/Residents/Register.vue
@@ -31,7 +31,7 @@ const submit = () => {
             <!-- 利用者登録フォーム -->
             <form
                 @submit.prevent="submit"
-                class="bg-white p-6 rounded-lg shadow"
+                class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow"
             >
                 <div class="mb-4">
                     <label

--- a/resources/js/Pages/Residents/Register.vue
+++ b/resources/js/Pages/Residents/Register.vue
@@ -36,7 +36,7 @@ const submit = () => {
                 <div class="mb-4">
                     <label
                         for="name"
-                        class="block text-sm font-medium text-gray-700"
+                        class="block text-sm font-medium text-gray-700 dark:text-gray-300"
                     >
                         {{ $t("Resident Name") }}
                     </label>

--- a/resources/js/Pages/Residents/Register.vue
+++ b/resources/js/Pages/Residents/Register.vue
@@ -58,7 +58,7 @@ const submit = () => {
                 <div class="mb-4">
                     <label
                         for="unit_id"
-                        class="block text-sm font-medium text-gray-700"
+                        class="block text-sm font-medium text-gray-700 dark:text-gray-300"
                     >
                         {{ $t("Unit") }}
                     </label>


### PR DESCRIPTION
# 変更・追加内容

## タイトル
職員・利用者登録ページのダークモード対応

## 目的
管理者のみが操作できる職員登録ページと利用者登録ページにダークモード対応を追加し、既存のダークモードトグル機能との整合性を保つ。

## 達成条件
- [x] 職員登録ページ（`/resources/js/Pages/Auth/Register.vue`）でのダークモード表示対応
- [x] 利用者登録ページ（`/resources/js/Pages/Residents/Register.vue`）でのダークモード表示対応  
- [x] 既存のダークモード実装との一貫性保持
- [x] ビルドエラーなしでの動作確認

## 実装の概要
### 職員登録ページ（Auth/Register.vue）
- ヘッダータイトル: `dark:text-gray-200` を追加
- フォーム背景: `dark:bg-gray-800` を追加
- セレクトボックス: `dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100` を追加
- 登録ボタン: `dark:bg-blue-800 dark:text-blue-300 dark:hover:bg-blue-600` を追加

### 利用者登録ページ（Residents/Register.vue）  
- ヘッダータイトル: `dark:text-gray-200` を追加
- フォーム背景: `dark:bg-gray-800` を追加
- ラベル: `dark:text-gray-300` を追加
- 入力フィールド: `dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100` を追加
- エラーメッセージ: `dark:text-red-400` を追加
- 登録ボタン: `dark:bg-blue-800 dark:text-blue-300 dark:hover:bg-blue-600` を追加

## 対処したバグ
該当なし

## 必要なかった実装
- カスタムコンポーネントの修正: InputLabelとTextInputコンポーネントは既にダークモード対応済みだったため、追加の修正は不要だった
- 新しいダークモード切り替え機能の実装: 既存のDarkModeToggle.vueコンポーネントを活用することで対応できた

## レビューしてほしいところ
- 既存のダークモード実装（DarkModeToggle.vue）との色調統一が適切か
- フォーカス状態とホバー状態でのダークモードスタイルが適切か
- エラーメッセージの可読性がダークモードで確保されているか

## 不安に思っていること
- 他のブラウザでのダークモード表示の一貫性
- アクセシビリティの観点でのコントラスト比が適切か

## 保留していること
該当なし

## テスト計画
- [x] ビルドプロセスでのエラーなし確認済み
- [x] ダークモード切り替え時の表示確認
- [x] フォーム入力時の表示確認

🤖 Generated with [Claude Code](https://claude.ai/code)