### PR TITLE
ResidentController・UnitControllerのService層化とセキュリティ強化

### DIFF
--- a/app/Services/ResidentService.php
+++ b/app/Services/ResidentService.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Resident;
+use App\Models\Unit;
+use App\Models\User;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use App\Http\Requests\Resident\ResidentStoreRequest;
+use App\Http\Requests\Resident\ResidentUpdateRequest;
+use App\Exceptions\Custom\TenantViolationException;
+use Illuminate\Support\Collection;
+
+class ResidentService
+{
+    /**
+     * テナントに属する利用者一覧を取得
+     */
+    public function getResidents(?int $unitId = null): Collection
+    {
+        /** @var User $currentUser */
+        $currentUser = Auth::user();
+        
+        return Resident::where('tenant_id', $currentUser->tenant_id)
+            ->when($unitId, function ($query) use ($unitId, $currentUser) {
+                // unit_idが指定されている場合、そのunitが現在のテナントに属するかチェック
+                $unit = Unit::where('id', $unitId)
+                    ->where('tenant_id', $currentUser->tenant_id)
+                    ->first();
+                    
+                if (!$unit) {
+                    throw new TenantViolationException(
+                        "指定された部署へのアクセスが許可されていません。",
+                        [
+                            'user_id' => $currentUser->id,
+                            'tenant_id' => $currentUser->tenant_id,
+                            'requested_unit_id' => $unitId,
+                            'action' => 'resident_filter_by_unit'
+                        ]
+                    );
+                }
+                
+                return $query->where('unit_id', $unitId);
+            })
+            ->with('unit')
+            ->get();
+    }
+
+    /**
+     * テナントに属する部署一覧を取得
+     */
+    public function getUnitsForTenant(): Collection
+    {
+        /** @var User $currentUser */
+        $currentUser = Auth::user();
+        
+        return Unit::where('tenant_id', $currentUser->tenant_id)
+            ->orderBy('sort_order')
+            ->get();
+    }
+
+    /**
+     * 利用者を新規作成
+     */
+    public function createResident(ResidentStoreRequest $request): Resident
+    {
+        $validated = $request->validated();
+        /** @var User $currentUser */
+        $currentUser = Auth::user();
+
+        // unit_idが指定されている場合、テナント境界チェック
+        if (isset($validated['unit_id'])) {
+            $this->validateUnitAccess($validated['unit_id'], $currentUser);
+        }
+
+        return Resident::create(array_merge($validated, [
+            'tenant_id' => $currentUser->tenant_id
+        ]));
+    }
+
+    /**
+     * 利用者情報を取得（テナント境界チェック付き）
+     */
+    public function getResident(int $residentId): Resident
+    {
+        /** @var User $currentUser */
+        $currentUser = Auth::user();
+        
+        $resident = Resident::with('unit')->find($residentId);
+        
+        if (!$resident) {
+            throw new TenantViolationException(
+                "指定された利用者が見つかりません。",
+                [
+                    'user_id' => $currentUser->id,
+                    'tenant_id' => $currentUser->tenant_id,
+                    'requested_resident_id' => $residentId,
+                    'action' => 'resident_access'
+                ]
+            );
+        }
+
+        // テナント境界チェック
+        if ($resident->tenant_id !== $currentUser->tenant_id) {
+            throw new TenantViolationException(
+                "他のテナントの利用者情報にアクセスしようとしました。",
+                [
+                    'user_id' => $currentUser->id,
+                    'user_tenant_id' => $currentUser->tenant_id,
+                    'resident_tenant_id' => $resident->tenant_id,
+                    'resident_id' => $residentId,
+                    'action' => 'resident_access'
+                ]
+            );
+        }
+
+        return $resident;
+    }
+
+    /**
+     * 利用者情報を更新
+     */
+    public function updateResident(ResidentUpdateRequest $request, int $residentId): Resident
+    {
+        $validated = $request->validated();
+        $resident = $this->getResident($residentId); // テナント境界チェック済み
+
+        /** @var User $currentUser */
+        $currentUser = Auth::user();
+
+        // unit_idが変更される場合、新しいunitのテナント境界チェック
+        if (isset($validated['unit_id']) && $validated['unit_id'] !== $resident->unit_id) {
+            $this->validateUnitAccess($validated['unit_id'], $currentUser);
+        }
+
+        $resident->update($validated);
+        
+        return $resident->fresh('unit');
+    }
+
+    /**
+     * 利用者を削除
+     */
+    public function deleteResident(int $residentId): void
+    {
+        $resident = $this->getResident($residentId); // テナント境界チェック済み
+        
+        DB::transaction(function () use ($resident) {
+            // 利用者削除時の追加処理があればここに記述
+            // 例：関連するケア記録の削除など
+            
+            $resident->delete();
+        });
+    }
+
+    /**
+     * 部署のテナント境界チェック
+     */
+    private function validateUnitAccess(int $unitId, User $currentUser): void
+    {
+        $unit = Unit::where('id', $unitId)
+            ->where('tenant_id', $currentUser->tenant_id)
+            ->first();
+            
+        if (!$unit) {
+            throw new TenantViolationException(
+                "指定された部署へのアクセスが許可されていません。",
+                [
+                    'user_id' => $currentUser->id,
+                    'tenant_id' => $currentUser->tenant_id,
+                    'requested_unit_id' => $unitId,
+                    'action' => 'unit_access_validation'
+                ]
+            );
+        }
+    }
+
+    /**
+     * 管理者権限チェック
+     */
+    public function isAdmin(): bool
+    {
+        /** @var User $user */
+        $user = Auth::user();
+        return $user->hasRole('admin');
+    }
+}

--- a/app/Services/UnitService.php
+++ b/app/Services/UnitService.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Unit;
+use App\Models\Forum;
+use App\Models\User;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use App\Http\Requests\Unit\UnitStoreRequest;
+use App\Http\Requests\Unit\UnitSortRequest;
+use App\Exceptions\Custom\TenantViolationException;
+use Illuminate\Support\Collection;
+
+class UnitService
+{
+    /**
+     * テナントに属する部署一覧を取得（フォーラム情報付き）
+     */
+    public function getUnitsWithForum(): Collection
+    {
+        /** @var User $currentUser */
+        $currentUser = Auth::user();
+        
+        return Unit::where('tenant_id', $currentUser->tenant_id)
+            ->with('forum')
+            ->get();
+    }
+
+    /**
+     * 部署作成画面用の部署一覧を取得
+     */
+    public function getUnitsForManagement(): Collection
+    {
+        /** @var User $currentUser */
+        $currentUser = Auth::user();
+        
+        return Unit::select('id', 'name', 'sort_order', 'created_at')
+            ->where('tenant_id', $currentUser->tenant_id)
+            ->orderBy('sort_order')
+            ->orderBy('created_at', 'desc')
+            ->get();
+    }
+
+    /**
+     * テナントに属するフォーラム一覧を取得
+     */
+    public function getForumsForTenant(): Collection
+    {
+        /** @var User $currentUser */
+        $currentUser = Auth::user();
+        
+        return Forum::where('tenant_id', $currentUser->tenant_id)->get();
+    }
+
+    /**
+     * 新しい部署を作成（フォーラムも同時作成）
+     */
+    public function createUnit(UnitStoreRequest $request): Unit
+    {
+        $validated = $request->validated();
+        /** @var User $currentUser */
+        $currentUser = Auth::user();
+
+        return DB::transaction(function () use ($validated, $currentUser) {
+            // 最新の並び順を取得
+            $maxSortOrder = Unit::where('tenant_id', $currentUser->tenant_id)
+                ->max('sort_order') ?? -1;
+
+            $unit = Unit::create([
+                'name' => $validated['name'],
+                'tenant_id' => $currentUser->tenant_id,
+                'sort_order' => $maxSortOrder + 1,
+            ]);
+
+            // 部署に対応するフォーラムを作成
+            Forum::create([
+                'name' => $validated['name'],
+                'unit_id' => $unit->id,
+                'description' => $validated['description'] ?? '',
+                'visibility' => $validated['visibility'] ?? 'public',
+                'status' => 'active',
+                'tenant_id' => $currentUser->tenant_id,
+            ]);
+
+            return $unit;
+        });
+    }
+
+    /**
+     * 部署を削除（テナント境界チェック付き）
+     */
+    public function deleteUnit(int $unitId): void
+    {
+        /** @var User $currentUser */
+        $currentUser = Auth::user();
+        
+        $unit = Unit::where('id', $unitId)
+            ->where('tenant_id', $currentUser->tenant_id)
+            ->first();
+            
+        if (!$unit) {
+            throw new TenantViolationException(
+                "指定された部署へのアクセスが許可されていません。",
+                [
+                    'user_id' => $currentUser->id,
+                    'tenant_id' => $currentUser->tenant_id,
+                    'requested_unit_id' => $unitId,
+                    'action' => 'unit_delete'
+                ]
+            );
+        }
+
+        DB::transaction(function () use ($unit) {
+            // 関連するフォーラムも削除
+            $unit->forum()?->delete();
+            
+            // 部署を削除
+            $unit->delete();
+        });
+    }
+
+    /**
+     * 部署の並び順を更新
+     */
+    public function updateSortOrder(UnitSortRequest $request): void
+    {
+        /** @var User $currentUser */
+        $currentUser = Auth::user();
+        $units = $request->validated()['units'];
+        
+        DB::transaction(function () use ($units, $currentUser) {
+            foreach ($units as $index => $unitData) {
+                // セキュリティチェック: 更新対象の部署がテナントに属するかチェック
+                $unit = Unit::where('id', $unitData['id'])
+                    ->where('tenant_id', $currentUser->tenant_id)
+                    ->first();
+                    
+                if (!$unit) {
+                    throw new TenantViolationException(
+                        "並び順更新対象の部署にアクセスする権限がありません。",
+                        [
+                            'user_id' => $currentUser->id,
+                            'tenant_id' => $currentUser->tenant_id,
+                            'requested_unit_id' => $unitData['id'],
+                            'action' => 'unit_sort_update'
+                        ]
+                    );
+                }
+                
+                $unit->update(['sort_order' => $index]);
+            }
+        });
+    }
+
+    /**
+     * 部署の詳細を取得（テナント境界チェック付き）
+     */
+    public function getUnit(int $unitId): Unit
+    {
+        /** @var User $currentUser */
+        $currentUser = Auth::user();
+        
+        $unit = Unit::find($unitId);
+        
+        if (!$unit) {
+            throw new TenantViolationException(
+                "指定された部署が見つかりません。",
+                [
+                    'user_id' => $currentUser->id,
+                    'tenant_id' => $currentUser->tenant_id,
+                    'requested_unit_id' => $unitId,
+                    'action' => 'unit_access'
+                ]
+            );
+        }
+
+        // テナント境界チェック
+        if ($unit->tenant_id !== $currentUser->tenant_id) {
+            throw new TenantViolationException(
+                "他のテナントの部署情報にアクセスしようとしました。",
+                [
+                    'user_id' => $currentUser->id,
+                    'user_tenant_id' => $currentUser->tenant_id,
+                    'unit_tenant_id' => $unit->tenant_id,
+                    'unit_id' => $unitId,
+                    'action' => 'unit_access'
+                ]
+            );
+        }
+
+        return $unit;
+    }
+}

--- a/app/Services/UnitService.php
+++ b/app/Services/UnitService.php
@@ -116,7 +116,7 @@ class UnitService
 
         DB::transaction(function () use ($unit) {
             // 関連するフォーラムも削除
-            $unit->forum()?->delete();
+            $unit->forum?->delete();
             
             // 部署を削除
             $unit->delete();

--- a/app/Traits/SecurityValidationTrait.php
+++ b/app/Traits/SecurityValidationTrait.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace App\Traits;
+
+use App\Models\User;
+use App\Exceptions\Custom\TenantViolationException;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
+
+trait SecurityValidationTrait
+{
+    /**
+     * 現在ログイン中のユーザーを取得（型安全）
+     */
+    protected function getCurrentUser(): User
+    {
+        /** @var User $user */
+        $user = Auth::user();
+        return $user;
+    }
+
+    /**
+     * 管理者権限チェック
+     */
+    protected function isCurrentUserAdmin(): bool
+    {
+        $user = $this->getCurrentUser();
+        return $user->hasRole('admin');
+    }
+
+    /**
+     * セキュリティログを記録
+     */
+    protected function logSecurityEvent(string $message, array $context = []): void
+    {
+        $user = $this->getCurrentUser();
+        
+        $logContext = array_merge([
+            'user_id' => $user->id,
+            'tenant_id' => $user->tenant_id,
+            'user_email' => $user->email,
+            'timestamp' => now()->toISOString(),
+            'ip_address' => request()->ip(),
+            'user_agent' => request()->userAgent(),
+        ], $context);
+        
+        Log::warning("セキュリティイベント: {$message}", $logContext);
+    }
+
+    /**
+     * リソースの所有者チェック（汎用）
+     */
+    protected function validateResourceOwnership($resource, string $ownerField = 'user_id'): void
+    {
+        $currentUser = $this->getCurrentUser();
+        
+        if ($resource->{$ownerField} !== $currentUser->id) {
+            $this->logSecurityEvent("リソース所有権違反", [
+                'resource_type' => get_class($resource),
+                'resource_id' => $resource->id ?? null,
+                'resource_owner_id' => $resource->{$ownerField},
+                'current_user_id' => $currentUser->id,
+                'action' => 'resource_ownership_check'
+            ]);
+            
+            throw new TenantViolationException(
+                "このリソースへのアクセス権限がありません。",
+                [
+                    'user_id' => $currentUser->id,
+                    'tenant_id' => $currentUser->tenant_id,
+                    'resource_type' => get_class($resource),
+                    'resource_id' => $resource->id ?? null,
+                    'action' => 'resource_ownership_validation'
+                ]
+            );
+        }
+    }
+
+    /**
+     * 管理者権限必須チェック
+     */
+    protected function requireAdminRole(): void
+    {
+        if (!$this->isCurrentUserAdmin()) {
+            $currentUser = $this->getCurrentUser();
+            
+            $this->logSecurityEvent("管理者権限必須操作への不正アクセス試行", [
+                'user_roles' => $currentUser->getRoleNames()->toArray(),
+                'action' => 'admin_role_check'
+            ]);
+            
+            throw new TenantViolationException(
+                "この操作には管理者権限が必要です。",
+                [
+                    'user_id' => $currentUser->id,
+                    'tenant_id' => $currentUser->tenant_id,
+                    'required_role' => 'admin',
+                    'user_roles' => $currentUser->getRoleNames()->toArray(),
+                    'action' => 'admin_role_validation'
+                ]
+            );
+        }
+    }
+
+    /**
+     * セキュリティ監査ログ
+     */
+    protected function auditAction(string $action, array $details = []): void
+    {
+        $user = $this->getCurrentUser();
+        
+        Log::info("ユーザーアクション監査", array_merge([
+            'user_id' => $user->id,
+            'tenant_id' => $user->tenant_id,
+            'action' => $action,
+            'timestamp' => now()->toISOString(),
+            'ip_address' => request()->ip(),
+        ], $details));
+    }
+}

--- a/app/Traits/TenantBoundaryCheckTrait.php
+++ b/app/Traits/TenantBoundaryCheckTrait.php
@@ -5,6 +5,7 @@ namespace App\Traits;
 use App\Models\User;
 use App\Exceptions\Custom\TenantViolationException;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Database\Eloquent\Model;
 
 trait TenantBoundaryCheckTrait
@@ -18,7 +19,7 @@ trait TenantBoundaryCheckTrait
         $currentUser = Auth::user();
         $tenantId = $expectedTenantId ?? $currentUser->tenant_id;
         
-        if (!property_exists($resource, 'tenant_id') || $resource->tenant_id !== $tenantId) {
+        if (!isset($resource->tenant_id) || $resource->tenant_id !== $tenantId) {
             $this->logSecurityViolation(
                 "テナント境界違反",
                 $resource,
@@ -108,7 +109,7 @@ trait TenantBoundaryCheckTrait
         /** @var User $currentUser */
         $currentUser = Auth::user();
         
-        \Log::critical("テナントセキュリティ違反検出", [
+        Log::critical("テナントセキュリティ違反検出", [
             'violation_type' => $violationType,
             'user_id' => $currentUser->id,
             'user_tenant_id' => $currentUser->tenant_id,

--- a/app/Traits/TenantBoundaryCheckTrait.php
+++ b/app/Traits/TenantBoundaryCheckTrait.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace App\Traits;
+
+use App\Models\User;
+use App\Exceptions\Custom\TenantViolationException;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Database\Eloquent\Model;
+
+trait TenantBoundaryCheckTrait
+{
+    /**
+     * テナント境界チェック（汎用）
+     */
+    protected function validateTenantBoundary(Model $resource, ?int $expectedTenantId = null): void
+    {
+        /** @var User $currentUser */
+        $currentUser = Auth::user();
+        $tenantId = $expectedTenantId ?? $currentUser->tenant_id;
+        
+        if (!property_exists($resource, 'tenant_id') || $resource->tenant_id !== $tenantId) {
+            $this->logSecurityViolation(
+                "テナント境界違反",
+                $resource,
+                $tenantId,
+                $resource->tenant_id ?? null
+            );
+            
+            throw new TenantViolationException(
+                "他のテナントのリソースにアクセスしようとしました。",
+                [
+                    'user_id' => $currentUser->id,
+                    'user_tenant_id' => $currentUser->tenant_id,
+                    'resource_tenant_id' => $resource->tenant_id ?? null,
+                    'resource_type' => get_class($resource),
+                    'resource_id' => $resource->id ?? null,
+                    'action' => 'tenant_boundary_check'
+                ]
+            );
+        }
+    }
+
+    /**
+     * リソース存在チェック（テナント境界込み）
+     */
+    protected function findResourceWithTenantCheck(string $modelClass, int $resourceId): Model
+    {
+        /** @var User $currentUser */
+        $currentUser = Auth::user();
+        
+        $resource = $modelClass::find($resourceId);
+        
+        if (!$resource) {
+            throw new TenantViolationException(
+                "指定されたリソースが見つかりません。",
+                [
+                    'user_id' => $currentUser->id,
+                    'tenant_id' => $currentUser->tenant_id,
+                    'resource_type' => $modelClass,
+                    'resource_id' => $resourceId,
+                    'action' => 'resource_not_found'
+                ]
+            );
+        }
+        
+        $this->validateTenantBoundary($resource);
+        
+        return $resource;
+    }
+
+    /**
+     * テナント専用クエリスコープ適用
+     */
+    protected function scopeToCurrentTenant($query)
+    {
+        /** @var User $currentUser */
+        $currentUser = Auth::user();
+        
+        return $query->where('tenant_id', $currentUser->tenant_id);
+    }
+
+    /**
+     * 複数リソースのテナント境界一括チェック
+     */
+    protected function validateMultipleTenantBoundaries(array $resources): void
+    {
+        /** @var User $currentUser */
+        $currentUser = Auth::user();
+        
+        foreach ($resources as $resource) {
+            if (!$resource instanceof Model) {
+                continue;
+            }
+            
+            $this->validateTenantBoundary($resource, $currentUser->tenant_id);
+        }
+    }
+
+    /**
+     * テナント境界違反の詳細ログ記録
+     */
+    private function logSecurityViolation(
+        string $violationType,
+        Model $resource,
+        int $expectedTenantId,
+        ?int $actualTenantId
+    ): void {
+        /** @var User $currentUser */
+        $currentUser = Auth::user();
+        
+        \Log::critical("テナントセキュリティ違反検出", [
+            'violation_type' => $violationType,
+            'user_id' => $currentUser->id,
+            'user_tenant_id' => $currentUser->tenant_id,
+            'expected_tenant_id' => $expectedTenantId,
+            'actual_tenant_id' => $actualTenantId,
+            'resource_type' => get_class($resource),
+            'resource_id' => $resource->id ?? null,
+            'ip_address' => request()->ip(),
+            'user_agent' => request()->userAgent(),
+            'timestamp' => now()->toISOString(),
+            'stack_trace' => debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 5)
+        ]);
+    }
+
+    /**
+     * 関連テーブルのテナント境界チェック
+     * 例: Post -> Forum -> Unit の連鎖チェック
+     */
+    protected function validateRelatedResourceTenant(Model $resource, string $relationPath): void
+    {
+        /** @var User $currentUser */
+        $currentUser = Auth::user();
+        
+        $relations = explode('.', $relationPath);
+        $currentResource = $resource;
+        
+        foreach ($relations as $relation) {
+            if (!$currentResource->{$relation}) {
+                throw new TenantViolationException(
+                    "関連リソースが見つかりません。",
+                    [
+                        'user_id' => $currentUser->id,
+                        'tenant_id' => $currentUser->tenant_id,
+                        'resource_type' => get_class($resource),
+                        'resource_id' => $resource->id ?? null,
+                        'missing_relation' => $relation,
+                        'action' => 'related_resource_check'
+                    ]
+                );
+            }
+            
+            $currentResource = $currentResource->{$relation};
+            $this->validateTenantBoundary($currentResource);
+        }
+    }
+
+    /**
+     * バッチ操作時のテナント境界チェック
+     */
+    protected function validateBatchTenantBoundary(array $resourceIds, string $modelClass): array
+    {
+        /** @var User $currentUser */
+        $currentUser = Auth::user();
+        
+        $resources = $modelClass::whereIn('id', $resourceIds)
+            ->where('tenant_id', $currentUser->tenant_id)
+            ->get();
+            
+        if ($resources->count() !== count($resourceIds)) {
+            $foundIds = $resources->pluck('id')->toArray();
+            $missingIds = array_diff($resourceIds, $foundIds);
+            
+            throw new TenantViolationException(
+                "一部のリソースへのアクセスが許可されていません。",
+                [
+                    'user_id' => $currentUser->id,
+                    'tenant_id' => $currentUser->tenant_id,
+                    'resource_type' => $modelClass,
+                    'requested_ids' => $resourceIds,
+                    'missing_ids' => $missingIds,
+                    'action' => 'batch_tenant_boundary_check'
+                ]
+            );
+        }
+        
+        return $resources->toArray();
+    }
+}

--- a/app/Traits/TenantBoundaryCheckTrait.php
+++ b/app/Traits/TenantBoundaryCheckTrait.php
@@ -109,7 +109,7 @@ trait TenantBoundaryCheckTrait
         /** @var User $currentUser */
         $currentUser = Auth::user();
         
-        Log::critical("テナントセキュリティ違反検出", [
+        $logContext = [
             'violation_type' => $violationType,
             'user_id' => $currentUser->id,
             'user_tenant_id' => $currentUser->tenant_id,
@@ -120,8 +120,13 @@ trait TenantBoundaryCheckTrait
             'ip_address' => request()->ip(),
             'user_agent' => request()->userAgent(),
             'timestamp' => now()->toISOString(),
-            'stack_trace' => debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 5)
-        ]);
+        ];
+        
+        if (!app()->environment('production')) {
+            $logContext['stack_trace'] = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 5);
+        }
+        
+        Log::critical("テナントセキュリティ違反検出", $logContext);
     }
 
     /**

--- a/tests/Unit/ResidentServiceTest.php
+++ b/tests/Unit/ResidentServiceTest.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use App\Services\ResidentService;
+use App\Models\Resident;
+use App\Models\Unit;
+use App\Models\User;
+use App\Http\Requests\Resident\ResidentStoreRequest;
+use App\Http\Requests\Resident\ResidentUpdateRequest;
+use App\Exceptions\Custom\TenantViolationException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Auth;
+
+class ResidentServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $residentService;
+    protected $tenant1User;
+    protected $tenant2User;
+    protected $tenant1Unit;
+    protected $tenant2Unit;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        
+        $this->residentService = new ResidentService();
+        
+        // テナント1のユーザーとデータ
+        $this->tenant1User = User::factory()->create(['tenant_id' => 1]);
+        $this->tenant1Unit = Unit::factory()->create(['tenant_id' => 1]);
+        
+        // テナント2のユーザーとデータ
+        $this->tenant2User = User::factory()->create(['tenant_id' => 2]);
+        $this->tenant2Unit = Unit::factory()->create(['tenant_id' => 2]);
+    }
+
+    public function test_getResidents_returns_only_tenant_residents()
+    {
+        Auth::login($this->tenant1User);
+        
+        // テナント1の利用者作成
+        $tenant1Resident = Resident::factory()->create([
+            'tenant_id' => 1,
+            'unit_id' => $this->tenant1Unit->id
+        ]);
+        
+        // テナント2の利用者作成（アクセス不可であるべき）
+        Resident::factory()->create([
+            'tenant_id' => 2,
+            'unit_id' => $this->tenant2Unit->id
+        ]);
+        
+        $residents = $this->residentService->getResidents();
+        
+        $this->assertCount(1, $residents);
+        $this->assertEquals($tenant1Resident->id, $residents->first()->id);
+    }
+
+    public function test_getResident_throws_exception_for_different_tenant()
+    {
+        Auth::login($this->tenant1User);
+        
+        // テナント2の利用者作成
+        $tenant2Resident = Resident::factory()->create([
+            'tenant_id' => 2,
+            'unit_id' => $this->tenant2Unit->id
+        ]);
+        
+        $this->expectException(TenantViolationException::class);
+        $this->expectExceptionMessage("他のテナントのリソースにアクセスしようとしました。");
+        
+        $this->residentService->getResident($tenant2Resident->id);
+    }
+
+    public function test_createResident_validates_unit_tenant_boundary()
+    {
+        Auth::login($this->tenant1User);
+        
+        $request = new ResidentStoreRequest();
+        $request->merge([
+            'name' => 'テスト利用者',
+            'unit_id' => $this->tenant2Unit->id, // 異なるテナントの部署
+        ]);
+        $request->setValidator(validator($request->all(), $request->rules()));
+        
+        $this->expectException(TenantViolationException::class);
+        
+        $this->residentService->createResident($request);
+    }
+
+    public function test_updateResident_validates_tenant_boundary()
+    {
+        Auth::login($this->tenant1User);
+        
+        $tenant2Resident = Resident::factory()->create([
+            'tenant_id' => 2,
+            'unit_id' => $this->tenant2Unit->id
+        ]);
+        
+        $request = new ResidentUpdateRequest();
+        $request->merge(['name' => '更新テスト']);
+        $request->setValidator(validator($request->all(), $request->rules()));
+        
+        $this->expectException(TenantViolationException::class);
+        
+        $this->residentService->updateResident($request, $tenant2Resident->id);
+    }
+
+    public function test_deleteResident_validates_tenant_boundary()
+    {
+        Auth::login($this->tenant1User);
+        
+        $tenant2Resident = Resident::factory()->create([
+            'tenant_id' => 2,
+            'unit_id' => $this->tenant2Unit->id
+        ]);
+        
+        $this->expectException(TenantViolationException::class);
+        
+        $this->residentService->deleteResident($tenant2Resident->id);
+    }
+
+    public function test_getUnitsForTenant_returns_only_tenant_units()
+    {
+        Auth::login($this->tenant1User);
+        
+        // テナント2の追加部署作成
+        Unit::factory()->create(['tenant_id' => 2]);
+        
+        $units = $this->residentService->getUnitsForTenant();
+        
+        $this->assertCount(1, $units);
+        $this->assertEquals($this->tenant1Unit->id, $units->first()->id);
+        $this->assertEquals(1, $units->first()->tenant_id);
+    }
+
+    public function test_successful_resident_operations_within_same_tenant()
+    {
+        Auth::login($this->tenant1User);
+        
+        // 正常な作成テスト
+        $request = new ResidentStoreRequest();
+        $request->merge([
+            'name' => 'テスト利用者',
+            'unit_id' => $this->tenant1Unit->id,
+            'meal_support' => '一部介助',
+        ]);
+        $request->setValidator(validator($request->all(), $request->rules()));
+        
+        $resident = $this->residentService->createResident($request);
+        
+        $this->assertEquals('テスト利用者', $resident->name);
+        $this->assertEquals(1, $resident->tenant_id);
+        
+        // 正常な取得テスト
+        $retrievedResident = $this->residentService->getResident($resident->id);
+        $this->assertEquals($resident->id, $retrievedResident->id);
+        
+        // 正常な更新テスト
+        $updateRequest = new ResidentUpdateRequest();
+        $updateRequest->merge(['name' => '更新された利用者']);
+        $updateRequest->setValidator(validator($updateRequest->all(), $updateRequest->rules()));
+        
+        $updatedResident = $this->residentService->updateResident($updateRequest, $resident->id);
+        $this->assertEquals('更新された利用者', $updatedResident->name);
+        
+        // 正常な削除テスト
+        $this->residentService->deleteResident($resident->id);
+        $this->assertDatabaseMissing('residents', ['id' => $resident->id]);
+    }
+}

--- a/tests/Unit/UnitServiceTest.php
+++ b/tests/Unit/UnitServiceTest.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use App\Services\UnitService;
+use App\Models\Unit;
+use App\Models\Forum;
+use App\Models\User;
+use App\Http\Requests\Unit\UnitStoreRequest;
+use App\Http\Requests\Unit\UnitSortRequest;
+use App\Exceptions\Custom\TenantViolationException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Auth;
+
+class UnitServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $unitService;
+    protected $tenant1User;
+    protected $tenant2User;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        
+        $this->unitService = new UnitService();
+        
+        $this->tenant1User = User::factory()->create(['tenant_id' => 1]);
+        $this->tenant2User = User::factory()->create(['tenant_id' => 2]);
+    }
+
+    public function test_getUnitsWithForum_returns_only_tenant_units()
+    {
+        Auth::login($this->tenant1User);
+        
+        // テナント1の部署作成
+        $tenant1Unit = Unit::factory()->create(['tenant_id' => 1]);
+        Forum::factory()->create(['unit_id' => $tenant1Unit->id, 'tenant_id' => 1]);
+        
+        // テナント2の部署作成（アクセス不可）
+        $tenant2Unit = Unit::factory()->create(['tenant_id' => 2]);
+        Forum::factory()->create(['unit_id' => $tenant2Unit->id, 'tenant_id' => 2]);
+        
+        $units = $this->unitService->getUnitsWithForum();
+        
+        $this->assertCount(1, $units);
+        $this->assertEquals($tenant1Unit->id, $units->first()->id);
+        $this->assertEquals(1, $units->first()->tenant_id);
+    }
+
+    public function test_createUnit_creates_unit_and_forum_for_current_tenant()
+    {
+        Auth::login($this->tenant1User);
+        
+        $request = new UnitStoreRequest();
+        $request->merge([
+            'name' => 'テスト部署',
+            'description' => 'テスト説明',
+            'visibility' => 'public'
+        ]);
+        $request->setValidator(validator($request->all(), $request->rules()));
+        
+        $unit = $this->unitService->createUnit($request);
+        
+        $this->assertEquals('テスト部署', $unit->name);
+        $this->assertEquals(1, $unit->tenant_id);
+        
+        // フォーラムも作成されているかチェック
+        $forum = Forum::where('unit_id', $unit->id)->first();
+        $this->assertNotNull($forum);
+        $this->assertEquals('テスト部署', $forum->name);
+        $this->assertEquals(1, $forum->tenant_id);
+    }
+
+    public function test_deleteUnit_throws_exception_for_different_tenant_unit()
+    {
+        Auth::login($this->tenant1User);
+        
+        $tenant2Unit = Unit::factory()->create(['tenant_id' => 2]);
+        
+        $this->expectException(TenantViolationException::class);
+        $this->expectExceptionMessage("指定されたリソースが見つかりません。");
+        
+        $this->unitService->deleteUnit($tenant2Unit->id);
+    }
+
+    public function test_updateSortOrder_validates_all_units_belong_to_tenant()
+    {
+        Auth::login($this->tenant1User);
+        
+        $tenant1Unit = Unit::factory()->create(['tenant_id' => 1, 'sort_order' => 0]);
+        $tenant2Unit = Unit::factory()->create(['tenant_id' => 2, 'sort_order' => 1]);
+        
+        $request = new UnitSortRequest();
+        $request->merge([
+            'units' => [
+                ['id' => $tenant1Unit->id],
+                ['id' => $tenant2Unit->id], // 異なるテナントの部署
+            ]
+        ]);
+        $request->setValidator(validator($request->all(), $request->rules()));
+        
+        $this->expectException(TenantViolationException::class);
+        $this->expectExceptionMessage("並び順更新対象の部署にアクセスする権限がありません。");
+        
+        $this->unitService->updateSortOrder($request);
+    }
+
+    public function test_getUnit_throws_exception_for_different_tenant()
+    {
+        Auth::login($this->tenant1User);
+        
+        $tenant2Unit = Unit::factory()->create(['tenant_id' => 2]);
+        
+        $this->expectException(TenantViolationException::class);
+        
+        $this->unitService->getUnit($tenant2Unit->id);
+    }
+
+    public function test_successful_unit_operations_within_same_tenant()
+    {
+        Auth::login($this->tenant1User);
+        
+        // 正常な作成テスト
+        $createRequest = new UnitStoreRequest();
+        $createRequest->merge([
+            'name' => 'テスト部署',
+            'description' => 'テスト説明'
+        ]);
+        $createRequest->setValidator(validator($createRequest->all(), $createRequest->rules()));
+        
+        $unit = $this->unitService->createUnit($createRequest);
+        $this->assertEquals('テスト部署', $unit->name);
+        
+        // 正常な取得テスト
+        $retrievedUnit = $this->unitService->getUnit($unit->id);
+        $this->assertEquals($unit->id, $retrievedUnit->id);
+        
+        // 正常な並び順更新テスト
+        $sortRequest = new UnitSortRequest();
+        $sortRequest->merge([
+            'units' => [
+                ['id' => $unit->id]
+            ]
+        ]);
+        $sortRequest->setValidator(validator($sortRequest->all(), $sortRequest->rules()));
+        
+        $this->unitService->updateSortOrder($sortRequest);
+        
+        $updatedUnit = Unit::find($unit->id);
+        $this->assertEquals(0, $updatedUnit->sort_order);
+        
+        // 正常な削除テスト
+        $this->unitService->deleteUnit($unit->id);
+        $this->assertDatabaseMissing('units', ['id' => $unit->id]);
+    }
+
+    public function test_sort_order_increments_correctly()
+    {
+        Auth::login($this->tenant1User);
+        
+        // 既存の部署を作成
+        Unit::factory()->create(['tenant_id' => 1, 'sort_order' => 5]);
+        
+        $request = new UnitStoreRequest();
+        $request->merge([
+            'name' => '新規部署',
+            'description' => '説明'
+        ]);
+        $request->setValidator(validator($request->all(), $request->rules()));
+        
+        $unit = $this->unitService->createUnit($request);
+        
+        $this->assertEquals(6, $unit->sort_order); // max(5) + 1
+    }
+}


### PR DESCRIPTION
## 目的
ResidentController・UnitControllerのService層リファクタリングによるセキュリティ脆弱性修正とコード品質向上

## 達成条件
- ResidentService・UnitServiceの新規実装完了
- テナント境界チェック機能統一
- 共通Traitによるセキュリティ機能統合
- 既存PostServiceパターンとの一貫性確保

## 実装の概要
1. **ResidentService.php** - 利用者管理ビジネスロジック分離、テナント境界チェック強化
2. **UnitService.php** - 部署管理機能統合、フォーラム連動処理実装
3. **SecurityValidationTrait.php** - 権限チェック・監査ログ統一機能
4. **TenantBoundaryCheckTrait.php** - テナント分離チェック汎用機能
5. **ResidentController・UnitControllerの完全Service層委譲**
6. **包括的テストケース実装**（ResidentServiceTest・UnitServiceTest）

## 対処したバグ
- ResidentController Line:47,83でのテナント境界チェック不備（Unit::all()使用問題）
- 個人情報アクセス制御の不統一
- セキュリティログ記録の欠如

## 必要なかった実装
既存PostServiceのリファクタリング（既に適切な実装のため保持）

## レビューしてほしいところ
- Traitの設計思想とService層での活用方法
- テナント境界チェックの包括性・抜け漏れ確認
- セキュリティログの詳細度と監査要件適合性

## 不安に思っていること
- 新Traitと既存PostServiceとの整合性
- テスト環境でのマイグレーションエラー（SQLiteインデックス構文問題）

## 保留していること
- 既存PostService・ForumServiceへの新Trait適用（別PR予定）
- テスト環境のマイグレーション構文修正