### PR TITLE
ゲスト入口URLをルートに集約（/guest/login→/）と周辺整合の修正

### DIFF
--- a/app/Http/Controllers/Auth/GuestTenantController.php
+++ b/app/Http/Controllers/Auth/GuestTenantController.php
@@ -67,7 +67,7 @@ class GuestTenantController extends Controller
         }
 
         $host = $domain . ($port ? ":{$port}" : '');
-        $url  = "{$scheme}://{$host}/guest/login";
+        $url  = "{$scheme}://{$host}/";
 
         Log::info('ゲスト遷移URLを生成', compact('env', 'domain', 'port', 'url'));
 

--- a/app/Http/Controllers/TenantHomeController.php
+++ b/app/Http/Controllers/TenantHomeController.php
@@ -49,12 +49,8 @@ class TenantHomeController extends Controller
         };
         $isGuestDomain = $guestDomain && request()->getHost() === $guestDomain;
 
-        // ゲスト表示条件: 専用パス or ゲストドメイン
-        $isGuestHome = (
-            request()->routeIs('guest.login.view') ||
-            request()->is('guest/login') ||
-            $isGuestDomain
-        );
+        // ゲスト表示条件: ゲストドメイン配下のルートアクセス時のみ
+        $isGuestHome = $isGuestDomain;
 
         return Inertia::render('TenantHome', [
             'canLogin' => \Route::has('login'),

--- a/app/Http/Controllers/TenantHomeController.php
+++ b/app/Http/Controllers/TenantHomeController.php
@@ -49,7 +49,7 @@ class TenantHomeController extends Controller
         };
         $isGuestDomain = $guestDomain && request()->getHost() === $guestDomain;
 
-        // ゲスト表示条件: ゲストドメイン配下のルートアクセス時のみ
+        // ゲスト表示条件: ゲストドメインでのアクセス時のみ（パスの判定は行っていません）
         $isGuestHome = $isGuestDomain;
 
         return Inertia::render('TenantHome', [

--- a/app/Http/Middleware/InitializeTenancyCustom.php
+++ b/app/Http/Middleware/InitializeTenancyCustom.php
@@ -15,7 +15,6 @@ class InitializeTenancyCustom extends InitializeTenancyByDomain
             '/',
             'tenant/login',
             'tenant/register',
-            'guest/login',
             'legal/privacy-policy',
             'legal/terms-of-service',
             // 他にもスキップしたいパスを追加

--- a/routes/tenant.php
+++ b/routes/tenant.php
@@ -12,11 +12,13 @@ use App\Http\Controllers\LikeController;
 // テナントドメイン限定のルートは、bootstrap/app.php 側の Route::domain() で
 // ミドルウェア（InitializeTenancyByDomain 等）を付与して読み込まれる前提。
 
-// テナントのトップページ
-Route::get('/', [TenantHomeController::class, 'index'])->name('tenant-home');
+// テナントのトップページ（ゲストデモ入口もここに統一）
+Route::get('/', [TenantHomeController::class, 'index'])->name('guest.login.view');
 
-// 表示：未ログインでも可（TenantHome.vue を見せる）
-Route::get('/guest/login', [TenantHomeController::class, 'index'])->name('guest.login.view');
+// 後方互換: 旧URLからルートへ恒久的リダイレクト（周知期間後に削除予定）
+Route::get('/guest/login', function () {
+    return redirect('/')->setStatusCode(301);
+});
 
 // 実行：ゲストで入る（中央には置かない）
 Route::middleware('guest')->get('/guest/user/login', [GuestLoginController::class, 'loginAsGuest'])->name('guest.user.login');

--- a/routes/tenant.php
+++ b/routes/tenant.php
@@ -16,9 +16,7 @@ use App\Http\Controllers\LikeController;
 Route::get('/', [TenantHomeController::class, 'index'])->name('guest.login.view');
 
 // 後方互換: 旧URLからルートへ恒久的リダイレクト（周知期間後に削除予定）
-Route::get('/guest/login', function () {
-    return redirect('/')->setStatusCode(301);
-});
+Route::redirect('/guest/login', '/', 301);
 
 // 実行：ゲストで入る（中央には置かない）
 Route::middleware('guest')->get('/guest/user/login', [GuestLoginController::class, 'loginAsGuest'])->name('guest.user.login');


### PR DESCRIPTION
### 目的

- ゲストデモの入口URLを `https://guestdemo.communi-care.jp/guest/login` から `https://guestdemo.communi-care.jp/` に変更し、今後の導線と仕様を簡潔にする。
- URL変更に伴う不整合（リダイレクト、例外ハンドラ、判定ロジック、ミドルウェア除外設定）を解消する。

### 達成条件

- `https://guestdemo.communi-care.jp/` でこれまでのゲストランディング（TenantHome）が表示されること。
- 旧 `https://guestdemo.communi-care.jp/guest/login` は 301 で `/` にリダイレクトされること。
- 中央→ゲストのリダイレクト（`guest.login.redirect`）が `/` を指すこと。
- ゲストUI表示条件がドメイン一致に一本化され、他テナントではゲストUIが出ないこと。

### 実装の概要

- routes/tenant.php
  - `/` を `TenantHomeController@index` の正規入口にし、ルート名を `guest.login.view` に統一。
  - `GET /guest/login` は後方互換のため恒久的リダイレクト(301) で `/` に転送。
- app/Http/Controllers/TenantHomeController.php
  - `isGuestHome` を「ゲストドメイン一致のみ」で判定するように整理（パス判定は削除）。
- app/Http/Controllers/Auth/GuestTenantController.php
  - 中央→ゲスト誘導URLを `.../guest/login` → `.../` に変更。
- app/Http/Middleware/InitializeTenancyCustom.php
  - 除外パスから `guest/login` を削除（URL集約に伴う整合）。

### 対処したバグ

- 厳密にはバグではないが、中央→ゲストの誘導先が旧パス（`/guest/login`）のままだった点を `/` に修正し、仕様と一致させた。

### 必要なかった実装

- 「/guest/login と / を併存させる」案は、二重入口が混乱を招くため採用を検討したが、最終的に `/guest/login` は 301 リダイレクトでの後方互換のみとし、採用を見送った。
- 「パスベースでのゲスト判定（`routeIs('guest.login.view')` や `is('guest/login')`）」は、URL集約後はドメイン一致で十分なため採用を検討したが、仕様の単純化を優先して削除した。
- 「InitializeTenancyCustom の `'/'` 除外見直し」は、テナント側での適用範囲設計をPR2（サブドメイン対応）で扱う想定のため、本PRでは採用を見送った（`guest/login` の除外削除のみ実施）。

### レビューしてほしいところ

- 301 リダイレクトの導線と、外部リンク/ブックマークの後方互換として十分か。
- `guest.login.view` を `/` に集約したことによる、例外ハンドラ（未認証時の `expired=1`）との整合性。
- ミドルウェア除外から `guest/login` を外した影響が他にないこと。

### 不安に思っていること

- 旧ルート `/guest/login` を直接参照する外部からの導線は 301 対応のみ。社外共有ドキュメント等に旧URLが残っていないか要確認。
- `tenant-home` という旧来の名称のルート名を使用している箇所は見当たらないが、もし外部依存があれば注意（検索では未検出）。

### 保留していること

- PR2: サブドメイン（`https://{tenant}.communi-care.jp/`）で各テナントのトップを提供するため、ルーティングのワイルドカード化と `central_domains` の調整、DNS/TLS 整備、ドメインレコード運用の整備を別PRで実施予定。

