### PR TITLE
デモ体験導線のURLと遷移方式を修正

### DIFF
--- a/app/Http/Controllers/WelcomeController.php
+++ b/app/Http/Controllers/WelcomeController.php
@@ -9,11 +9,28 @@ class WelcomeController extends Controller
 {
     public function index()
     {
+        $env = config('app.env');
+        $domain = match ($env) {
+            'local'      => config('guest.domains.local'),
+            'staging'    => config('guest.domains.staging'),
+            'production' => config('guest.domains.production'),
+            default      => config('guest.domains.production'),
+        };
+        $scheme = config('guest.protocol', $env === 'local' ? 'http' : 'https');
+        $port   = match ($env) {
+            'local'      => config('guest.ports.local'),
+            'staging'    => config('guest.ports.staging'),
+            'production' => config('guest.ports.production'),
+            default      => null,
+        };
+        $host = $domain . ($port ? ":{$port}" : '');
+        $guestUrl = "{$scheme}://{$host}/";
+
         return Inertia::render('Welcome', [
             'canLogin' => Route::has('login'),
             'canRegister' => Route::has('register'),
-            // 中央→テナント遷移URL（サーバ側で生成し、フロントは絶対URLで遷移）
-            'guestLoginUrl' => route('guest.login.redirect'),
+            // 中央→テナント遷移URLは絶対URLで返し、フロントは通常リンクでフル遷移
+            'guestLoginUrl' => $guestUrl,
         ]);
     }
 }

--- a/app/Http/Controllers/WelcomeController.php
+++ b/app/Http/Controllers/WelcomeController.php
@@ -23,7 +23,18 @@ class WelcomeController extends Controller
             'production' => config('guest.ports.production'),
             default      => null,
         };
-        $host = $domain . ($port ? ":{$port}" : '');
+        if (is_string($domain) && $domain !== '') {
+            $host = $domain . ($port ? ":{$port}" : '');
+        } else {
+            // フォールバック: app.url からスキーム/ホスト/ポートを解決
+            $appUrl = (string) config('app.url', '');
+            $fallbackHost   = parse_url($appUrl, PHP_URL_HOST) ?: 'localhost';
+            $fallbackPort   = parse_url($appUrl, PHP_URL_PORT);
+            $fallbackScheme = parse_url($appUrl, PHP_URL_SCHEME) ?: ($env === 'local' ? 'http' : 'https');
+            $host   = $fallbackHost . ($fallbackPort ? ":{$fallbackPort}" : '');
+            $scheme = $fallbackScheme ?: $scheme;
+        }
+
         $guestUrl = "{$scheme}://{$host}/";
 
         return Inertia::render('Welcome', [

--- a/resources/js/Pages/Welcome.vue
+++ b/resources/js/Pages/Welcome.vue
@@ -110,10 +110,8 @@ const submit = () => {
                             </ul>
                         </div>
                         <div class="flex items-center space-x-4">
-                            <Link
+                            <a
                                 :href="guestLoginUrl"
-                                method="get"
-                                as="button"
                                 class="inline-flex items-center px-6 py-3 rounded-lg bg-blue-600 text-white hover:bg-blue-700 transition"
                             >
                                 <span class="mr-2">デモで体験する</span>
@@ -129,7 +127,7 @@ const submit = () => {
                                         clip-rule="evenodd"
                                     />
                                 </svg>
-                            </Link>
+                            </a>
                         </div>
                     </div>
 


### PR DESCRIPTION
### 目的

中央ドメイン（ゲスト用エントリ）から各テナント環境への遷移時に、環境ごとの絶対URLへフルページ遷移させることで、ドメイン跨ぎでの状態引き継ぎやInertia経由の不整合を防ぎ、マルチテナント特性に即した安全な導線へ統一すること。

### 達成条件

- Welcome画面の「デモで体験する」から、環境に応じた絶対URL（ルート`/`）へフルリロードで遷移すること
- `Inertia <Link>`を使用せず、通常の`<a href>`リンクで遷移すること
- サーバ側（`WelcomeController`）が、環境別の絶対URLを返却していること
- クリティカルな仕様（DB・権限・テナント境界）に影響を与えないこと（差分確認済）

### 実装の概要

- `app/Http/Controllers/WelcomeController.php`
  - `config('app.env')`に基づき、`guest.domains`/`guest.ports`/`guest.protocol`からスキーム・ホスト・ポートを解決
  - 環境別に`https`/`http`と`domain:port`を組み立て、テナント側のエントリURLを絶対パス（`/`）で返却
  - これまでの`route('guest.login.redirect')`による相対的な生成を廃止し、明示的な絶対URLへ変更
- `resources/js/Pages/Welcome.vue`
  - `Inertia <Link>`を通常の`<a>`要素へ置換し、フルページ遷移に変更
  - `method`や`as`指定を削除し、シンプルなアンカーリンクへ統一

### 対処したバグ

- 環境により中央→テナント遷移が相対URLやInertia遷移となり、ドメイン跨ぎ時に状態が意図せず保持される/反映されないことがあった問題
- ローカル環境でポートやスキームの不一致により、想定外の遷移先となることがあった問題

### 必要なかった実装

- Inertia `<Link method="get" as="button">`での擬似ボタン遷移:
  - 採用を検討したが、Inertiaのインターセプトによりクロスドメイン/テナント遷移で完全なリロードが保証されず、状態・クッキーの扱いに不整合が生じ得るため結果的に削除（採用を見送り）。
- `route('guest.login.redirect')`に基づく動的ルーティング:
  - ルーティングでの解決案を検討したが、最終的にテナント側のエントリはルート`/`への絶対URLで十分と判断し、明示的なURL生成に統一したため削除（採用を見送り）。
- フロント側で`window.location`へ書き換える実装:
  - 強制リロードを目的として一時的に検討したが、通常のアンカーリンクで同等の効果が得られ、アクセシビリティやシンプルさの観点でアンカーを採用。`window.location`直接操作は見送り。

### レビューしてほしいところ

- `config/guest.php` 等で期待するキー（`guest.domains.*`/`guest.ports.*`/`guest.protocol`）が揃っているか、命名やデフォルトの妥当性
- ローカル/ステージング/本番の各環境で、期待する絶対URL（`scheme://domain[:port]/`）が生成されるか
- 他画面に中央→テナント遷移が残っていないか（`route('guest.login.redirect')`の残存有無）
- マルチテナント境界の観点で、今回の導線変更が副作用なく安全に機能するか

### 不安に思っていること

- `guest.*`設定が未定義の場合のフォールバック挙動（production相当の既定値）で、想定外のURLにならないか
- テナントの初期エントリが`/`以外に変更される将来要件がある場合の拡張余地
- ローカル環境のポート解決（プロキシやSail構成差）に依存するケースの取りこぼし

### 保留していること

- E2Eテスト（Cypress等）での導線確認の追加
- `guest.*`設定値に関するドキュメント整備（README/configコメント）
- 例外系（設定不足・無効値）の検出とログ/アラート設計