### PR TITLE
Logファサード未定義エラーの修正

### DIFF
--- a/app/Http/Controllers/Auth/GuestLoginController.php
+++ b/app/Http/Controllers/Auth/GuestLoginController.php
@@ -78,7 +78,7 @@ class GuestLoginController extends Controller
             $guestUser->delete();
         } catch (\Throwable $e) {
             // 外部キー制約等で削除できない場合はゲストフラグのみ解除して継続
-            \Log::warning('ゲストユーザー削除に失敗。guest_session_idを解除して継続', [
+            Log::warning('ゲストユーザー削除に失敗。guest_session_idを解除して継続', [
                 'user_id' => $guestUser->id,
                 'error' => $e->getMessage(),
             ]);


### PR DESCRIPTION
### 目的

- `app/Http/Controllers/Auth/GuestLoginController.php` における `Undefined type 'Log'` エラー（行81付近）を解消し、静的解析/CIをグリーンに戻す。
- コントローラのログ出力呼び出しを`Log`ファサードに統一し、可読性と一貫性を向上する。

### 達成条件

- 静的解析（IDE/CI）で当該エラーが発生しない。
- `sail test` 実行時に失敗が増えない（機能変更なし）。
- ログアウト処理の挙動に変更がない（500エラー回避処理は維持）。

### 実装の概要

- `\Log::warning(...)` を `Log::warning(...)` に修正。
- 既に存在する `use Illuminate\Support\Facades\Log;` を活かす形に統一。
- 対象ファイル: `app/Http/Controllers/Auth/GuestLoginController.php`（1行修正、ロジック変更なし）。

### 対処したバグ

- バグ: `Undefined type 'Log'`（IDEまたは静的解析ツールにて検出）。
- 原因: 同一クラス内で `Log` ファサードのインポートがある一方、`\Log::...` と `Log::...` が混在していたため、型解決の不一致が生じていた。
- 影響: ビルド/CIの失敗、レビュー時の誤警報。実行時の挙動には影響なし。

### 必要なかった実装

- `logger()->warning(...)` への置換を検討したが、プロジェクト内の既存方針（ファサード統一）との一貫性を優先し採用を見送った。
- `use Illuminate\Support\Facades\Log as LaravelLog;` としてエイリアス化する案も検討したが、既存の `Log` インポートで十分なため採用を見送った。

### レビューしてほしいところ

- 当該ファイルにおけるログ呼び出しの統一が妥当か（他に `\Log::...` 形式の残骸がないか）。
- 本修正により、ログアウト処理（セッション無効化・例外時のフォールバック含む）の挙動に変化がないこと。

### 不安に思っていること

- なし（小規模かつ非機能変更）。ただし、コード規約として「ログはファサードに統一」方針をドキュメント化するかはご相談したいです。

### 保留していること

- 静的解析（PHPStan/Psalm）での「ファサード呼び出しの統一」ルール化は未対応。別PRで検討します。
