### PR TITLE
本番ゲストドメイン設定の是正（config/guest.php の production 既定値）

### DIFF
--- a/config/guest.php
+++ b/config/guest.php
@@ -4,7 +4,7 @@ return [
     'domains' => [
         'local'      => env('GUEST_DOMAIN_LOCAL', 'guestdemo.localhost'),
         'staging'    => env('GUEST_DOMAIN_STAGING', 'guestdemo.staging.example.com'),
-        'production' => env('GUEST_DOMAIN_PRODUCTION', 'guestdemo.example.com'),
+        'production' => env('GUEST_DOMAIN_PRODUCTION', 'guestdemo.communi-care.jp'),
     ],
 
     // config読み込み中はapp()を使わず、env()のみで分岐させる


### PR DESCRIPTION


### 目的
- 本番環境のゲストドメイン既定値を、実運用ドメインに整合する形で是正し、サーバ生成URLの安定性を確保する。
- route:cache 実行時や `.env` 未設定時でも意図した本番ドメインへ誘導できるようにする。

### 達成条件
- `config/guest.php` の `domains.production` 既定値が正しい本番ドメイン（`guestdemo.communi-care.jp`）になっていること。
- `.env` 未設定時でも本番環境でのゲスト導線が正しいドメインへ誘導されること。
- 他環境（local/staging）の既定値に影響がないこと。

### 実装の概要
- `config/guest.php`
  - `GUEST_DOMAIN_PRODUCTION` の既定値を `guestdemo.example.com` → `guestdemo.communi-care.jp` に修正。
  - 既存の local/staging の値は変更なし。
- 調査・切り分けの経緯（本番アクセスで `/guest/login` が 404 になった件の対応）
  - 本番アクセス時に `/guest/login` が 404 となる事象を確認し、DNS・`domains` テーブル・`.env.production` を順次切り分け。
  - 当初は `.env.production` の設定や `domains` テーブルの不足を疑ったが、いずれも正しく設定済みであることを確認。
  - 調査の結果、`config/guest.php` の production 既定値が `example.com` のままキャッシュされ、ルーティングが `guestdemo.example.com` として生成されていたことが原因と判明。
  - `php artisan config:clear` + `cache:clear` + `config:cache` だけでは解消せず、`route:clear` を含めたキャッシュクリアを行ったところ解決。

### 対処したバグ
- `.env` に `GUEST_DOMAIN_PRODUCTION` が未設定の場合、意図しない `guestdemo.example.com` を参照してしまう問題を是正。

### 必要なかった実装
- 中央ドメイン（`app.url`）からの派生でゲストドメインを自動生成する案は、環境差異や将来のドメイン移行時の意図しない変更リスクがあるため採用を検討したが、明示設定（env）＋安定した既定値の方が安全と判断し見送り。
- 既定値を `.env.production` に必須化して既定値非保持とする案は、デフォルト起動性を損なうため見送り。
- 本番で直接 `config/guest.php` を編集する方法を一時的に試行したが、最終的にはローカルで修正を反映し Git 管理下に置く方針に統一（本番直編集は見送り）。
- `.env.production` 側の修正は、既に正しい値が設定されていたため不要と判断（見送り）。

### レビューしてほしいところ
- 既定値（`guestdemo.communi-care.jp`）が現行の本番運用ドメインと一致しているか。
- 既存のゲスト導線（`/guest/redirect` → テナント `/guest/login`）で、この既定値が齟齬なく機能するか。

### 不安に思っていること
- 将来的に本番ドメインが `communicare.com` 等へ移行する場合、既定値の追随漏れを防ぐ運用（チェックリスト/CI）をどう設けるか。
- 今後もキャッシュ周りで `.env` の値が反映されない可能性があるため、デプロイ後は必ず `php artisan optimize:clear` を実行する運用が必要かもしれない。

### 保留していること
- ドメイン解決ロジックの共通化（Controller/Bootstrap側の重複を helper/service へ集約）は別PRで対応予定。
